### PR TITLE
Remove Manual Install Step

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ yarn i @xmtp/react-native-sdk
 In the `ios` directory, update your `Podfile` file as follows:
 
 - Set this value: `platform :ios, '16.0'`. This is required by XMTP.
-- Add this line: `pod 'secp256k1.swift', :modular_headers => true`. This is required for web3.swift.
 
 ```bash
 npx pod-install

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -48,8 +48,6 @@ target 'xmtpreactnativesdkexample' do
   # Flags change depending on the env values.
   flags = get_default_flags()
 
-  pod 'secp256k1.swift', :modular_headers => true
-
   use_react_native!(
     :path => config[:reactNativePath],
     :hermes_enabled => podfile_properties['expo.jsEngine'] == nil || podfile_properties['expo.jsEngine'] == 'hermes',

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -24,6 +24,7 @@ Pod::Spec.new do |s|
   }
 
   s.source_files = "**/*.{h,m,swift}"
+  s.dependency 'secp256k1.swift'
 	s.dependency "MessagePacker"
   s.dependency "XMTP", "= 0.7.3-alpha0"
 end


### PR DESCRIPTION
Problem:
There are a number of manual steps required when integrating with React Native SDK

Would like to make sure that this is indeed a requirement or if we can smooth out integration steps

Solution:
Move dependency to podspec
Remove ReadMe step

Opening as draft to see how CI handles this change