### PR TITLE
Proposal : unsubscribe all message & conversation event

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,14 +155,17 @@ You can also listen for new conversations being started in real-time. This will 
 > This stream will continue infinitely. To end the stream you can call the method returned by `conversations.stream()`.
 
 ```tsx
-const stream = await xmtp.conversations.stream()
-for await (const conversation of stream) {
-  console.log(`New conversation started with ${conversation.peerAddress}`)
-  // Say hello to your new friend
-  await conversation.send('Hi there!')
-  // Break from the loop to stop listening
-  break
-}
+const cancelStream = await xmtp.conversations.stream(
+  async (conversation) => {
+    console.log(`New conversation started with ${conversation.peerAddress}`)
+
+    // Say hello to your new friend
+    await conversation.send('Hi there!')
+  }
+)
+
+// To unsubscribe from the stream
+cancelStream()
 ```
 
 ### Start a new conversation
@@ -228,13 +231,16 @@ The Stream returned by the `stream` methods is an asynchronous iterator and as s
 const conversation = await xmtp.conversations.newConversation(
   '0x3F11b27F323b62B159D2642964fa27C46C841897'
 )
-for await (const message of await conversation.streamMessages()) {
+const cancelStream = await conversation.streamMessages(async (message) => {
   if (message.senderAddress === xmtp.address) {
     // This message was sent from me
     continue
   }
   console.log(`New message from ${message.senderAddress}: ${message.content}`)
-}
+})
+
+// To unsubscribe from the stream
+cancelStream()
 ```
 
 ### Listen for new messages in all conversations
@@ -248,13 +254,18 @@ To listen for any new messages from _all_ conversations, use `conversations.stre
 > This stream will continue infinitely. To end the stream you can call the method returned by `conversations.streamAllMessages()`.
 
 ```tsx
-for await (const message of await xmtp.conversations.streamAllMessages()) {
-  if (message.senderAddress === xmtp.address) {
-    // This message was sent from me
-    continue
+const cancelAllMessagesStream = await xmtp.conversations.streamAllMessages(
+  async (message) => {
+    if (message.senderAddress === xmtp.address) {
+      // This message was sent from me
+      continue
+    }
+    console.log(`New message from ${message.senderAddress}: ${message.content}`)
   }
-  console.log(`New message from ${message.senderAddress}: ${message.content}`)
-}
+)
+
+// To unsubscribe from the all messages stream
+cancelAllMessagesStream()
 ```
 
 ## Request and respect user consent

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ These conversations include all conversations for a user **regardless of which a
 You can also listen for new conversations being started in real-time. This will allow applications to display incoming messages from new contacts.
 
 > **Warning**  
-> This stream will continue infinitely. To end the stream you can call `cancelStream()`.
+> This stream will continue infinitely. To end the stream you can call the method returned by `conversations.stream()`.
 
 ```tsx
 const stream = await xmtp.conversations.stream()
@@ -222,7 +222,7 @@ You can listen for any new messages (incoming or outgoing) in a conversation by 
 
 A successfully received message (that makes it through the decoding and decryption without throwing) can be trusted to be authentic, i.e. that it was sent by the owner of the `message.senderAddress` wallet and that it wasn't modified in transit. The `message.sent` timestamp can be trusted to have been set by the sender.
 
-The Stream returned by the `stream` methods is an asynchronous iterator and as such usable by a for-await-of loop. Note however that it is by its nature infinite, so any looping construct used with it will not terminate, unless the termination is explicitly initiated by calling `cancelStreamMessages()`.
+The Stream returned by the `stream` methods is an asynchronous iterator and as such usable by a for-await-of loop. Note however that it is by its nature infinite, so any looping construct used with it will not terminate, unless the termination is explicitly initiated by calling the method returned by `conversation.streamMessages()`.
 
 ```tsx
 const conversation = await xmtp.conversations.newConversation(
@@ -245,7 +245,7 @@ To listen for any new messages from _all_ conversations, use `conversations.stre
 > There is a chance this stream can miss messages if multiple new conversations are received in the time it takes to update the stream to include a new conversation.
 
 > **Warning**  
-> This stream will continue infinitely. To end the stream you can call `cancelStreamAllMessages()`.
+> This stream will continue infinitely. To end the stream you can call the method returned by `conversations.streamAllMessages()`.
 
 ```tsx
 for await (const message of await xmtp.conversations.streamAllMessages()) {

--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -361,15 +361,19 @@ test('can stream messages', async () => {
 
   // Record new conversation stream
   const allConversations: Conversation<any>[] = []
-  await alice.conversations.stream(async (conversation) => {
-    allConversations.push(conversation)
-  })
+  const cancelStream = await alice.conversations.stream(
+    async (conversation) => {
+      allConversations.push(conversation)
+    }
+  )
 
   // Record message stream across all conversations
   const allMessages: DecodedMessage[] = []
-  await alice.conversations.streamAllMessages(async (message) => {
-    allMessages.push(message)
-  })
+  const cancelStreamAllMessages = await alice.conversations.streamAllMessages(
+    async (message) => {
+      allMessages.push(message)
+    }
+  )
 
   // Start Bob starts a new conversation.
   const bobConvo = await bob.conversations.newConversation(alice.address, {
@@ -447,8 +451,8 @@ test('can stream messages', async () => {
       throw Error('Unexpected convo message topic ' + convoMessages[i].topic)
     }
   }
-  alice.conversations.cancelStream()
-  alice.conversations.cancelStreamAllMessages()
+  cancelStream()
+  cancelStreamAllMessages()
 
   return true
 })
@@ -586,9 +590,11 @@ test('can stream all messages', async () => {
 
   // Record message stream across all conversations
   const allMessages: DecodedMessage[] = []
-  await alix.conversations.streamAllMessages(async (message) => {
-    allMessages.push(message)
-  })
+  const cancelStreamAllMessages = await alix.conversations.streamAllMessages(
+    async (message) => {
+      allMessages.push(message)
+    }
+  )
 
   // Start Bob starts a new conversation.
   const boConvo = await bo.conversations.newConversation(alix.address)
@@ -617,7 +623,7 @@ test('can stream all messages', async () => {
     throw Error('Unexpected all messages count ' + allMessages.length)
   }
 
-  alix.conversations.cancelStreamAllMessages()
+  cancelStreamAllMessages()
 
   await alix.conversations.streamAllMessages(async (message) => {
     allMessages.push(message)

--- a/src/lib/Conversations.ts
+++ b/src/lib/Conversations.ts
@@ -63,8 +63,7 @@ export default class Conversations<ContentTypes> {
    * This method subscribes to conversations in real-time and listens for incoming conversation events.
    * When a new conversation is detected, the provided callback function is invoked with the details of the conversation.
    * @param {Function} callback - A callback function that will be invoked with the new Conversation when a conversation is started.
-   * @returns {Promise<void>} A Promise that resolves when the stream is set up.
-   * @warning This stream will continue infinitely. To end the stream, you can call {@linkcode Conversations.cancelStream | cancelStream()}.
+   * @returns {Promise<void>} A function that, when called, unsubscribes from the message stream and ends real-time updates..
    */
   async stream(
     callback: (conversation: Conversation<ContentTypes>) => Promise<void>
@@ -101,7 +100,7 @@ export default class Conversations<ContentTypes> {
    *
    * This method subscribes to all conversations in real-time and listens for incoming and outgoing messages.
    * @param {Function} callback - A callback function that will be invoked when a message is sent or received.
-   * @returns {Promise<void>} A Promise that resolves when the stream is set up.
+   * @returns {Promise<void>} A function that, when called, unsubscribes from all the messages stream and ends real-time updates.
    */
   async streamAllMessages(
     callback: (message: DecodedMessage) => Promise<void>


### PR DESCRIPTION
**Description:**
Building upon the insights gained from issue #187, this pull request introduces a refined approach to proper unsubscription from the methods returned by `stream` and `streamAllMessages`. Simultaneously, it recommends the removal of the static methods `cancelStream()` and `cancelStreamAllMessages()`.

This adjustment serves to eliminate redundant listeners and prevent the occurrence of duplicated events.

| iOS | Android |
|:--:|:--:|
| <img src='https://github.com/xmtp/xmtp-react-native/assets/57466680/f41bd531-35f9-40c2-9029-91d42ab756b4' width='400' /> | <img src='https://github.com/xmtp/xmtp-react-native/assets/57466680/3f223f4e-6712-4502-b38e-598713befccd' width='400' /> |