### PR TITLE
Fix decoding messages

### DIFF
--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -281,7 +281,6 @@ test('can paginate batch messages', async () => {
     await bobConversation.send({ text: `Message ${i}` })
     await delayToPropogate()
   }
-  await bobConversation.send('')
 
   const messagesLimited: DecodedMessage[] = await alice.listBatchMessages([
     {
@@ -305,6 +304,9 @@ test('can paginate batch messages', async () => {
     } as Query,
   ])
 
+  await bobConversation.send('')
+  await delayToPropogate()
+
   const messagesAsc: DecodedMessage[] = await alice.listBatchMessages([
     {
       contentTopic: bobConversation.topic,
@@ -316,8 +318,6 @@ test('can paginate batch messages', async () => {
     throw Error('Unexpected messagesLimited count ' + messagesLimited.length)
   }
 
-  const content: number = messagesLimited[0].content()
-  console.log('string', content)
   if (messagesLimited[0].content() !== 'Message 4') {
     throw Error(
       'Unexpected messagesLimited content ' + messagesLimited[0].content()
@@ -349,6 +349,10 @@ test('can paginate batch messages', async () => {
 
   if (messagesAsc[0].content() !== 'Initial Message') {
     throw Error('Unexpected messagesAsc content ' + messagesAsc[0].content())
+  }
+
+  if (messagesAsc[6].contentTypeId !== 'xmtp.org/text:1.0') {
+    throw Error('Unexpected messagesAsc content ' + messagesAsc[6].content())
   }
 
   return true
@@ -398,7 +402,6 @@ test('can stream messages', async () => {
     )
   }
   if (!bobConvo.createdAt) {
-    console.log('bobConvo', bobConvo)
     throw Error('Missing createdAt ' + bobConvo.createdAt)
   }
 

--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -281,6 +281,7 @@ test('can paginate batch messages', async () => {
     await bobConversation.send({ text: `Message ${i}` })
     await delayToPropogate()
   }
+  await bobConversation.send('')
 
   const messagesLimited: DecodedMessage[] = await alice.listBatchMessages([
     {

--- a/src/lib/Conversation.ts
+++ b/src/lib/Conversation.ts
@@ -68,8 +68,6 @@ export class Conversation<ContentTypes> {
       | undefined
   ): Promise<DecodedMessage<ContentTypes>[]> {
     try {
-      console.log('message() client is', this.client)
-
       const messages = await XMTP.listMessages(
         this.client,
         this.topic,

--- a/src/lib/DecodedMessage.ts
+++ b/src/lib/DecodedMessage.ts
@@ -86,11 +86,18 @@ export class DecodedMessage<ContentTypes = any> {
       const codec = this.client.codecRegistry[
         this.contentTypeId
       ] as JSContentCodec<ContentTypes>
-
+      if (!codec) {
+        throw new Error(
+          `no content type found ${JSON.stringify(this.contentTypeId)}`
+        )
+      }
       return codec.decode(encoded)
     } else {
       for (const codec of Object.values(this.client.codecRegistry)) {
-        if ('contentKey' in codec && this.nativeContent[codec.contentKey]) {
+        if (
+          ('contentKey' in codec && this.nativeContent[codec.contentKey]) ||
+          this.nativeContent.hasOwnProperty('text')
+        ) {
           return (codec as NativeContentCodec<ContentTypes>).decode(
             this.nativeContent
           )

--- a/src/lib/DecodedMessage.ts
+++ b/src/lib/DecodedMessage.ts
@@ -97,7 +97,9 @@ export class DecodedMessage<ContentTypes = any> {
         }
       }
 
-      throw new Error(`no content type found ${JSON.stringify(this.nativeContent)}`)
+      throw new Error(
+        `no content type found ${JSON.stringify(this.nativeContent)}`
+      )
     }
   }
 }


### PR DESCRIPTION
When sending a text message with an empty string the app would error as the string was considered falsy since it was empty. We now handle all text messages as they are supported by default.

In this process I also caught that custom content types would break on decode because the codec did not exist. We now error gracefully for unsupported content types allowing for the handling of them in app.

<img width="884" alt="Screenshot 2023-12-20 at 11 34 03 AM" src="https://github.com/xmtp/xmtp-react-native/assets/3522670/bb94d2ad-3077-488d-aa07-c49298030cf9">

