### PR TITLE
fix: unsubscribe message event

### DIFF
--- a/src/lib/Conversation.ts
+++ b/src/lib/Conversation.ts
@@ -229,7 +229,7 @@ export class Conversation<ContentTypes> {
   ): () => void {
     XMTP.subscribeToMessages(this.client.address, this.topic)
     const hasSeen = {}
-    XMTP.emitter.addListener(
+    const messageSubscription = XMTP.emitter.addListener(
       'message',
       async ({
         clientAddress,
@@ -253,6 +253,7 @@ export class Conversation<ContentTypes> {
     )
 
     return () => {
+      messageSubscription.remove()
       XMTP.unsubscribeFromMessages(this.client.address, this.topic)
     }
   }


### PR DESCRIPTION
**Description:**
This pull request addresses the concerns raised in issue #180 by implementing the removal of the event subscription. The primary focus is on enhancing the reliability of unsubscribing from the message stream.

It is highly recommended to utilize the method returned by the `streamMessages` function for unsubscribing, as opposed to relying solely on the static `unsubscribeFromMessages`. This is crucial because the latter may not comprehensively handle unsubscription and might inadvertently impact multiple listeners.

For instance, consider the updated usage example below:

```typescript
export function useXmtpStream(conversation?: Conversation<any>) {
  useEffect(() => {
    const streamMessages = () => {
      if (!conversation) {
        return;
      }

      return conversation.streamMessages(async (message) => {
        console.log(message);
      });
    };

    const unsubscribe = streamMessages();

    return () => {
      if (conversation) {
        unsubscribe?.(); // Invoke the unsubscribe method
      }
    };
  }, []);
}
```

By calling the `unsubscribe` method obtained from `streamMessages`, we ensure a more comprehensive unsubscription process, mitigating potential issues related to multiple listeners.