### PR TITLE
Can Message Test

### DIFF
--- a/example/android/app/src/androidTest/java/expo/modules/xmtpreactnativesdk/example/EspressoViewFinder.kt
+++ b/example/android/app/src/androidTest/java/expo/modules/xmtpreactnativesdk/example/EspressoViewFinder.kt
@@ -15,8 +15,8 @@ import org.hamcrest.Matcher
 import java.util.concurrent.TimeoutException
 
 object EspressoViewFinder {
-    private const val CHECK_INTERVAL = 50L
-    private const val TIMEOUT_MS = 15 * 1000L
+    private const val CHECK_INTERVAL = 150L
+    private const val TIMEOUT_MS = 30 * 1000L
 
     /**
      * Waits for the view referenced in [viewMatcher] to become visible, with a timeout of [timeOut]. If it

--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -48,10 +48,18 @@ test("can message a client", async () => {
   const messages = await aliceConversation.messages();
 
   if (messages.length !== 1) {
-    throw "No message";
+    throw Error("No message");
   }
 
   const message = messages[0];
 
   return message.content === "hello world";
+});
+
+test("canMessage", async () => {
+  const bob = await XMTP.Client.createRandom("local");
+  const alice = await XMTP.Client.createRandom("local");
+
+  const canMessage = await bob.canMessage(alice.address);
+  return canMessage;
 });


### PR DESCRIPTION
Closes https://github.com/xmtp/xmtp-react-native/issues/3

This adds a test for the recently added `canMessage` method and increases the timeout on the android tests to hopefully decrease timeouts in CI.