### PR TITLE
fix: for now set ios target to 16 to match XMTPRust

### DIFF
--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.0'
+  s.platform       = :ios, '16.0'
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/xmtp/xmtp-react-native-sdk' }
   s.static_framework = true


### PR DESCRIPTION
## Overview

When checking `npm` install of 1.0.0 on a test ReactNative expo project ([branch](https://github.com/xmtp/xmtp-quickstart-react-native/tree/use_xmtp_react_native_npm)), we realized that we needed to manually change to target to 16.0 in `node_modules/@xmtp/react-native-sdk/ios/XMTPReactNative.podspec`, then run `npx pod-install` again.

This is caused by XMTPRust requiring 16.0, probably unnecessarily (issue tracking: https://github.com/xmtp/xmtp-rust-swift/issues/9)

For now, we bump the version to 16.0 for our releases but should later revisit and lower to 13.0 across the board. From `xmtp-rust-ios` to `xmtp-ios` and in this repo again.

## Test Plan

- Will test e2e with npm install from remote