### PR TITLE
Update block to deny and add implicit consent for sending messages

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.6.7"
+  implementation "org.xmtp:android:0.6.8"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.6.8"
+  implementation "org.xmtp:android:0.6.9"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.6.9"
+  implementation "org.xmtp:android:0.6.10"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -496,15 +496,16 @@ class XMTPModule : Module() {
             client.contacts.isAllowed(address)
         }
 
-        Function("isBlocked") { clientAddress: String, address: String ->
-            logV("isBlocked")
+        Function("isDenied") { clientAddress: String, address: String ->
+            logV("isDenied")
             val client = clients[clientAddress] ?: throw XMTPException("No client")
-            client.contacts.isBlocked(address)
+            client.contacts.isDenied(address)
         }
 
-        AsyncFunction("blockContacts") { clientAddress: String, addresses: List<String> ->
+        AsyncFunction("denyContacts") { clientAddress: String, addresses: List<String> ->
+            logV("denyContacts")
             val client = clients[clientAddress] ?: throw XMTPException("No client")
-            client.contacts.block(addresses)
+            client.contacts.deny(addresses)
         }
 
         AsyncFunction("allowContacts") { clientAddress: String, addresses: List<String> ->
@@ -522,7 +523,7 @@ class XMTPModule : Module() {
                 ?: throw XMTPException("no conversation found for $conversationTopic")
             when (conversation.consentState()) {
                 ConsentState.ALLOWED -> "allowed"
-                ConsentState.BLOCKED -> "blocked"
+                ConsentState.DENIED -> "denied"
                 ConsentState.UNKNOWN -> "unknown"
             }
         }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -415,7 +415,7 @@ PODS:
     - GenericJSON (~> 2.0)
     - Logging (~> 1.0.0)
     - secp256k1.swift (~> 0.1)
-  - XMTP (0.6.3-alpha0):
+  - XMTP (0.6.6-alpha0):
     - Connect-Swift
     - GzipSwift
     - web3.swift
@@ -423,7 +423,7 @@ PODS:
   - XMTPReactNative (0.1.0):
     - ExpoModulesCore
     - MessagePacker
-    - XMTP (= 0.6.3-alpha0)
+    - XMTP (= 0.6.6-alpha0)
   - XMTPRust (0.3.6-beta0)
   - Yoga (1.14.0)
 
@@ -680,8 +680,8 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   SwiftProtobuf: bcfd2bc231cf9ae552cdc7c4e877bd3b41fe57b1
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: 3181e5c8e9d9885a97e5c5b22ac523bf9a713656
-  XMTPReactNative: 27185719aae360bc307cc6faf7bcf879cf681d97
+  XMTP: 6ba5240596cfe7d60248398b651b230dcf88be29
+  XMTPReactNative: f0ed6e62b6e52dd3a8582d4d6f987e27fe6243ff
   XMTPRust: 3c958736a4f4ee798e425b5644551f1c948da4b0
   Yoga: 065f0b74dba4832d6e328238de46eb72c5de9556
 

--- a/example/src/HomeScreen.tsx
+++ b/example/src/HomeScreen.tsx
@@ -87,7 +87,7 @@ function ConversationItem({ conversation, client }: { conversation: Conversation
             ({messages?.length} messages)
           </Text>
           <Button
-            title="Denied"
+            title="Deny"
             onPress={denyContact}
             disabled={
               getConsentState == "denied"

--- a/example/src/HomeScreen.tsx
+++ b/example/src/HomeScreen.tsx
@@ -66,7 +66,7 @@ function ConversationItem({ conversation, client }: { conversation: Conversation
   conversation.consentState().then(result => {
     setConsentState(result);
   })
-  const blockContact = () => client?.contacts.block([conversation.peerAddress]);
+  const denyContact = () => client?.contacts.deny([conversation.peerAddress]);
 
   return (
     <Pressable
@@ -87,10 +87,10 @@ function ConversationItem({ conversation, client }: { conversation: Conversation
             ({messages?.length} messages)
           </Text>
           <Button
-            title="Block"
-            onPress={blockContact}
+            title="Denied"
+            onPress={denyContact}
             disabled={
-              getConsentState == "blocked"
+              getConsentState == "denied"
             }
           />
         </View>

--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -565,24 +565,24 @@ test("canManagePreferences", async () => {
     throw new Error(`contacts created by bo should be allowed by default not ${initialState}`);
   }
 
-  bo.contacts.block([alixConversation.peerAddress]);
+  bo.contacts.deny([alixConversation.peerAddress]);
   await delayToPropogate();
 
-  const blockedState = await bo.contacts.isBlocked(alixConversation.peerAddress);
+  const deniedState = await bo.contacts.isDenied(alixConversation.peerAddress);
   const allowedState = await bo.contacts.isAllowed(alixConversation.peerAddress);
-  if (!blockedState) {
-    throw new Error(`contacts blocked by bo should be blocked not ${blockedState}`);
+  if (!deniedState) {
+    throw new Error(`contacts denied by bo should be denied not ${deniedState}`);
   }
 
   if (allowedState) {
-    throw new Error(`contacts blocked by bo should be blocked not ${allowedState}`);
+    throw new Error(`contacts denied by bo should be denied not ${allowedState}`);
   }
 
   const convoState = await alixConversation.consentState();
   await delayToPropogate();
 
-  if (convoState != "blocked") {
-    throw new Error(`conversations blocked by bo should be blocked not ${convoState}`);
+  if (convoState != "denied") {
+    throw new Error(`conversations denied by bo should be denied not ${convoState}`);
   }
   
   return true

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -524,18 +524,18 @@ public class XMTPModule: Module {
             return await client.contacts.isAllowed(address)
         }
 
-        AsyncFunction("isBlocked") { (clientAddress: String, address: String) -> Bool in
+        AsyncFunction("isDenied") { (clientAddress: String, address: String) -> Bool in
             guard let client = await clientsManager.getClient(key: clientAddress) else {
                 throw Error.noClient
             }
-            return await client.contacts.isBlocked(address)
+            return await client.contacts.isDenied(address)
         }
 
-        AsyncFunction("blockContacts") { (clientAddress: String, addresses: [String]) in
+        AsyncFunction("denyContacts") { (clientAddress: String, addresses: [String]) in
             guard let client = await clientsManager.getClient(key: clientAddress) else {
                 throw Error.noClient
             }
-            try await client.contacts.block(addresses: addresses)
+            try await client.contacts.deny(addresses: addresses)
         }
 
         AsyncFunction("allowContacts") { (clientAddress: String, addresses: [String]) in
@@ -558,7 +558,7 @@ public class XMTPModule: Module {
             }
             switch (await conversation.consentState()) {
             case .allowed: return "allowed"
-            case .blocked: return "blocked"
+            case .denied: return "denied"
             case .unknown: return "unknown"
             }
         }     

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -25,5 +25,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "**/*.{h,m,swift}"
 	s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.6.3-alpha0"
+  s.dependency "XMTP", "= 0.6.6-alpha0"
 end

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,7 +264,7 @@ export async function decodeMessage(
 export async function conversationConsentState(
   clientAddress: string, 
   conversationTopic: string
-): Promise<"allowed" | "blocked" | "unknown"> {
+): Promise<"allowed" | "denied" | "unknown"> {
   return await XMTPModule.conversationConsentState(clientAddress, conversationTopic);
 }
 
@@ -275,18 +275,18 @@ export async function isAllowed(
   return await XMTPModule.isAllowed(clientAddress, address);
 }
 
-export async function isBlocked(
+export async function isDenied(
   clientAddress: string,
   address: string,
 ): Promise<boolean> {
-  return await XMTPModule.isBlocked(clientAddress, address);
+  return await XMTPModule.isDenied(clientAddress, address);
 }
 
-export function blockContacts(
+export function denyContacts(
   clientAddress: string,
   addresses: string[],
 ) {
-  XMTPModule.blockContacts(clientAddress, addresses);
+  XMTPModule.denyContacts(clientAddress, addresses);
 }
 
 export function allowContacts(

--- a/src/lib/Contacts.ts
+++ b/src/lib/Contacts.ts
@@ -13,13 +13,13 @@ export default class Contacts {
     return result;
   }
 
-  async isBlocked(address: string): Promise<boolean> {
-    const result = await XMTPModule.isBlocked(this.client.address, address);
+  async isDenied(address: string): Promise<boolean> {
+    const result = await XMTPModule.isDenied(this.client.address, address);
     return result;
   }
 
-  block(addresses: string[]) {
-    XMTPModule.blockContacts(this.client.address, addresses);
+  deny(addresses: string[]) {
+    XMTPModule.denyContacts(this.client.address, addresses);
   }
 
   allow(addresses: string[]) {

--- a/src/lib/Conversation.ts
+++ b/src/lib/Conversation.ts
@@ -114,7 +114,7 @@ export class Conversation {
     }
   }
 
-  async consentState(): Promise<"allowed" | "blocked" | "unknown"> {
+  async consentState(): Promise<"allowed" | "denied" | "unknown"> {
     return await XMTP.conversationConsentState(this.clientAddress, this.topic);
   }
 


### PR DESCRIPTION
This addresses the items outlined here: https://github.com/orgs/xmtp/discussions/49#discussioncomment-7429217

Changes the word blocked to denied and adds implicit consent for sending a message to a conversation with unknown consent.