### PR TITLE
Added instructions for running local xmtp server/unit tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ Access the `xmtp-react-native` client SDK [reference documentation](https://xmtp
 
 ## Example app
 
-Use the [XMTP React Native example app](example) as a tool to start building an app with XMTP. This basic messaging app has an intentionally unopinionated UI to help make it easier for you to build with.
+Use the [XMTP React Native example app](example) as a tool to start building an app with XMTP. This basic messaging app has an intentionally unopinionated UI to help make it easier for you to build with. [See example/README.md](example/README.md) for more instructions.
+
+### Quickstart to use the example app:
 
 Follow the [React Native guide](https://reactnative.dev/docs/environment-setup) to set up a CLI environment.
 
-To use the example app, run:
-
 ```bash
+npm install
 cd example
 npm install --force
 npm run [ios or android]

--- a/example/README.md
+++ b/example/README.md
@@ -30,7 +30,7 @@ Running tests locally is useful when updating GitHub actions, or locally testing
     NAME                STATUS              CONFIG FILES
     xmtp                running(3)          <REPO_DIRECTORY>/xmtp-react-native/example/dev/local/docker-compose.yml
     ```
-4. You can now run Unit tests on your local emulators
+4. You can now run unit tests on your local emulators
 5. You can stop the local xmtp server with the following command
     ```bash
     docker-compose -p xmtp -f dev/local/docker-compose.yml down

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,37 @@
+# XMTP React Native Example App
+
+This basic messaging app has an intentionally unopinionated UI to help make it easier for you to build with.
+
+## Running the Example App
+Follow the [React Native guide](https://reactnative.dev/docs/environment-setup) to set up a CLI environment.
+
+To use the example app, run:
+
+```bash
+npm install
+cd example
+npm install --force
+npm run [ios or android]
+```
+
+## Running Example App Unit tests on local emulators
+Running tests locally is useful when updating GitHub actions, or locally testing between changes.
+
+1. [Install docker](https://docs.docker.com/get-docker/)
+
+2. Start a local XMTP server (from example directory)
+    ```bash
+    docker-compose -p xmtp -f dev/local/docker-compose.yml up -d
+    ```
+3. Verify XMTP server is running
+    ```bash
+    docker-compose ls
+
+    NAME                STATUS              CONFIG FILES
+    xmtp                running(3)          <REPO_DIRECTORY>/xmtp-react-native/example/dev/local/docker-compose.yml
+    ```
+4. You can now run Unit tests on your local emulators
+5. You can stop the local xmtp server with the following command
+    ```bash
+    docker-compose -p xmtp -f dev/local/docker-compose.yml down
+    ```

--- a/example/README.md
+++ b/example/README.md
@@ -14,7 +14,7 @@ npm install --force
 npm run [ios or android]
 ```
 
-## Running Example App Unit tests on local emulators
+## Run example app unit tests on local emulators
 Running tests locally is useful when updating GitHub actions, or locally testing between changes.
 
 1. [Install docker](https://docs.docker.com/get-docker/)

--- a/example/README.md
+++ b/example/README.md
@@ -17,7 +17,7 @@ npm run [ios or android]
 ## Run example app unit tests on local emulators
 Running tests locally is useful when updating GitHub actions, or locally testing between changes.
 
-1. [Install docker](https://docs.docker.com/get-docker/)
+1. [Install Docker](https://docs.docker.com/get-docker/)
 
 2. Start a local XMTP server (from example directory)
     ```bash

--- a/example/README.md
+++ b/example/README.md
@@ -2,7 +2,7 @@
 
 This basic messaging app has an intentionally unopinionated UI to help make it easier for you to build with.
 
-## Running the Example App
+## Run the example app
 Follow the [React Native guide](https://reactnative.dev/docs/environment-setup) to set up a CLI environment.
 
 To use the example app, run:

--- a/example/README.md
+++ b/example/README.md
@@ -31,7 +31,7 @@ Running tests locally is useful when updating GitHub actions, or locally testing
     xmtp                running(3)          <REPO_DIRECTORY>/xmtp-react-native/example/dev/local/docker-compose.yml
     ```
 4. You can now run unit tests on your local emulators
-5. You can stop the local xmtp server with the following command
+5. You can stop the XMTP server with the following command:
     ```bash
     docker-compose -p xmtp -f dev/local/docker-compose.yml down
     ```

--- a/example/README.md
+++ b/example/README.md
@@ -23,7 +23,7 @@ Running tests locally is useful when updating GitHub actions, or locally testing
     ```bash
     docker-compose -p xmtp -f dev/local/docker-compose.yml up -d
     ```
-3. Verify XMTP server is running
+3. Verify the XMTP server is running
     ```bash
     docker-compose ls
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,4 +1,4 @@
-# XMTP React Native Example App
+# XMTP React Native example app
 
 This basic messaging app has an intentionally unopinionated UI to help make it easier for you to build with.
 


### PR DESCRIPTION
See updated README.md and new [example/README.md](https://github.com/xmtp/xmtp-react-native/blob/cameronvoell/add-local-unit-test-readme/example/README.md). 

My thinking here is to get commands used for running and testing the Example app explicit stated in the repo. Feedback welcomed!