### PR TITLE
feat: support prepareMessage and sendPreparedMessage

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,7 +88,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.5.3"
+  implementation "org.xmtp:android:0.5.5"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/PreparedLocalMessage.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/PreparedLocalMessage.kt
@@ -1,0 +1,24 @@
+package expo.modules.xmtpreactnativesdk.wrappers
+
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonParser
+
+class PreparedLocalMessage(
+    val messageId: String,
+    val preparedFileUri: String,
+) {
+    companion object {
+        fun fromJson(json: String): PreparedLocalMessage {
+            val obj = JsonParser.parseString(json).asJsonObject
+            return PreparedLocalMessage(
+                obj.get("messageId").asString,
+                obj.get("preparedFileUri").asString,
+            )
+        }
+    }
+
+    fun toJson(): String = GsonBuilder().create().toJson(mapOf(
+        "messageId" to messageId,
+        "preparedFileUri" to preparedFileUri,
+    ))
+}

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -415,7 +415,7 @@ PODS:
     - GenericJSON (~> 2.0)
     - Logging (~> 1.0.0)
     - secp256k1.swift (~> 0.1)
-  - XMTP (0.5.1-alpha0):
+  - XMTP (0.5.2-alpha0):
     - Connect-Swift
     - GzipSwift
     - web3.swift
@@ -423,7 +423,7 @@ PODS:
   - XMTPReactNative (0.1.0):
     - ExpoModulesCore
     - MessagePacker
-    - XMTP (= 0.5.1-alpha0)
+    - XMTP (= 0.5.2-alpha0)
   - XMTPRust (0.3.1-beta0)
   - Yoga (1.14.0)
 
@@ -680,8 +680,8 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   SwiftProtobuf: 7773c4e96a99d7b8ab7cda0fc30a883732ff93b1
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: 1f7a1daf482994871a920cb6fff4ee4ceeefae12
-  XMTPReactNative: 7dd97d8bd98a7fc8e70e3511c4f75de116450379
+  XMTP: 84bc7d2140d86d9548062ce78d67b8890f5f07e3
+  XMTPReactNative: a1aff726077eb75086d0cb8fb1b81edbaa5f174b
   XMTPRust: 78f65f77b1454392980da244961777aee955652f
   Yoga: 065f0b74dba4832d6e328238de46eb72c5de9556
 

--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -92,6 +92,33 @@ test("createFromKeyBundle throws error for non string value", async () => {
   return false;
 });
 
+test("canPrepareMessage", async () => {
+  const bob = await XMTP.Client.createRandom({ env: "local" });
+  const alice = await XMTP.Client.createRandom({ env: "local" });
+  await delayToPropogate();
+
+  const bobConversation = await bob.conversations.newConversation(
+      alice.address,
+  );
+  await delayToPropogate();
+
+  const prepared = await bobConversation.prepareMessage("hi");
+
+  // Either of these should work:
+  await bobConversation.sendPreparedMessage(prepared);
+  // await bob.sendPreparedMessage(prepared);
+
+  await delayToPropogate();
+  const messages = await bobConversation.messages()
+  if (messages.length !== 1) {
+    throw new Error(`expected 1 message: got ${messages.length}`);
+  }
+  const message = messages[0]
+
+  return message?.id === prepared.messageId;
+});
+
+
 test("can list batch messages", async () => {
   const bob = await XMTP.Client.createRandom({ env: "local" });
   await delayToPropogate();

--- a/ios/Wrappers/DecodedMessageWrapper.swift
+++ b/ios/Wrappers/DecodedMessageWrapper.swift
@@ -270,6 +270,28 @@ struct DecryptedLocalAttachment {
   }
 }
 
+struct PreparedLocalMessage {
+    var messageId: String
+    var preparedFileUri: String
+
+    static func fromJson(_ json: String) throws -> PreparedLocalMessage {
+        let data = json.data(using: .utf8)!
+        let obj = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+        return PreparedLocalMessage(
+          messageId: obj["messageId"] as? String ?? "",
+          preparedFileUri: obj["preparedFileUri"] as? String ?? ""
+        )
+    }
+
+    func toJson() throws -> String {
+      let obj: [String: Any] = [
+        "messageId": messageId,
+        "preparedFileUri": preparedFileUri
+      ]
+      return try obj.toJson()
+    }
+}
+
 extension [String: Any] {
     func toJson() throws -> String {
         let data = try JSONSerialization.data(withJSONObject: self)

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -25,5 +25,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "**/*.{h,m,swift}"
 	s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.5.1-alpha0"
+  s.dependency "XMTP", "= 0.5.2-alpha0"
 end

--- a/src/XMTP.types.ts
+++ b/src/XMTP.types.ts
@@ -44,6 +44,34 @@ export type RemoteAttachmentContent = RemoteAttachmentMetadata & {
   url: string;
 };
 
+// This contains a message that has been prepared for sending.
+// It contains the message ID and the URI of a local file
+// containing the payload that needs to be published.
+// See Conversation.sendPreparedMessage() and Client.sendPreparedMessage()
+//
+// For native integrations (e.g. if you have native code for a robust
+// pending-message queue in a background task) you can load the referenced
+// `preparedFileUri` as a serialized `PreparedMessage` with the native SDKs.
+// The contained `envelopes` can then be directly `.publish()`ed with the native `Client`.
+//   e.g. on iOS:
+//    let preparedFileUrl = URL(string: preparedFileUri)
+//    let preparedData = try Data(contentsOf: preparedFileUrl)
+//    let prepared = try PreparedMessage.fromSerializedData(preparedData)
+//    try await client.publish(envelopes: prepared.envelopes)
+//   e.g. on Android:
+//     val preparedFileUri = Uri.parse(preparedFileUri)
+//     val preparedData = contentResolver.openInputStream(preparedFileUrl)!!
+//         .use { it.buffered().readBytes() }
+//     val prepared = PreparedMessage.fromSerializedData(preparedData)
+//     client.publish(envelopes = prepared.envelopes)
+//
+// You can also stuff the `preparedData` elsewhere (e.g. in a database) if that
+// is more convenient for your use case.
+export type PreparedLocalMessage = {
+  messageId: string;
+  preparedFileUri: `file://${string}`;
+}
+
 // This contains the contents of a message.
 // Each of these corresponds to a codec supported by the native libraries.
 // This is a one-of or union type: only one of these fields will be present.

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import type {
   DecryptedLocalAttachment,
   EncryptedLocalAttachment,
   MessageContent,
+  PreparedLocalMessage,
 } from "./XMTP.types";
 
 export function address(): string {
@@ -179,6 +180,33 @@ export async function sendMessage(
     clientAddress,
     conversationTopic,
     contentJson,
+  );
+}
+
+export async function prepareMessage(
+  clientAddress: string,
+  conversationTopic: string,
+  content: MessageContent,
+): Promise<PreparedLocalMessage> {
+  // TODO: consider eager validating of `MessageContent` here
+  //       instead of waiting for native code to validate
+  let contentJson = JSON.stringify(content);
+  let preparedJson = await XMTPModule.prepareMessage(
+    clientAddress,
+    conversationTopic,
+    contentJson,
+  );
+  return JSON.parse(preparedJson);
+}
+
+export async function sendPreparedMessage(
+  clientAddress: string,
+  preparedLocalMessage: PreparedLocalMessage,
+): Promise<string> {
+  let preparedLocalMessageJson = JSON.stringify(preparedLocalMessage);
+  return await XMTPModule.sendPreparedMessage(
+    clientAddress,
+    preparedLocalMessageJson,
   );
 }
 

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -5,6 +5,7 @@ import type {
   DecryptedLocalAttachment,
   DecodedMessage,
   EncryptedLocalAttachment,
+  PreparedLocalMessage,
 } from "../XMTP.types";
 import { Query } from "./Query";
 import { hexToBytes } from "./util";
@@ -117,6 +118,15 @@ export class Client {
       throw new Error("the attachment must be a local file:// uri");
     }
     return await XMTPModule.decryptAttachment(this.address, encryptedFile);
+  }
+
+  async sendPreparedMessage(prepared: PreparedLocalMessage): Promise<string> {
+    try {
+      return await XMTPModule.sendPreparedMessage(this.address, prepared);
+    } catch (e) {
+      console.info("ERROR in sendPreparedMessage()", e);
+      throw e;
+    }
   }
 }
 

--- a/src/lib/Conversation.ts
+++ b/src/lib/Conversation.ts
@@ -1,5 +1,5 @@
 import * as XMTP from "../index";
-import { MessageContent, DecodedMessage } from "../XMTP.types";
+import { DecodedMessage, MessageContent, PreparedLocalMessage } from "../XMTP.types";
 import { ConversationContext } from "../index";
 
 export class Conversation {
@@ -65,6 +65,36 @@ export class Conversation {
       return await XMTP.sendMessage(this.clientAddress, this.topic, content);
     } catch (e) {
       console.info("ERROR in send()", e);
+      throw e;
+    }
+  }
+
+  // Prepare the message to be sent.
+  //
+  // Instead of immediately `.send`ing a message, you can `.prepare` it first.
+  // This yields a `PreparedLocalMessage` object, which you can send later.
+  // This is useful to help construct a robust pending-message queue
+  // that can survive connectivity outages and app restarts.
+  //
+  // Note: the sendPreparedMessage() method is available on both this `Conversation`
+  //       or the top-level `Client` (when you don't have the `Conversation` handy).
+  async prepareMessage(content: string | MessageContent): Promise<PreparedLocalMessage> {
+    try {
+      if (typeof content === "string") {
+        content = { text: content };
+      }
+      return await XMTP.prepareMessage(this.clientAddress, this.topic, content);
+    } catch (e) {
+      console.info("ERROR in prepareMessage()", e);
+      throw e;
+    }
+  }
+
+  async sendPreparedMessage(prepared: PreparedLocalMessage): Promise<string> {
+    try {
+      return await XMTP.sendPreparedMessage(this.clientAddress, prepared);
+    } catch (e) {
+      console.info("ERROR in sendPreparedMessage()", e);
       throw e;
     }
   }


### PR DESCRIPTION
This adds support for `.preparedMessage()` to the SDK with a specific eye toward supporting robust pending-message queues.

This fixes https://github.com/xmtp/xmtp-react-native/issues/82
See also https://github.com/xmtp/xmtp-ios/pull/152 and https://github.com/xmtp/xmtp-android/pull/113