### PR TITLE
Make allow and deny awaitable

### DIFF
--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -648,7 +648,7 @@ test('canManagePreferences', async () => {
     )
   }
 
-  bo.contacts.deny([alixConversation.peerAddress])
+  await bo.contacts.deny([alixConversation.peerAddress])
   await delayToPropogate()
 
   const deniedState = await bo.contacts.isDenied(alixConversation.peerAddress)

--- a/src/index.ts
+++ b/src/index.ts
@@ -342,12 +342,18 @@ export async function isDenied(
   return await XMTPModule.isDenied(clientAddress, address)
 }
 
-export function denyContacts(clientAddress: string, addresses: string[]) {
-  XMTPModule.denyContacts(clientAddress, addresses)
+export async function denyContacts(
+  clientAddress: string,
+  addresses: string[]
+): Promise<void> {
+  return await XMTPModule.denyContacts(clientAddress, addresses)
 }
 
-export function allowContacts(clientAddress: string, addresses: string[]) {
-  XMTPModule.allowContacts(clientAddress, addresses)
+export async function allowContacts(
+  clientAddress: string,
+  addresses: string[]
+): Promise<void> {
+  return await XMTPModule.allowContacts(clientAddress, addresses)
 }
 
 export async function refreshConsentList(

--- a/src/lib/Contacts.ts
+++ b/src/lib/Contacts.ts
@@ -17,12 +17,12 @@ export default class Contacts {
     return await XMTPModule.isDenied(this.client.address, address)
   }
 
-  deny(addresses: string[]) {
-    XMTPModule.denyContacts(this.client.address, addresses)
+  async deny(addresses: string[]): Promise<void> {
+    return await XMTPModule.denyContacts(this.client.address, addresses)
   }
 
-  allow(addresses: string[]) {
-    XMTPModule.allowContacts(this.client.address, addresses)
+  async allow(addresses: string[]): Promise<void> {
+    return await XMTPModule.allowContacts(this.client.address, addresses)
   }
 
   async refreshConsentList(): Promise<ConsentListEntry[]> {


### PR DESCRIPTION
Right now methods client.contacts.allow(addresses) & client.contacts.deny(addresses) are not awaitable
To provide a good experience we need to know if we updated the consent state successfully in the protocol, would it be possible to make them awaitable and return only if the protocol state was successfully updated?