### PR TITLE
fix: cut/add bad type import to fix build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,13 @@
+name: Test
+on:
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+      # Note: this triggers `prepare` which compiles the types.
+      - run: npm ci

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -2,18 +2,13 @@ import { Signer, utils } from "ethers";
 
 import Conversations from "./Conversations";
 import type {
+  DecryptedLocalAttachment,
   DecodedMessage,
   EncryptedLocalAttachment,
-  RemoteAttachmentMetadata,
 } from "../XMTP.types";
 import { Query } from "./Query";
 import { hexToBytes } from "./util";
 import * as XMTPModule from "../index";
-import {
-  AttachmentFile,
-  DecryptedLocalAttachment,
-  LocalAttachment,
-} from "../XMTP.types";
 
 declare const Buffer;
 export class Client {


### PR DESCRIPTION
This fixes the type import error from https://github.com/xmtp/xmtp-react-native/actions/runs/5954675712

It also adds a test workflow to PRs to trigger type compilation (so we catch these earlier).