### PR TITLE
fix: misc missing properties and type fixes

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ConversationWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ConversationWrapper.kt
@@ -4,35 +4,34 @@ import com.google.gson.GsonBuilder
 import org.xmtp.android.library.Client
 import org.xmtp.android.library.Conversation
 
-data class ConversationWithClientAddress(
-    var clientAddress: String,
-    var topic: String,
-    var peerAddress: String,
-    var version: String,
-    var conversationId: String?,
-) {
-    constructor(client: Client, conversation: Conversation): this(
-        clientAddress = client.address,
-        topic = conversation.topic,
-        peerAddress = conversation.peerAddress,
-        version = if (conversation.version == Conversation.Version.V1) "v1" else "v2",
-        conversationId = conversation.conversationId)
-
-}
-
 class ConversationWrapper {
 
     companion object {
-        fun encode(model: ConversationWithClientAddress): String {
-            val gson = GsonBuilder().create()
-            val conversation = mapOf(
-                "clientAddress" to model.clientAddress,
-                "topic" to model.topic,
-                "peerAddress" to model.peerAddress,
-                "version" to model.version,
-                "conversationID" to model.conversationId
+        fun encodeToObj(client: Client, conversation: Conversation): Map<String, Any> {
+            val context = when (conversation.version) {
+                Conversation.Version.V2 -> mapOf<String, Any>(
+                    "conversationID" to (conversation.conversationId ?: ""),
+                    // TODO: expose the context/metadata explicitly in xmtp-android
+                    "metadata" to conversation.toTopicData().invitation.context.metadataMap,
+                )
+
+                else -> mapOf()
+            }
+            return mapOf(
+                "clientAddress" to client.address,
+                "createdAt" to conversation.createdAt.time,
+                "context" to context,
+                "topic" to conversation.topic,
+                "peerAddress" to conversation.peerAddress,
+                "version" to if (conversation.version == Conversation.Version.V1) "v1" else "v2",
+                "conversationID" to (conversation.conversationId ?: "")
             )
-            return gson.toJson(conversation)
+        }
+
+        fun encode(client: Client, conversation: Conversation): String {
+            val gson = GsonBuilder().create()
+            val obj = encodeToObj(client, conversation)
+            return gson.toJson(obj)
         }
     }
 }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DecodedMessageWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DecodedMessageWrapper.kt
@@ -2,21 +2,24 @@ package expo.modules.xmtpreactnativesdk.wrappers
 
 import com.google.gson.GsonBuilder
 import org.xmtp.android.library.DecodedMessage
+import org.xmtp.android.library.codecs.id
 
 class DecodedMessageWrapper {
 
     companion object {
-        fun encode(model: DecodedMessage): String {
+        fun encode(model: DecodedMessage, topic: String): String {
             val gson = GsonBuilder().create()
-            val message = encodeMap(model)
+            val message = encodeMap(model, topic)
             return gson.toJson(message)
         }
 
-        fun encodeMap(model: DecodedMessage): Map<String, Any> = mapOf(
+        fun encodeMap(model: DecodedMessage, topic: String): Map<String, Any> = mapOf(
             "id" to model.id,
+            "topic" to topic,
+            "contentTypeId" to model.encodedContent.type.id,
             "content" to ContentJson(model.encodedContent).toJsonMap(),
             "senderAddress" to model.senderAddress,
-            "sent" to model.sent.getTime(),
+            "sent" to model.sent.time,
         )
     }
 }

--- a/example/ios/xmtpreactnativesdkexample.xcodeproj/project.pbxproj
+++ b/example/ios/xmtpreactnativesdkexample.xcodeproj/project.pbxproj
@@ -423,7 +423,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = expo.modules.xmtpreactnativesdk.example;
-				PRODUCT_NAME = "xmtpreactnativesdkexample";
+				PRODUCT_NAME = xmtpreactnativesdkexample;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -451,7 +451,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = expo.modules.xmtpreactnativesdk.example;
-				PRODUCT_NAME = "xmtpreactnativesdkexample";
+				PRODUCT_NAME = xmtpreactnativesdkexample;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";

--- a/example/src/TestScreen.tsx
+++ b/example/src/TestScreen.tsx
@@ -129,7 +129,7 @@ export default function TestScreen(): JSX.Element {
           accessibilityLabel="tests-complete"
           style={{ paddingHorizontal: 12 }}
         >
-          {tests.slice(0, completedTests + 1).map((test: Test, i) => {
+          {(tests || []).slice(0, completedTests + 1).map((test: Test, i) => {
             return (
               <TestView
                 test={test}

--- a/ios/Wrappers/DecodedMessageWrapper.swift
+++ b/ios/Wrappers/DecodedMessageWrapper.swift
@@ -4,13 +4,19 @@ import XMTP
 // Wrapper around XMTP.DecodedMessage to allow passing these objects back
 // into react native.
 struct DecodedMessageWrapper {
-    static func encode(_ model: XMTP.DecodedMessage) throws -> String {
-        let obj: [String: Any] = [
+    static func encodeToObj(_ model: XMTP.DecodedMessage, topic: String) throws -> [String: Any] {
+        return [
             "id": model.id,
+            "topic": topic,
+            "contentTypeId": model.encodedContent.type.id,
             "content": try ContentJson.fromEncoded(model.encodedContent).toJsonMap() as Any,
             "senderAddress": model.senderAddress,
             "sent": UInt64(model.sent.timeIntervalSince1970 * 1000)
         ]
+    }
+
+    static func encode(_ model: XMTP.DecodedMessage, topic: String) throws -> String {
+        let obj = try encodeToObj(model, topic: topic)
         let data = try JSONSerialization.data(withJSONObject: obj)
         guard let result = String(data: data, encoding: .utf8) else {
             throw WrapperError.encodeError("could not encode \(model)")

--- a/src/XMTP.types.ts
+++ b/src/XMTP.types.ts
@@ -46,7 +46,13 @@ export type MessageContent = {
 export type DecodedMessage = {
   id: string;
   topic: string;
+  contentTypeId: string;
   content: MessageContent;
   senderAddress: string;
   sent: number; // timestamp in milliseconds
+};
+
+export type ConversationContext = {
+  conversationID: string;
+  metadata: { [key: string]: string };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,11 @@ import { NativeModulesProxy, EventEmitter } from "expo-modules-core";
 import XMTPModule from "./XMTPModule";
 import { Conversation } from "./lib/Conversation";
 import type { Query } from "./lib/Query";
-import type { MessageContent, DecodedMessage } from "./XMTP.types";
+import type {
+  ConversationContext,
+  MessageContent,
+  DecodedMessage,
+} from "./XMTP.types";
 
 export function address(): string {
   return XMTPModule.address();
@@ -88,7 +92,6 @@ export async function listConversations(
 export async function listMessages(
   clientAddress: string,
   conversationTopic: string,
-  conversationID: string | undefined,
   limit?: number | undefined,
   before?: Date | undefined,
   after?: Date | undefined,
@@ -128,14 +131,14 @@ export async function listBatchMessages(
 export async function createConversation(
   clientAddress: string,
   peerAddress: string,
-  conversationID: string | undefined,
+  context?: ConversationContext,
 ): Promise<Conversation> {
   return new Conversation(
     JSON.parse(
       await XMTPModule.createConversation(
         clientAddress,
         peerAddress,
-        conversationID,
+        JSON.stringify(context || {}),
       ),
     ),
   );
@@ -144,7 +147,6 @@ export async function createConversation(
 export async function sendMessage(
   clientAddress: string,
   conversationTopic: string,
-  conversationID: string | undefined,
   content: MessageContent,
 ): Promise<string> {
   // TODO: consider eager validating of `MessageContent` here
@@ -153,7 +155,6 @@ export async function sendMessage(
   return await XMTPModule.sendMessage(
     clientAddress,
     conversationTopic,
-    conversationID,
     contentJson,
   );
 }
@@ -169,25 +170,15 @@ export function subscribeToAllMessages(clientAddress: string) {
 export async function subscribeToMessages(
   clientAddress: string,
   topic: string,
-  conversationID?: string | undefined,
 ) {
-  return await XMTPModule.subscribeToMessages(
-    clientAddress,
-    topic,
-    conversationID,
-  );
+  return await XMTPModule.subscribeToMessages(clientAddress, topic);
 }
 
 export async function unsubscribeFromMessages(
   clientAddress: string,
   topic: string,
-  conversationID?: string | undefined,
 ) {
-  return await XMTPModule.unsubscribeFromMessages(
-    clientAddress,
-    topic,
-    conversationID,
-  );
+  return await XMTPModule.unsubscribeFromMessages(clientAddress, topic);
 }
 
 export function registerPushToken(pushServer: string, token: string) {
@@ -202,15 +193,9 @@ export async function decodeMessage(
   clientAddress: string,
   topic: string,
   encryptedMessage: string,
-  conversationID?: string | undefined,
 ): Promise<DecodedMessage> {
   return JSON.parse(
-    await XMTPModule.decodeMessage(
-      clientAddress,
-      topic,
-      encryptedMessage,
-      conversationID,
-    ),
+    await XMTPModule.decodeMessage(clientAddress, topic, encryptedMessage),
   );
 }
 


### PR DESCRIPTION
This fixes a pile of bugs/missing fields (coming from partners exploring SDK integrations).

Here's the hit-list:
- [x] `Conversation` is missing `.createdAt` and `.context.metadata`
- [x] `listBatchMessages` is ignoring `pageSize` on iOS
- [x] `DecodedMessage` is missing `contentTypeId`
- [ ] `DecodedMessage` is missing `topic`
  - [x] ... from `conversation.messages`
  - [x] ... from `conversation.streamMessages`
  - [ ] ... from `listBatchMessages` (future PR, requires `xmtp-ios` and `xmtp-android` fixes)
  - [ ] ... from `streamAllMessages` (future PR, requires `xmtp-ios` and `xmtp-android` fixes)

Along the way this also:
- adds a bunch of tests around adapting message and conversation types
- formalizes some of the JSON generation in the native code
- reduces the imprint of `conversationId` to merely part of the `context` (i.e. `topic` alone can identify the conversation)
