### PR TITLE
Fix: Refactors createFromKeyBundle swift function to guard string conv

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -143,8 +143,7 @@ class XMTPModule : Module() {
             clients[client.address] = client
             client.address
         } catch (e: Exception) {
-            Log.e("createFromKeyBundle", "Failed to create client: $e")
-            ""
+            throw XMTPException("Failed to create client: $e")
             }
         }
 

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -133,6 +133,7 @@ class XMTPModule : Module() {
         }
 
         AsyncFunction("createFromKeyBundle") { keyBundle: String, environment: String ->
+        try {
             logV("createFromKeyBundle")
             val options =
                 ClientOptions(api = apiEnvironments[environment] ?: apiEnvironments["dev"]!!)
@@ -141,6 +142,10 @@ class XMTPModule : Module() {
             val client = Client().buildFromBundle(bundle = bundle, options = options)
             clients[client.address] = client
             client.address
+        } catch (e: Exception) {
+            Log.e("createFromKeyBundle", "Failed to create client: $e")
+            ""
+            }
         }
 
         AsyncFunction("exportKeyBundle") { clientAddress: String ->

--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -5,6 +5,7 @@ import * as XMTP from "../../src/index";
 import { DecodedMessage } from "../../src/index";
 import { CodecError } from "../../src/lib/CodecError";
 import { CodecRegistry } from "../../src/lib/CodecRegistry";
+import { randomBytes } from "crypto";
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -179,18 +180,12 @@ test("can send and receive number codec", async () => {
   }
 });
 
-test("should return a Client even when passing weird keyBundle to createFromKeyBundle and not crash", async () => {
-  const fakeKeyBundle = {
-    array: [10, 20, 30, 40, 50],
-  };
-
+test("createFromKeyBundle throws error for non string value", async () => {
   try {
-    const c = await XMTP.Client.createFromKeyBundle(
-      JSON.stringify(fakeKeyBundle),
-      "local"
-    );
-    return !!c;
+    const bytes = randomBytes(32);
+    await XMTP.Client.createFromKeyBundle(JSON.stringify(bytes), "local");
   } catch (e) {
-    return false;
+    return true;
   }
+  return false;
 });

--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -178,3 +178,19 @@ test("can send and receive number codec", async () => {
     return false;
   }
 });
+
+test("should return a Client even when passing weird keyBundle to createFromKeyBundle and not crash", async () => {
+  const fakeKeyBundle = {
+    array: [10, 20, 30, 40, 50],
+  };
+
+  try {
+    const c = await XMTP.Client.createFromKeyBundle(
+      JSON.stringify(fakeKeyBundle),
+      "local"
+    );
+    return !!c;
+  } catch (e) {
+    return false;
+  }
+});

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -148,7 +148,7 @@ public class XMTPModule: Module {
                 return client.address
             } catch {
                 print("ERRO! Failed to create client: \(error)")
-                return ""
+                throw error
             }
         }
 

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -91,7 +91,8 @@ public class XMTPModule: Module {
     var subscriptions: [String: Task<Void, Never>] = [:]
 
     enum Error: Swift.Error {
-        case noClient, conversationNotFound(String), noMessage
+        case noClient, conversationNotFound(String), noMessage, invalidKeyBundle
+        
     }
 
     public func definition() -> ModuleDefinition {
@@ -135,11 +136,21 @@ public class XMTPModule: Module {
 
         // Create a client using its serialized key bundle.
         AsyncFunction("createFromKeyBundle") { (keyBundle: String, environment: String) -> String in
-            let bundle = try PrivateKeyBundle(serializedData: Data(base64Encoded: Data(keyBundle.utf8))!)
-            let options = XMTP.ClientOptions(api: apiEnvironments[environment] ?? apiEnvironments["dev"]!)
-            let client = try await Client.from(bundle: bundle, options: options)
-            self.clients[client.address] = client
-            return client.address
+            do {
+                guard let keyBundleData = Data(base64Encoded: keyBundle),
+                    let bundle = try? PrivateKeyBundle(serializedData: keyBundleData) else {
+                    throw Error.invalidKeyBundle
+                }
+                
+                let options = XMTP.ClientOptions(api: apiEnvironments[environment] ?? apiEnvironments["dev"]!)
+                let client = try await Client.from(bundle: bundle, options: options)
+                self.clients[client.address] = client
+                return client.address
+            } catch {
+                throw error
+                print("ERRO! Failed to create client: \(error)")
+                return ""
+            }
         }
 
         // Export the client's serialized key bundle.

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -147,7 +147,6 @@ public class XMTPModule: Module {
                 self.clients[client.address] = client
                 return client.address
             } catch {
-                throw error
                 print("ERRO! Failed to create client: \(error)")
                 return ""
             }


### PR DESCRIPTION
This fixes the issue #66 when the app crashes while dealing with non String types on `createFromKeyBundle`.

**Taken Actions:**

- Added guard to the function to transfer program control out of scope.
- Added new error enum `invalidKeyBundle`.
- Returning empty string in case of problems.

**How to test it?**

- Pass any non string value to  `createFromKeyBundle` func.