### PR TITLE
Read Receipts

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.6.2"
+  implementation "org.xmtp:android:0.6.3"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
@@ -105,7 +105,7 @@ class ContentJson(
                     contentType = nested.type,
                 ))
             } else if (obj.has("readReceipt")) {
-                return ContentJson(ContentTypeReadReceipt, ReadReceipt())
+                return ContentJson(ContentTypeReadReceipt, ReadReceipt)
             } else {
                 throw Exception("Unknown content type")
             }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
@@ -13,12 +13,15 @@ import org.xmtp.android.library.codecs.ContentTypeReaction
 import org.xmtp.android.library.codecs.ContentTypeText
 import org.xmtp.android.library.codecs.AttachmentCodec
 import org.xmtp.android.library.codecs.Attachment
+import org.xmtp.android.library.codecs.ContentTypeReadReceipt
 import org.xmtp.android.library.codecs.ContentTypeRemoteAttachment
 import org.xmtp.android.library.codecs.ContentTypeReply
 import org.xmtp.android.library.codecs.ReactionAction
 import org.xmtp.android.library.codecs.ReactionSchema
 import org.xmtp.android.library.codecs.ReactionCodec
 import org.xmtp.android.library.codecs.Reaction
+import org.xmtp.android.library.codecs.ReadReceipt
+import org.xmtp.android.library.codecs.ReadReceiptCodec
 import org.xmtp.android.library.codecs.RemoteAttachment
 import org.xmtp.android.library.codecs.RemoteAttachmentCodec
 import org.xmtp.android.library.codecs.Reply
@@ -48,6 +51,7 @@ class ContentJson(
             Client.register(ReactionCodec())
             Client.register(RemoteAttachmentCodec())
             Client.register(ReplyCodec())
+            Client.register(ReadReceiptCodec())
             // TODO:
             //Client.register(CompositeCodec())
         }
@@ -100,6 +104,8 @@ class ContentJson(
                     content = nested.content,
                     contentType = nested.type,
                 ))
+            } else if (obj.has("readReceipt")) {
+                return ContentJson(ContentTypeReadReceipt, ReadReceipt())
             } else {
                 throw Exception("Unknown content type")
             }
@@ -151,6 +157,10 @@ class ContentJson(
                     "reference" to (content as Reply).reference,
                     "content" to ContentJson(content.contentType, content.content).toJsonMap(),
                 )
+            )
+
+            ContentTypeReadReceipt.id -> mapOf(
+                "readReceipt" to ""
             )
 
             else -> mapOf(

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -415,7 +415,7 @@ PODS:
     - GenericJSON (~> 2.0)
     - Logging (~> 1.0.0)
     - secp256k1.swift (~> 0.1)
-  - XMTP (0.5.6-alpha0):
+  - XMTP (0.5.7-alpha0):
     - Connect-Swift
     - GzipSwift
     - web3.swift
@@ -423,7 +423,7 @@ PODS:
   - XMTPReactNative (0.1.0):
     - ExpoModulesCore
     - MessagePacker
-    - XMTP (= 0.5.6-alpha0)
+    - XMTP (= 0.5.7-alpha0)
   - XMTPRust (0.3.1-beta0)
   - Yoga (1.14.0)
 
@@ -680,8 +680,8 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   SwiftProtobuf: b70d65f419fbfe61a2d58003456ca5da58e337d6
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: 187f0cd4eb4988d09d6b631b5ffb56f8334be243
-  XMTPReactNative: d50e495767b22569ca90bc99af62fe2180647802
+  XMTP: 1b584f662fff8f006987dba2d5b1c9cacc929966
+  XMTPReactNative: a8057fb0fa8ab1decf2f70414a7359b2b194055c
   XMTPRust: 78f65f77b1454392980da244961777aee955652f
   Yoga: 065f0b74dba4832d6e328238de46eb72c5de9556
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - BigInt (5.0.0)
   - boost (1.76.0)
-  - Connect-Swift (0.7.0):
+  - Connect-Swift (0.8.0):
     - SwiftProtobuf (~> 1.23.0)
   - DoubleConversion (1.1.6)
   - EXApplication (5.1.1):
@@ -415,7 +415,7 @@ PODS:
     - GenericJSON (~> 2.0)
     - Logging (~> 1.0.0)
     - secp256k1.swift (~> 0.1)
-  - XMTP (0.5.4-alpha0):
+  - XMTP (0.5.6-alpha0):
     - Connect-Swift
     - GzipSwift
     - web3.swift
@@ -423,7 +423,7 @@ PODS:
   - XMTPReactNative (0.1.0):
     - ExpoModulesCore
     - MessagePacker
-    - XMTP (= 0.5.4-alpha0)
+    - XMTP (= 0.5.6-alpha0)
   - XMTPRust (0.3.1-beta0)
   - Yoga (1.14.0)
 
@@ -617,7 +617,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   BigInt: 74b4d88367b0e819d9f77393549226d36faeb0d8
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  Connect-Swift: 3b305e8305a8b88a33be087dad207d84aad57dd2
+  Connect-Swift: ed4000df7d6cdd794f2530e844e649a672d032ee
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EXApplication: d8f53a7eee90a870a75656280e8d4b85726ea903
   EXConstants: f348da07e21b23d2b085e270d7b74f282df1a7d9
@@ -680,8 +680,8 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   SwiftProtobuf: b70d65f419fbfe61a2d58003456ca5da58e337d6
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: 8e220d6c064c293911d88adb08087b90d06c22c5
-  XMTPReactNative: cfa66e30fa730f3b5f6cb4fed64eb3d11552e4b6
+  XMTP: 187f0cd4eb4988d09d6b631b5ffb56f8334be243
+  XMTPReactNative: d50e495767b22569ca90bc99af62fe2180647802
   XMTPRust: 78f65f77b1454392980da244961777aee955652f
   Yoga: 065f0b74dba4832d6e328238de46eb72c5de9556
 

--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -460,3 +460,38 @@ test("remote attachments should work", async () => {
   }
   return true;
 });
+
+test("can send read receipts", async () => {
+  const bob = await XMTP.Client.createRandom({ env: "local" });
+  await delayToPropogate();
+  const alice = await XMTP.Client.createRandom({ env: "local" });
+  await delayToPropogate();
+  if (bob.address === alice.address) {
+    throw new Error("bob and alice should be different");
+  }
+
+  const bobConversation = await bob.conversations.newConversation(
+    alice.address
+  );
+  await delayToPropogate();
+
+  const aliceConversation = (await alice.conversations.list())[0];
+  if (!aliceConversation) {
+    throw new Error("aliceConversation should exist");
+  }
+
+  await bobConversation.send({ readReceipt: {}});
+
+  const bobMessages = await bobConversation.messages();
+
+  if (bobMessages.length < 1) {
+    throw Error("No message");
+  }
+
+  if (bobMessages[0].contentTypeId !== "xmtp.org/readReceipt:1.0") {
+    throw Error("Unexpected message content " + bobMessages[0].content);
+  }
+
+  return true;
+});
+

--- a/ios/Wrappers/DecodedMessageWrapper.swift
+++ b/ios/Wrappers/DecodedMessageWrapper.swift
@@ -37,7 +37,7 @@ struct ContentJson {
         ReactionCodec(),
         AttachmentCodec(),
         ReplyCodec(),
-        RemoteAttachmentCodec()
+        RemoteAttachmentCodec(),
         ReadReceiptCodec()
         // TODO:
         //CompositeCodec(),

--- a/ios/Wrappers/DecodedMessageWrapper.swift
+++ b/ios/Wrappers/DecodedMessageWrapper.swift
@@ -38,6 +38,7 @@ struct ContentJson {
         AttachmentCodec(),
         ReplyCodec(),
         RemoteAttachmentCodec()
+        ReadReceiptCodec()
         // TODO:
         //CompositeCodec(),
     ]
@@ -102,6 +103,8 @@ struct ContentJson {
             content.filename = metadata.filename
             content.contentLength = metadata.contentLength
             return ContentJson(type: ContentTypeRemoteAttachment, content: content)
+        } else if let readReceipt = obj["readReceipt"] as? [String: Any] {
+            return ContentJson(type: ContentTypeReadReceipt, content: ReadReceipt())
         } else {
             throw Error.unknownContentType
         }
@@ -151,6 +154,8 @@ struct ContentJson {
                 "scheme": "https://",
                 "url": remoteAttachment.url
             ]]
+        case ContentTypeReadReceipt.id where content is XMTP.ReadReceipt:
+            return ["readReceipt": ""]
         default:
             return ["unknown": ["contentTypeId": type.description]]
         }

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -25,5 +25,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "**/*.{h,m,swift}"
 	s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.5.4-alpha0"
+  s.dependency "XMTP", "= 0.5.6-alpha0"
 end

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -25,5 +25,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "**/*.{h,m,swift}"
 	s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.5.6-alpha0"
+  s.dependency "XMTP", "= 0.5.7-alpha0"
 end

--- a/src/XMTP.types.ts
+++ b/src/XMTP.types.ts
@@ -2,6 +2,10 @@ export type UnknownContent = {
   contentTypeId: string;
 };
 
+export type ReadReceiptContent = {
+  content: MessageContent;
+};
+
 export type ReplyContent = {
   reference: string;
   content: MessageContent;

--- a/src/XMTP.types.ts
+++ b/src/XMTP.types.ts
@@ -2,9 +2,7 @@ export type UnknownContent = {
   contentTypeId: string;
 };
 
-export type ReadReceiptContent = {
-  content: MessageContent;
-};
+export type ReadReceiptContent = object;
 
 export type ReplyContent = {
   reference: string;
@@ -88,6 +86,7 @@ export type MessageContent = {
   reaction?: ReactionContent;
   attachment?: StaticAttachmentContent;
   remoteAttachment?: RemoteAttachmentContent;
+  readReceipt?: ReadReceiptContent;
 };
 
 export type DecodedMessage = {


### PR DESCRIPTION
Closes https://github.com/xmtp/xmtp-react-native/issues/106

This adds the read receipt content type to react native

| iOS | Android |
|--------|--------|
| <img width="426" alt="Screenshot 2023-09-15 at 4 45 12 PM" src="https://github.com/xmtp/xmtp-react-native/assets/3522670/d151fa50-c70e-4e4d-8bcb-510b6335bf91"> | <img width="438" alt="Screenshot 2023-09-15 at 1 33 22 PM" src="https://github.com/xmtp/xmtp-react-native/assets/3522670/763de9d3-973d-4d2f-866b-24e89582bba6"> | 