### PR TITLE
Fix: Consent capping at 100 entries

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.7.1"
+  implementation "org.xmtp:android:0.7.3"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -411,7 +411,7 @@ PODS:
     - GenericJSON (~> 2.0)
     - Logging (~> 1.0.0)
     - secp256k1.swift (~> 0.1)
-  - XMTP (0.7.4-alpha0):
+  - XMTP (0.7.5-alpha0):
     - Connect-Swift (= 0.3.0)
     - GzipSwift
     - web3.swift
@@ -419,7 +419,8 @@ PODS:
   - XMTPReactNative (0.1.0):
     - ExpoModulesCore
     - MessagePacker
-    - XMTP (= 0.7.4-alpha0)
+    - secp256k1.swift
+    - XMTP (= 0.7.5-alpha0)
   - XMTPRust (0.3.7-beta0)
   - Yoga (1.14.0)
 
@@ -476,7 +477,6 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
-  - secp256k1.swift
   - XMTPReactNative (from `../../ios`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -668,11 +668,11 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   SwiftProtobuf: b02b5075dcf60c9f5f403000b3b0c202a11b6ae1
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: 9ba94e797211aa4f7cbed9ed2a2f4c44d32c8d06
-  XMTPReactNative: 6f194a2f3ab388d2517f92feae01cff961ee88ab
+  XMTP: aa137f3c8ac7b61ecfb3de0973f2dc2e672a9ec1
+  XMTPReactNative: e4a325b0b51dedf1a2785cad53ca3bceb1149b86
   XMTPRust: 8848a2ba761b2c961d666632f2ad27d1082faa93
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
-PODFILE CHECKSUM: 522d88edc2d5fac4825e60a121c24abc18983367
+PODFILE CHECKSUM: bf49a4bdc3d11b67c441720989a50fa1e6be21f3
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.13.0

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
   s.dependency 'secp256k1.swift'
 	s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.7.4-alpha0"
+  s.dependency "XMTP", "= 0.7.5-alpha0"
 end


### PR DESCRIPTION
Fixes https://github.com/xmtp/xmtp-react-native/issues/197
Fixes https://github.com/xmtp/xmtp-react-native/issues/196

Correctly paginate consent so that all entries are used not just first 100.
Correctly handle public key computations when leading zeros exist.