### PR TITLE
removed deprecated classifier (Gradle 8) from Android build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ buildscript {
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-  classifier = 'sources'
+  archiveClassifier = 'sources'
   from android.sourceSets.main.java.srcDirs
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,10 +35,21 @@ buildscript {
   }
 }
 
+// Check the Gradle version
+def gradleVersion = GradleVersion.current()
+def requiredGradleVersion = GradleVersion.version('8.0')
+
 // Creating sources with comments
-task androidSourcesJar(type: Jar) {
-  archiveClassifier = 'sources'
-  from android.sourceSets.main.java.srcDirs
+if (gradleVersion < requiredGradleVersion) {
+    task androidSourcesJar(type: Jar) {
+      classifier  = 'sources'
+      from android.sourceSets.main.java.srcDirs
+    }
+} else {
+    task androidSourcesJar(type: Jar) {
+      archiveClassifier = 'sources'
+      from android.sourceSets.main.java.srcDirs
+    }
 }
 
 afterEvaluate {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,12 +35,8 @@ buildscript {
   }
 }
 
-// Check the Gradle version
-def gradleVersion = GradleVersion.current()
-def requiredGradleVersion = GradleVersion.version('8.0')
-
 // Creating sources with comments
-if (gradleVersion < requiredGradleVersion) {
+if (GradleVersion.current() < GradleVersion.version('8.0')) {
     task androidSourcesJar(type: Jar) {
       classifier  = 'sources'
       from android.sourceSets.main.java.srcDirs


### PR DESCRIPTION
Gradle 8 has removed the depricated property `classifier ` and instead we need to use `archiveClassifier` otherwise the build will fail