### PR TITLE
feat: allow numeric timestamp in listMessages

### DIFF
--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -85,7 +85,7 @@ test("can pass a custom filter date and receive message objects with expected da
     // Show all messages before date in the future
     const messages4: DecodedMessage[] = await aliceConversation.messages(
       undefined,
-      initialQueryDate.getTime()
+      finalQueryDate.getTime()
     );
 
     const passingTimestampFieldSuccessful = !messages3.length && messages4.length === 1;

--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -52,21 +52,45 @@ test("can pass a custom filter date and receive message objects with expected da
     let sentAt = Date.now();
     await bobConversation.send({ text: "hello" });
 
+    const initialQueryDate = new Date("2023-01-01")
+    const finalQueryDate = new Date("2025-01-01")
+
     // Show all messages before date in the past
     const messages1: DecodedMessage[] = await aliceConversation.messages(
       undefined,
-      new Date("2023-01-01")
+      initialQueryDate
     );
 
     // Show all messages before date in the future
     const messages2: DecodedMessage[] = await aliceConversation.messages(
       undefined,
-      new Date("2025-01-01")
+      finalQueryDate
     );
 
     const isAboutRightSendTime = Math.abs(messages2[0].sent - sentAt) < 1000;
+    if (!isAboutRightSendTime) return false
 
-    return !messages1.length && messages2.length === 1 && isAboutRightSendTime;
+    const passingDateFieldSuccessful = !messages1.length && messages2.length === 1;
+
+    if (!passingDateFieldSuccessful) return false
+
+    // repeat the above test with a numeric date value
+
+    // Show all messages before date in the past
+    const messages3: DecodedMessage[] = await aliceConversation.messages(
+      undefined,
+      initialQueryDate.getTime()
+    );
+
+    // Show all messages before date in the future
+    const messages4: DecodedMessage[] = await aliceConversation.messages(
+      undefined,
+      initialQueryDate.getTime()
+    );
+
+    const passingTimestampFieldSuccessful = !messages3.length && messages4.length === 1;
+
+    return passingTimestampFieldSuccessful
   } catch (e) {
     return false;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,16 +117,16 @@ export async function listMessages(
   clientAddress: string,
   conversationTopic: string,
   limit?: number | undefined,
-  before?: Date | undefined,
-  after?: Date | undefined,
+  before?: number | Date | undefined,
+  after?: number | Date | undefined,
   direction?: "SORT_DIRECTION_ASCENDING" | "SORT_DIRECTION_DESCENDING" | undefined,
 ): Promise<DecodedMessage[]> {
   const messages = await XMTPModule.loadMessages(
     clientAddress,
     conversationTopic,
     limit,
-    before?.getTime(),
-    after?.getTime(),
+    typeof before === 'number' ? before : before?.getTime(),
+    typeof after === 'number' ? after : after?.getTime(),
     direction || "SORT_DIRECTION_DESCENDING",
   );
   return messages.map((json: string) => {
@@ -142,8 +142,8 @@ export async function listBatchMessages(
     return JSON.stringify({
       limit: item.pageSize || 0,
       topic: item.contentTopic,
-      after: item.startTime?.getTime() || 0,
-      before: item.endTime?.getTime() || 0,
+      after: (typeof item.startTime === 'number' ? item.startTime :  item.startTime?.getTime()) || 0,
+      before: (typeof item.endTime === 'number' ? item.endTime :  item.endTime?.getTime()) || 0,
       direction: item.direction || "SORT_DIRECTION_DESCENDING",
     });
   });

--- a/src/lib/Conversation.ts
+++ b/src/lib/Conversation.ts
@@ -39,8 +39,8 @@ export class Conversation {
   // TODO: Support pagination and conversation ID here
   async messages(
     limit?: number | undefined,
-    before?: Date | undefined,
-    after?: Date | undefined,
+    before?: number | Date | undefined,
+    after?: number | Date | undefined,
     direction?: "SORT_DIRECTION_ASCENDING" | "SORT_DIRECTION_DESCENDING" | undefined,
   ): Promise<DecodedMessage[]> {
     try {

--- a/src/lib/Query.ts
+++ b/src/lib/Query.ts
@@ -1,6 +1,6 @@
 export type Query = {
-  startTime?: Date | undefined;
-  endTime?: Date | undefined;
+  startTime?: number | Date | undefined;
+  endTime?: number | Date | undefined;
   contentTopic: string;
   pageSize?: number | undefined;
   direction?: "SORT_DIRECTION_ASCENDING" | "SORT_DIRECTION_DESCENDING" | undefined;


### PR DESCRIPTION
When querying messages based on Dates the timestamps are usually coming from a local cache (in our case, but I assume in most others too).

In order to avoid multiple conversions `number` / `string` -> `Date` -> `number`, I think it makes sense to allow the users to pass a number to `listMessages` & `listBatchMessages`.
