### PR TITLE
fix: bump to more performant android version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,6 +88,6 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.1.5"
+  implementation "org.xmtp:android:0.1.6"
   implementation 'com.google.code.gson:gson:2.10.1'
 }


### PR DESCRIPTION
Not as fast as iOS but large performance improvement on Android cold load.

Now: `Loaded 2001 conversations in 19488ms (19.4s)`
Previously: `Loaded 2001 conversations in 31709ms (31.7s)`

This should fix the cold load issues outlined in https://github.com/xmtp/xmtp-react-native/issues/33