### PR TITLE
fix: register codecs on create of clients in android

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -145,6 +145,7 @@ class XMTPModule : Module() {
             signer = reactSigner
             val options = ClientOptions(api = apiEnvironments(environment, appVersion))
             clients[address] = Client().create(account = reactSigner, options = options)
+            ContentJson.Companion
             signer = null
             sendEvent("authed")
         }
@@ -160,6 +161,7 @@ class XMTPModule : Module() {
             val privateKey = PrivateKeyBuilder()
             val options = ClientOptions(api = apiEnvironments(environment, appVersion))
             val randomClient = Client().create(account = privateKey, options = options)
+            ContentJson.Companion
             clients[randomClient.address] = randomClient
             randomClient.address
         }
@@ -176,6 +178,7 @@ class XMTPModule : Module() {
                         )
                     )
                 val client = Client().buildFromBundle(bundle = bundle, options = options)
+                ContentJson.Companion
                 clients[client.address] = client
                 client.address
             } catch (e: Exception) {

--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -74,6 +74,14 @@ test('can make a client', async () => {
     env: 'local',
     appVersion: 'Testing/0.0.0',
   })
+  client.register(new RemoteAttachmentCodec())
+  if (Object.keys(client.codecRegistry).length !== 2) {
+    throw new Error(
+      `Codecs length should be 2 not ${
+        Object.keys(client.codecRegistry).length
+      }`
+    )
+  }
   return client.address.length > 0
 })
 


### PR DESCRIPTION
We weren't registering the codecs in Android when creating the client which could cause issues with rendering codecs. This registers the codecs on client create 