### PR TITLE
fix: set semaphore as nil after complete de function

### DIFF
--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -576,12 +576,14 @@ public class XMTPModule: Module {
 		Function("preEnableIdentityCallbackCompleted") {
 			DispatchQueue.global().async {
 				self.preEnableIdentityCallbackDeferred?.signal()
+				self.preEnableIdentityCallbackDeferred = nil
 			}
 		}
 		
 		Function("preCreateIdentityCallbackCompleted") {
 			DispatchQueue.global().async {
 				self.preCreateIdentityCallbackDeferred?.signal()
+				self.preCreateIdentityCallbackDeferred = nil
 			}
 		}
 	}
@@ -724,12 +726,10 @@ public class XMTPModule: Module {
 	func preEnableIdentityCallback() {
 		sendEvent("preEnableIdentityCallback")
 		self.preEnableIdentityCallbackDeferred?.wait()
-		self.preCreateIdentityCallbackDeferred = nil
 	}
 
 	func preCreateIdentityCallback() {
 		sendEvent("preCreateIdentityCallback")
 		self.preCreateIdentityCallbackDeferred?.wait()
-		self.preEnableIdentityCallbackDeferred = nil
 	}
 }


### PR DESCRIPTION
**Description:**
This PR fixes the pre-event callbacks on iOS setting as nill only when the execution is finished. The issue happens when a user tries to log in with a wallet that has never been connected with XMTP. Triggering the `create` callback first and then waiting until `enable` ends the execution to launch the Enable signature.

**Evidence:**
_In this test a 10 sec timer was sent as a callback_
<video src='https://github.com/xmtp/xmtp-react-native/assets/57466680/013a8a73-edc2-4d6d-a144-5d359afb4871' width='600' />