### PR TITLE
fix: add file name to decrypted local attachment

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.5.6"
+  implementation "org.xmtp:android:0.6.0"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -262,7 +262,7 @@ class XMTPModule : Module() {
             DecryptedLocalAttachment(
                 fileUri = file.toURI().toString(),
                 mimeType = attachment.mimeType,
-                fileName = attachment.filename
+                filename = attachment.filename
             ).toJson()
         }
 

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -262,6 +262,7 @@ class XMTPModule : Module() {
             DecryptedLocalAttachment(
                 fileUri = file.toURI().toString(),
                 mimeType = attachment.mimeType,
+                fileName = attachment.filename
             ).toJson()
         }
 

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DecryptedLocalAttachment.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DecryptedLocalAttachment.kt
@@ -10,11 +10,13 @@ import com.google.gson.JsonParser
 class DecryptedLocalAttachment(
     val fileUri: String,
     val mimeType: String,
+    val filename: String,
 ) {
     companion object {
         fun fromJsonObject(obj: JsonObject) = DecryptedLocalAttachment(
             obj.get("fileUri").asString,
             obj.get("mimeType").asString,
+            obj.get("filename").asString,
         )
 
         fun fromJson(json: String): DecryptedLocalAttachment {
@@ -26,6 +28,7 @@ class DecryptedLocalAttachment(
     fun toJsonMap(): Map<String, Any> = mapOf(
         "fileUri" to fileUri,
         "mimeType" to mimeType,
+        "filename" to filename,
     )
 
     fun toJson(): String = GsonBuilder().create().toJson(toJsonMap())

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DecryptedLocalAttachment.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DecryptedLocalAttachment.kt
@@ -16,7 +16,7 @@ class DecryptedLocalAttachment(
         fun fromJsonObject(obj: JsonObject) = DecryptedLocalAttachment(
             obj.get("fileUri").asString,
             obj.get("mimeType").asString,
-            obj.get("filename").asString,
+            obj.get("filename")?.asString ?: "",
         )
 
         fun fromJson(json: String): DecryptedLocalAttachment {

--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -438,6 +438,9 @@ test("remote attachments should work", async () => {
   if (attached.mimeType !== "text/plain") {
     throw new Error("Expected mimeType to match");
   }
+  if (attached.filename !== filename) {
+    throw new Error(`Expected ${attached.filename} to equal ${filename}`);
+  }
   const text = await fs.readFile(new URL(attached.fileUri).pathname, "utf8");
   if (text !== "hello world") {
     throw new Error("Expected text to match");

--- a/ios/Wrappers/DecodedMessageWrapper.swift
+++ b/ios/Wrappers/DecodedMessageWrapper.swift
@@ -251,20 +251,23 @@ struct EncryptedLocalAttachment {
 struct DecryptedLocalAttachment {
   var fileUri: String
   var mimeType: String
+  var filename: String
 
   static func fromJson(_ json: String) throws -> DecryptedLocalAttachment {
     let data = json.data(using: .utf8)!
     let obj = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
     return DecryptedLocalAttachment(
       fileUri: obj["fileUri"] as? String ?? "",
-      mimeType: obj["mimeType"] as? String ?? ""
+      mimeType: obj["mimeType"] as? String ?? "",
+      filename: obj["filename"] as? String ?? ""
     )
   }
 
   func toJson() throws -> String {
     let obj: [String: Any] = [
       "fileUri": fileUri,
-      "mimeType": mimeType
+      "mimeType": mimeType,
+      "filename": filename
     ]
     return try obj.toJson()
   }

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -223,7 +223,8 @@ public class XMTPModule: Module {
             try attachment.data.write(to: file)
             return try DecryptedLocalAttachment(
                     fileUri: file.absoluteString,
-                    mimeType: attachment.mimeType
+                    mimeType: attachment.mimeType,
+                    filename: attachment.filename
             ).toJson()
         }
 

--- a/src/XMTP.types.ts
+++ b/src/XMTP.types.ts
@@ -23,6 +23,7 @@ export type StaticAttachmentContent = {
 export type DecryptedLocalAttachment = {
   fileUri: string;
   mimeType?: string;
+  filename?: string;
 };
 
 export type RemoteAttachmentMetadata = {


### PR DESCRIPTION
Fixes https://github.com/xmtp/xmtp-react-native/issues/105

Adds the filename to the decrypted local attachment

| Android | iOS |
|--------|--------|
| <img width="438" alt="Screenshot 2023-09-13 at 10 05 51 PM" src="https://github.com/xmtp/xmtp-react-native/assets/3522670/568c53f4-f979-4e53-a0db-ff6f685a619d"> | <img width="436" alt="Screenshot 2023-09-13 at 10 02 59 PM" src="https://github.com/xmtp/xmtp-react-native/assets/3522670/c1ea67df-a2ad-482d-8d4c-00f20976608c"> | 