### PR TITLE
fix: upgrade to the latest android for stream performance

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.6.11"
+  implementation "org.xmtp:android:0.6.12"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"


### PR DESCRIPTION
This uses the new subscribe2 method for streamAllMessages hopefully fixing stream connection and reconnection issues. 
https://github.com/xmtp/xmtp-react-native/issues/138

<img width="442" alt="Screenshot 2023-11-07 at 12 23 44 PM" src="https://github.com/xmtp/xmtp-react-native/assets/3522670/46a37551-baee-4d1f-97e7-23be48243f08">
