### PR TITLE
Fix Android CI timeout

### DIFF
--- a/.github/workflows/androidTests.yml
+++ b/.github/workflows/androidTests.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Install React Native CLI
         run: npm i -g react-native-cli --force
 
+      # Workaround for https://github.com/actions/runner-images/issues/8104
+      - name: Fix Qemu Error
+        run: |
+          brew remove --ignore-dependencies qemu
+          curl -o ./qemu.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/f88e30b3a23ef3735580f9b05535ce5a0a03c9e3/Formula/qemu.rb
+          brew install ./qemu.rb
+
       - name: Install docker
         run: brew install docker docker-compose
       


### PR DESCRIPTION
Workaround for https://github.com/actions/runner-images/issues/8104