### PR TITLE
fix: releases JSDoc types can only be used inside documentation comments

### DIFF
--- a/src/XMTP.types.ts
+++ b/src/XMTP.types.ts
@@ -19,7 +19,7 @@ export type XMTPViewProps = {
 
 export type EncodedContent = {
   type: ContentTypeID;
-  parameters: { [key: string]: [value: string] }? ,
+  parameters: { [key: string]: [value: string] } | undefined;
   content: Uint8Array;
   fallback?: string;
 };


### PR DESCRIPTION
Introduced in https://github.com/xmtp/xmtp-react-native/pull/56 and blocking releases from going out https://github.com/xmtp/xmtp-react-native/actions/runs/5350301250/jobs/9702723521.

We need to specify undefined.