### PR TITLE
feat: add canMessage to client

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -129,6 +129,12 @@ class XMTPModule : Module() {
 
         //
         // Client API
+        AsyncFunction("canMessage") { clientAddress: String, peerAddress: String ->
+            val client = clients[clientAddress] ?: throw XMTPException("No client")
+
+            client.canMessage(peerAddress)
+        }
+
         AsyncFunction("listConversations") { clientAddress: String ->
             val client = clients[clientAddress] ?: throw XMTPException("No client")
             val conversationList = client.conversations.list()

--- a/example/src/HomeHeaderView.tsx
+++ b/example/src/HomeHeaderView.tsx
@@ -27,7 +27,7 @@ function NewConversationView({
       const canMessage = await client.canMessage(address);
       if (!canMessage) {
         setIsCreating(false);
-        setErr(`${address} is not on the XMTP Network yet`);
+        setErr(`${address} is not on the XMTP network yet`);
         return;
       }
       const conversation = await client.conversations.newConversation(address);

--- a/example/src/HomeHeaderView.tsx
+++ b/example/src/HomeHeaderView.tsx
@@ -24,6 +24,12 @@ function NewConversationView({
   async function startConverstation() {
     setIsCreating(true);
     try {
+      const canMessage = await client.canMessage(address);
+      if (!canMessage) {
+        setIsCreating(false);
+        setErr(`${address} is not on the XMTP Network yet`);
+        return;
+      }
       const conversation = await client.conversations.newConversation(address);
       setIsCreating(false);
       onSuccess();

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -134,6 +134,14 @@ public class XMTPModule: Module {
 
 		//
 		// Client API
+		AsyncFunction("canMessage") { (clientAddress: String, peerAddress: String) -> Bool in
+			guard let client = clients[clientAddress] else {
+				throw Error.noClient
+			}
+
+			return try await client.canMessage(peerAddress)
+		}
+
 		AsyncFunction("listConversations") { (clientAddress: String) -> [String] in
 			guard let client = clients[clientAddress] else {
 				throw Error.noClient

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,10 @@ export async function createRandom(
   return await XMTPModule.createRandom(environment);
 }
 
+export async function canMessage(clientAddress: string, peerAddress: string): Promise<boolean> {
+  return await XMTPModule.canMessage(clientAddress, peerAddress)
+}
+
 export async function listConversations(
   clientAddress: string
 ): Promise<Conversation[]> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export async function createRandom(
 }
 
 export async function canMessage(clientAddress: string, peerAddress: string): Promise<boolean> {
-  return await XMTPModule.canMessage(clientAddress, peerAddress)
+  return await XMTPModule.canMessage(clientAddress, peerAddress);
 }
 
 export async function listConversations(

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -49,6 +49,12 @@ export class Client {
     return new Client(address);
   }
 
+  async canMessage(
+    peerAddress: string
+  ): Promise<boolean> {
+    return await XMTPModule.canMessage(this.address, peerAddress);
+  }
+
   constructor(address: string) {
     this.address = address;
     this.conversations = new Conversations(this);


### PR DESCRIPTION
Resolves https://github.com/xmtp/xmtp-react-native/issues/8

Tested it out on iOS and Android by implementing it into the example app flow. Ensured I could still create conversations on both with valid addresses as well.

| Android | iOS |
|--|--|
| ![Screenshot_1685036485](https://github.com/xmtp/xmtp-react-native/assets/556051/3956eff3-2ae6-481d-a4d0-146d0cd410ce) | ![Simulator Screen Shot - iPhone 14 - 2023-05-25 at 13 42 53](https://github.com/xmtp/xmtp-react-native/assets/556051/ce4dc9ba-7433-490d-888b-424908da1102) |