### PR TITLE
fix: fix type import errors

### DIFF
--- a/example/src/ConversationCreateScreen.tsx
+++ b/example/src/ConversationCreateScreen.tsx
@@ -1,11 +1,6 @@
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { NavigationParamList } from "./Navigation";
-import {
-  Button,
-  ScrollView,
-  Text,
-  TextInput,
-} from "react-native";
+import { Button, ScrollView, Text, TextInput } from "react-native";
 import React, { useState } from "react";
 import { useXmtp } from "./XmtpContext";
 

--- a/src/XMTP.types.ts
+++ b/src/XMTP.types.ts
@@ -1,5 +1,3 @@
-import { ContentTypeID } from "../build/lib/ContentTypeID";
-
 export type UnknownContent = {
   contentTypeId: string;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,8 @@ import { NativeModulesProxy, EventEmitter } from "expo-modules-core";
 
 import XMTPModule from "./XMTPModule";
 import { Conversation } from "./lib/Conversation";
-import type { DecodedMessage } from "./lib/DecodedMessage";
 import type { Query } from "./lib/Query";
-import { MessageContent } from "./XMTP.types";
+import type { MessageContent, DecodedMessage } from "./XMTP.types";
 
 export function address(): string {
   return XMTPModule.address();

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -1,7 +1,7 @@
 import { Signer, utils } from "ethers";
 
 import Conversations from "./Conversations";
-import { DecodedMessage } from "./DecodedMessage";
+import type { DecodedMessage } from "../XMTP.types";
 import { Query } from "./Query";
 import { hexToBytes } from "./util";
 import * as XMTPModule from "../index";

--- a/src/lib/Conversations.ts
+++ b/src/lib/Conversations.ts
@@ -1,6 +1,6 @@
 import { Client } from "./Client";
 import { Conversation } from "./Conversation";
-import type { DecodedMessage } from "./DecodedMessage";
+import type { DecodedMessage } from "../XMTP.types";
 import * as XMTPModule from "../index";
 
 type Context = {


### PR DESCRIPTION
This fixes the `Release` typescript errors we saw in the last merge https://github.com/xmtp/xmtp-react-native/actions/runs/5769170223

It also includes some fixes from `npm run pretty`.