### PR TITLE
fix: XMTP cocoapod version 0.2.1-beta0 does not exist, back to 0.1.3-beta0

### DIFF
--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |s|
   }
   
   s.source_files = "**/*.{h,m,swift}"
-  s.dependency "XMTP", "= 0.2.1-beta0"
+  s.dependency "XMTP", "= 0.1.3-beta0"
 end


### PR DESCRIPTION
## Overview

In testing with a clean repo, XMTP 0.2.1-beta0 does not exist. This is backed up by the Cocoapod trunk data [search query](https://github.com/search?q=repo%3ACocoaPods%2FSpecs+XMTP&type=commits). It might have been a local version for one of us at some point, but we should update the `main` version back to an existing release (0.1.3-beta0).

NOTES: 0.1.3-beta0 was the first XMTP Cocoapod release and lines up with XMTPRust=0.1.2-beta0 (xmtp-rust-swift versioning [chart](https://github.com/xmtp/xmtp-rust-swift#releases)). We'll be working towards releasing a new XMTP cocoapod (0.2.x?) that uses XMTPRust=0.2.x also.