### PR TITLE
fix: Return correctly formatted contentTypeID

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
@@ -24,6 +24,7 @@ import org.xmtp.android.library.codecs.RemoteAttachmentCodec
 import org.xmtp.android.library.codecs.Reply
 import org.xmtp.android.library.codecs.ReplyCodec
 import org.xmtp.android.library.codecs.TextCodec
+import org.xmtp.android.library.codecs.description
 import org.xmtp.android.library.codecs.id
 
 import java.lang.Exception
@@ -152,7 +153,7 @@ class ContentJson(
 
             else -> mapOf(
                 "unknown" to mapOf(
-                    "contentTypeId" to type.id
+                    "contentTypeId" to type.description
                 )
             )
         }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DecodedMessageWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DecodedMessageWrapper.kt
@@ -2,6 +2,7 @@ package expo.modules.xmtpreactnativesdk.wrappers
 
 import com.google.gson.GsonBuilder
 import org.xmtp.android.library.DecodedMessage
+import org.xmtp.android.library.codecs.description
 import org.xmtp.android.library.codecs.id
 
 class DecodedMessageWrapper {
@@ -16,7 +17,7 @@ class DecodedMessageWrapper {
         fun encodeMap(model: DecodedMessage): Map<String, Any> = mapOf(
             "id" to model.id,
             "topic" to model.topic,
-            "contentTypeId" to model.encodedContent.type.id,
+            "contentTypeId" to model.encodedContent.type.description,
             "content" to ContentJson(model.encodedContent).toJsonMap(),
             "senderAddress" to model.senderAddress,
             "sent" to model.sent.time,

--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -321,6 +321,10 @@ test("remote attachments should work", async () => {
     throw new Error("Expected 1 message");
   }
   const message = messages[0];
+
+  if (message.contentTypeId !== "xmtp.org/remoteStaticAttachment:1.0") {
+    throw new Error("Expected correctly formatted typeId");
+  }
   if (!message.content.remoteAttachment) {
     throw new Error("Expected remoteAttachment");
   }

--- a/ios/Wrappers/DecodedMessageWrapper.swift
+++ b/ios/Wrappers/DecodedMessageWrapper.swift
@@ -8,7 +8,7 @@ struct DecodedMessageWrapper {
         return [
             "id": model.id,
             "topic": model.topic,
-            "contentTypeId": model.encodedContent.type.id,
+            "contentTypeId": model.encodedContent.type.description,
             "content": try ContentJson.fromEncoded(model.encodedContent).toJsonMap() as Any,
             "senderAddress": model.senderAddress,
             "sent": UInt64(model.sent.timeIntervalSince1970 * 1000)
@@ -152,7 +152,7 @@ struct ContentJson {
                 "url": remoteAttachment.url
             ]]
         default:
-            return ["unknown": ["contentTypeId": type.id]]
+            return ["unknown": ["contentTypeId": type.description]]
         }
     }
 }


### PR DESCRIPTION
string representation of the content type is not consistent with the JS SDK:
message.contentTypeId = xmtp.org:text in the RN SDK, but  [xmtp.org/text:1.0](http://xmtp.org/text:1.0) in the JS SDK (https://github.com/xmtp/xmtp-js/blob/main/src/MessageContent.ts#L18)

This fixes it to use the contentType description instead of id.