### PR TITLE
fix: sign actions should wait for preCallback completion before proceeding

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -17,8 +17,8 @@ import expo.modules.xmtpreactnativesdk.wrappers.DecodedMessageWrapper
 import expo.modules.xmtpreactnativesdk.wrappers.DecryptedLocalAttachment
 import expo.modules.xmtpreactnativesdk.wrappers.EncryptedLocalAttachment
 import expo.modules.xmtpreactnativesdk.wrappers.PreparedLocalMessage
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -127,8 +127,9 @@ class XMTPModule : Module() {
     private val isDebugEnabled = BuildConfig.DEBUG // TODO: consider making this configurable
     private val conversations: MutableMap<String, Conversation> = mutableMapOf()
     private val subscriptions: MutableMap<String, Job> = mutableMapOf()
-    var waitForPreEnableIdentityCallback: Boolean = false
-    var waitForPreCreateIdentityCallback: Boolean = false
+    private var preEnableIdentityCallbackDeferred: CompletableDeferred<Unit>? = null
+    private var preCreateIdentityCallbackDeferred: CompletableDeferred<Unit>? = null
+
 
     override fun definition() = ModuleDefinition {
         Name("XMTP")
@@ -155,8 +156,10 @@ class XMTPModule : Module() {
             val reactSigner = ReactNativeSigner(module = this@XMTPModule, address = address)
             signer = reactSigner
 
-            waitForPreEnableIdentityCallback = hasEnableIdentityCallback == true
-            waitForPreCreateIdentityCallback = hasCreateIdentityCallback == true
+            if (hasCreateIdentityCallback == true) 
+                preCreateIdentityCallbackDeferred = CompletableDeferred()
+            if (hasEnableIdentityCallback == true) 
+                preEnableIdentityCallbackDeferred = CompletableDeferred()
             val preCreateIdentityCallback: PreEventCallback? =
                 preCreateIdentityCallback.takeIf { hasCreateIdentityCallback == true }
             val preEnableIdentityCallback: PreEventCallback? =
@@ -182,8 +185,10 @@ class XMTPModule : Module() {
             logV("createRandom")
             val privateKey = PrivateKeyBuilder()
 
-            waitForPreEnableIdentityCallback = hasEnableIdentityCallback == true
-            waitForPreCreateIdentityCallback = hasCreateIdentityCallback == true
+            if (hasCreateIdentityCallback == true) 
+                preCreateIdentityCallbackDeferred = CompletableDeferred()
+            if (hasEnableIdentityCallback == true) 
+                preEnableIdentityCallbackDeferred = CompletableDeferred()
             val preCreateIdentityCallback: PreEventCallback? =
                 preCreateIdentityCallback.takeIf { hasCreateIdentityCallback == true }
             val preEnableIdentityCallback: PreEventCallback? =
@@ -600,16 +605,14 @@ class XMTPModule : Module() {
             client.contacts.consentList.entries.map { ConsentWrapper.encode(it.value) }
         }
 
-        Function("preEnableIdentityCallbackCompleted") { 
-            logV("preEnableIdentityCallbackCompleted")
-            waitForPreEnableIdentityCallback = false
-            true
-        }
-
         Function("preCreateIdentityCallbackCompleted") {
             logV("preCreateIdentityCallbackCompleted")
-            waitForPreCreateIdentityCallback = false
-            true
+            preCreateIdentityCallbackDeferred?.complete(Unit)
+        }
+
+        Function("preEnableIdentityCallbackCompleted") { 
+            logV("preEnableIdentityCallbackCompleted")
+            preEnableIdentityCallbackDeferred?.complete(Unit)
         }
     }
 
@@ -736,19 +739,14 @@ class XMTPModule : Module() {
 
     private val preEnableIdentityCallback: suspend () -> Unit = {
         sendEvent("preEnableIdentityCallback")
-        waitForCallback { waitForPreEnableIdentityCallback }
+        preEnableIdentityCallbackDeferred?.await()
+        preCreateIdentityCallbackDeferred == null
     }
 
     private val preCreateIdentityCallback: suspend () -> Unit = {
         sendEvent("preCreateIdentityCallback")
-        waitForCallback { waitForPreCreateIdentityCallback }
-    }
-
-    // Helper function to wait for a callback
-    private suspend fun waitForCallback(check: () -> Boolean) {
-        while (check()) {
-            delay(100) // Wait for 100ms before checking again
-        }
+        preCreateIdentityCallbackDeferred?.await()
+        preCreateIdentityCallbackDeferred = null
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -393,6 +393,14 @@ export async function consentList(
   })
 }
 
+export function preEnableIdentityCallbackCompleted() {
+  XMTPModule.preEnableIdentityCallbackCompleted()
+}
+
+export function preCreateIdentityCallbackCompleted() {
+  XMTPModule.preCreateIdentityCallbackCompleted()
+}
+
 export const emitter = new EventEmitter(XMTPModule ?? NativeModulesProxy.XMTP)
 
 export * from './lib/ContentCodec'

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -236,6 +236,7 @@ export class Client<ContentTypes> {
       opts,
       async () => {
         await this.executeCallback(opts?.preEnableIdentityCallback)
+        XMTPModule.preEnableIdentityCallbackCompleted()
       }
     )
 
@@ -244,6 +245,7 @@ export class Client<ContentTypes> {
       opts,
       async () => {
         await this.executeCallback(opts?.preCreateIdentityCallback)
+        XMTPModule.preCreateIdentityCallbackCompleted()
       }
     )
 


### PR DESCRIPTION
Related PRs:
- https://github.com/xmtp/xmtp-react-native/pull/177
- https://github.com/xmtp/xmtp-react-native/pull/192
- https://github.com/xmtp/xmtp-android/pull/144
- https://github.com/xmtp/xmtp-ios/pull/201

## Description

- [X] TypeScript code updated
- [X] Android Kotlin code updated
- [x] iOS Swift code updated
- [ ] Finish verifying no unexpected error conditions can occur (see **To Test** section below)

In the PRs linked above we added a callback that could be passed in during identity creation that would be fired to notify when identity creation and enabling occurred. 

However those callbacks were implemented in a way that merely notified that sign actions would occur without actually blocking the signing actions until the callbacks were finished. 

For example, the preEventCallbacks in `xmtp-js` block signing actions until after callbacks are finished, which gives developers greater flexibility: https://github.com/xmtp/xmtp-js/blob/e96b2e214bef3965f703be09863fa8b2fb4552d2/src/Client.ts#L178-L194

This change updates our code to wait until callbacks are completed before resuming identity sign request logic. 

## To Test

The following branch has changes from this PR cherry-picked on to a branch that has in progress code for connecting external wallets in the example app (via thirdweb-sdk + wallet connect): [cameronvoell-callback-testing-wallet](https://github.com/xmtp/xmtp-react-native/compare/cameronvoell/example-wallet-auth...cameronvoell-callback-testing-wallet?expand=1)

Paths to check:

1. Passing in callbacks blocks signing actions until callback completes on Android + iOS
2. Identity creation works as expected when no callbacks are passed in to identity creation functions on Android and iOS
3. Paths where errors occur due to rejected signing attempts or anything else do not cause callbacks to block identity creation indefinitely or lead to any other unexpected errors. 



