### PR TITLE
Example App - Live Update Deny

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,6 +1,6 @@
 import { NavigationContainer } from '@react-navigation/native'
 import React from 'react'
-import { Button } from 'react-native'
+import { Button, Platform } from 'react-native'
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import ConversationCreateScreen from './src/ConversationCreateScreen'
@@ -53,7 +53,7 @@ export default function App() {
                   <Button
                     onPress={() => navigation.navigate('conversationCreate')}
                     title="New"
-                    color="#fff"
+                    color={Platform.OS === 'ios' ? '#fff' : 'rgb(49 0 110)'}
                   />
                 ),
               })}

--- a/example/src/HomeScreen.tsx
+++ b/example/src/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import { NavigationContext } from '@react-navigation/native'
 import moment from 'moment'
-import React, { useContext, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import {
   Button,
   FlatList,
@@ -46,7 +46,7 @@ export default function HomeScreen() {
           }}
         >
           <Text style={{ fontSize: 14 }}>Connected as</Text>
-          <Text style={{ fontSize: 14, fontWeight: 'bold' }}>
+          <Text selectable style={{ fontSize: 14, fontWeight: 'bold' }}>
             {client?.address}
           </Text>
         </View>
@@ -67,10 +67,16 @@ function ConversationItem({
   const lastMessage = messages?.[0]
   const [getConsentState, setConsentState] = useState<string | undefined>()
 
-  conversation.consentState().then((result) => {
-    setConsentState(result)
-  })
-  const denyContact = () => client?.contacts.deny([conversation.peerAddress])
+  useEffect(() => {
+    conversation.consentState().then((result) => {
+      setConsentState(result)
+    })
+  }, [conversation])
+
+  const denyContact = () => {
+    client?.contacts.deny([conversation.peerAddress])
+    conversation.consentState().then(setConsentState)
+  }
 
   return (
     <Pressable


### PR DESCRIPTION
Resolves https://github.com/xmtp/xmtp-react-native/issues/160 
Added request after denying the conversation to set state on the conversation item
Made wallet string selectable for easier developing
Fixed Android Button styling on home screen

https://github.com/xmtp/xmtp-react-native/assets/23103150/0d38903f-9c51-4f49-a371-ff607b021a6f


