### PR TITLE
+ Fix Docker image on Mac M1

### DIFF
--- a/example/dev/local/docker-compose.yml
+++ b/example/dev/local/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.8"
 services:
   wakunode:
     image: xmtp/node-go:latest
+    platform: linux/amd64
     environment:
       - GOWAKU-NODEKEY=8a30dcb604b0b53627a5adc054dbf434b446628d4bd1eccc681d223f0550ce67
     command:
@@ -27,6 +28,7 @@ services:
       POSTGRES_PASSWORD: xmtp
   js:
     restart: always
+    platform: linux/amd64
     depends_on:
       wakunode:
         condition: service_healthy


### PR DESCRIPTION
This is to fix error when running docker compose
```
no matching manifest for linux/arm64/v8 in the manifest list entries
```
