### PR TITLE
feat: bump the ios and android version to get the new fallbacks

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.5.5"
+  implementation "org.xmtp:android:0.5.6"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -415,7 +415,7 @@ PODS:
     - GenericJSON (~> 2.0)
     - Logging (~> 1.0.0)
     - secp256k1.swift (~> 0.1)
-  - XMTP (0.5.2-alpha0):
+  - XMTP (0.5.3-alpha0):
     - Connect-Swift
     - GzipSwift
     - web3.swift
@@ -423,7 +423,7 @@ PODS:
   - XMTPReactNative (0.1.0):
     - ExpoModulesCore
     - MessagePacker
-    - XMTP (= 0.5.2-alpha0)
+    - XMTP (= 0.5.3-alpha0)
   - XMTPRust (0.3.1-beta0)
   - Yoga (1.14.0)
 
@@ -680,8 +680,8 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   SwiftProtobuf: 7773c4e96a99d7b8ab7cda0fc30a883732ff93b1
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: 84bc7d2140d86d9548062ce78d67b8890f5f07e3
-  XMTPReactNative: a1aff726077eb75086d0cb8fb1b81edbaa5f174b
+  XMTP: 01fd25bc966b9546f1a04210d4162764861b076d
+  XMTPReactNative: 6feac2b747871f469660b43b85576efaa6c558d1
   XMTPRust: 78f65f77b1454392980da244961777aee955652f
   Yoga: 065f0b74dba4832d6e328238de46eb72c5de9556
 

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -25,5 +25,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "**/*.{h,m,swift}"
 	s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.5.2-alpha0"
+  s.dependency "XMTP", "= 0.5.3-alpha0"
 end


### PR DESCRIPTION
Part of this work https://github.com/xmtp/xmtp-android/pull/114

Moves fallbacks into the supported codecs.