### PR TITLE
feat: support listBatchMessages (placeholder sequential)

### DIFF
--- a/example/src/ConversationListView.tsx
+++ b/example/src/ConversationListView.tsx
@@ -15,10 +15,16 @@ export default function ConversationListView({
   const client = route.params.client;
 
   const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [messageCount, setMessageCount] = useState<number>(0);
 
   async function refreshConversations() {
     const conversations = await client.conversations.list();
+    const allMessages = await client.listBatchMessages(
+        conversations.map((conversation) => conversation.topic),
+        conversations.map((conversation) => conversation.conversationID)
+    );
     setConversations(conversations);
+    setMessageCount(allMessages.length);
   }
 
   useEffect(() => {
@@ -55,6 +61,7 @@ export default function ConversationListView({
       }
     >
       <HomeHeaderView client={client} navigation={navigation} />
+      <Text style={{marginLeft: 12}}>{messageCount} messages in {conversations.length} conversations</Text>
 
       {conversations.map((conversation) => {
         return (

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -156,18 +156,25 @@ public class XMTPModule: Module {
 			}
 		}
 
-		AsyncFunction("loadMessages") { (clientAddress: String, conversationTopic: String, conversationID: String?, limit: Int?, before: Double?, after: Double?) -> [String] in
-
-			guard let conversation = try await findConversation(clientAddress: clientAddress, topic: conversationTopic, conversationID: conversationID) else {
-				throw Error.conversationNotFound("no conversation found for \(conversationTopic)")
-			}
+		AsyncFunction("loadMessages") { (clientAddress: String, topics: [String], conversationIDs: [String?], limit: Int?, before: Double?, after: Double?) -> [String] in
             let beforeDate = before != nil ? Date(timeIntervalSince1970: before!) : nil
             let afterDate = after != nil ? Date(timeIntervalSince1970: after!) : nil
-
-			let messages = try await conversation.messages(limit: limit, before: beforeDate, after: afterDate).map { try DecodedMessageWrapper.encode($0) }
-
-			let client = clients[clientAddress]!
-
+            var messages:[String] = []
+            // TODO: use batchQuery instead of one-at-a-time (once iOS and libxmtp support it).
+            for (topic, conversationID) in zip(topics, conversationIDs) {
+                guard let conversation = try await findConversation(
+                    clientAddress: clientAddress,
+                    topic: topic,
+                    conversationID: conversationID) else {
+                    throw Error.conversationNotFound("no conversation found for \(topic)")
+                }
+                messages += try await conversation.messages(
+                    limit: limit,
+                    before: beforeDate,
+                    after: afterDate)
+                    .map { (msg) in try DecodedMessageWrapper.encode(msg) }
+            }
+            // print("found \(messages.count) messages from \(topics.count) conversations");
 			return messages
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,8 +50,30 @@ export async function listMessages(
   return (
     await XMTPModule.loadMessages(
       clientAddress,
-      conversationTopic,
-      conversationID,
+      [conversationTopic],
+      [conversationID],
+      limit,
+      before?.getTime,
+      after?.getTime
+    )
+  ).map((json: string) => {
+    return JSON.parse(json);
+  });
+}
+
+export async function listBatchMessages(
+  clientAddress: string,
+  conversationTopics: string[],
+  conversationIDs: (string | undefined)[],
+  limit?: number | undefined,
+  before?: Date | undefined,
+  after?: Date | undefined
+): Promise<DecodedMessage[]> {
+  return (
+    await XMTPModule.loadMessages(
+      clientAddress,
+      conversationTopics,
+      conversationIDs,
       limit,
       before?.getTime,
       after?.getTime

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -36,7 +36,6 @@ export class Client {
           const address = await signer.getAddress();
           resolve(new Client(address));
         });
-
         XMTPModule.auth(await signer.getAddress(), environment);
       })();
     });
@@ -58,5 +57,27 @@ export class Client {
   constructor(address: string) {
     this.address = address;
     this.conversations = new Conversations(this);
+  }
+
+  async listBatchMessages(
+    topics: string[],
+    conversationIDs: (string | undefined)[],
+    limit?: number | undefined,
+    before?: Date | undefined,
+    after?: Date | undefined
+  ): Promise<XMTPModule.DecodedMessage[]> {
+      try {
+          return await XMTPModule.listBatchMessages(
+              this.address,
+              topics,
+              conversationIDs,
+              limit,
+              before,
+              after
+          );
+      } catch (e) {
+          console.info("ERROR in listBatchMessages", e);
+          return [];
+      }
   }
 }

--- a/src/lib/DecodedMessage.ts
+++ b/src/lib/DecodedMessage.ts
@@ -1,5 +1,7 @@
 export type DecodedMessage = {
   id: string;
+  // TODO:
+  // topic: string;
   content: any;
   senderAddress: string;
   sent: Date;


### PR DESCRIPTION
This is a WIP toward implementing #34.

- [x] define `listBatchMessages` in RN JS
- [x] implement placeholder edition for iOS RN using sequential requests
- [x] implement placeholder for Android RN using sequential requests

To do in follow-up PRs
- [ ] in Android SDK, support `batchQuery` so we can implement the performant edition in RN
- [ ] in the rust + iOS SDK, ^ do the same thing ^