### PR TITLE
feat: add timestamp to prepared messages

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -352,11 +352,13 @@ class XMTPModule : Module() {
                 content = sending.content,
                 options = SendOptions(contentType = sending.type)
             )
+            val preparedAtMillis = prepared.envelopes[0].timestampNs / 1_000_000
             val preparedFile = File.createTempFile(prepared.messageId, null)
             preparedFile.writeBytes(prepared.toSerializedData())
             PreparedLocalMessage(
                 messageId = prepared.messageId,
                 preparedFileUri = preparedFile.toURI().toString(),
+                preparedAt = preparedAtMillis,
             ).toJson()
         }
 

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/PreparedLocalMessage.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/PreparedLocalMessage.kt
@@ -6,6 +6,7 @@ import com.google.gson.JsonParser
 class PreparedLocalMessage(
     val messageId: String,
     val preparedFileUri: String,
+    val preparedAt: Long,
 ) {
     companion object {
         fun fromJson(json: String): PreparedLocalMessage {
@@ -13,6 +14,7 @@ class PreparedLocalMessage(
             return PreparedLocalMessage(
                 obj.get("messageId").asString,
                 obj.get("preparedFileUri").asString,
+                obj.get("preparedAt").asNumber.toLong(),
             )
         }
     }
@@ -20,5 +22,6 @@ class PreparedLocalMessage(
     fun toJson(): String = GsonBuilder().create().toJson(mapOf(
         "messageId" to messageId,
         "preparedFileUri" to preparedFileUri,
+        "preparedAt" to preparedAt,
     ))
 }

--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -103,6 +103,9 @@ test("canPrepareMessage", async () => {
   await delayToPropogate();
 
   const prepared = await bobConversation.prepareMessage("hi");
+  if (!prepared.preparedAt) {
+    throw new Error("missing `preparedAt` on prepared message");
+  }
 
   // Either of these should work:
   await bobConversation.sendPreparedMessage(prepared);

--- a/ios/Wrappers/DecodedMessageWrapper.swift
+++ b/ios/Wrappers/DecodedMessageWrapper.swift
@@ -273,20 +273,23 @@ struct DecryptedLocalAttachment {
 struct PreparedLocalMessage {
     var messageId: String
     var preparedFileUri: String
+    var preparedAt: UInt64
 
     static func fromJson(_ json: String) throws -> PreparedLocalMessage {
         let data = json.data(using: .utf8)!
         let obj = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
         return PreparedLocalMessage(
           messageId: obj["messageId"] as? String ?? "",
-          preparedFileUri: obj["preparedFileUri"] as? String ?? ""
+          preparedFileUri: obj["preparedFileUri"] as? String ?? "",
+          preparedAt: UInt64(truncating: obj["preparedAt"] as? NSNumber ?? 0)
         )
     }
 
     func toJson() throws -> String {
       let obj: [String: Any] = [
         "messageId": messageId,
-        "preparedFileUri": preparedFileUri
+        "preparedFileUri": preparedFileUri,
+        "preparedAt": preparedAt
       ]
       return try obj.toJson()
     }

--- a/src/XMTP.types.ts
+++ b/src/XMTP.types.ts
@@ -70,6 +70,7 @@ export type RemoteAttachmentContent = RemoteAttachmentMetadata & {
 export type PreparedLocalMessage = {
   messageId: string;
   preparedFileUri: `file://${string}`;
+  preparedAt: number; // timestamp in milliseconds
 }
 
 // This contains the contents of a message.


### PR DESCRIPTION
This adds a `preparedAt` timestamp to the `PreparedLocalMessage` (useful to keep them sorted).

It also adds some safety catches around iOS decoding (to address some reports of decoding failures causing entire listings to fail).

And it uses an opaque random identifier (like Android) when decrypting files to disk (this avoids some issues that cropped up from OS-specific treatment of certain characters in filenames).