### PR TITLE
feat: (iOS) use batchQuery instead of one-at-a-time for messages

### DIFF
--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -160,23 +160,16 @@ public class XMTPModule: Module {
             let beforeDate = before != nil ? Date(timeIntervalSince1970: before!) : nil
             let afterDate = after != nil ? Date(timeIntervalSince1970: after!) : nil
             var messages:[String] = []
-            // TODO: use batchQuery instead of one-at-a-time (once iOS and libxmtp support it).
-            for (topic, conversationID) in zip(topics, conversationIDs) {
-                guard let conversation = try await findConversation(
-                    clientAddress: clientAddress,
-                    topic: topic,
-                    conversationID: conversationID) else {
-                    throw Error.conversationNotFound("no conversation found for \(topic)")
-                }
-                messages += try await conversation.messages(
+            guard let client = clients[clientAddress] else {
+                throw Error.noClient
+            }
+            return try await client.conversations.listBatchMessages(
+                topics: topics,
                     limit: limit,
                     before: beforeDate,
                     after: afterDate)
                     .map { (msg) in try DecodedMessageWrapper.encode(msg) }
             }
-            // print("found \(messages.count) messages from \(topics.count) conversations");
-			return messages
-		}
 
 		// TODO: Support content types
 		AsyncFunction("sendMessage") { (clientAddress: String, conversationTopic: String, conversationID: String?, content: String) -> String in

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES',
     'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
-  
+
   s.source_files = "**/*.{h,m,swift}"
-  s.dependency "XMTP", "= 0.2.2-alpha0"
+  s.dependency "XMTP", "= 0.3.0-alpha0"
 end


### PR DESCRIPTION
This replaces the placeholder implementation of batch-message-listing on iOS with an actual call to batchQuery.

This depends on landing and using https://github.com/xmtp/xmtp-ios/pull/106