### PR TITLE
Added test for custom type encoding

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -28,13 +28,15 @@
     "react-native-screens": "~3.20.0",
     "react-native-svg": "^13.9.0",
     "react-native-url-polyfill": "^2.0.0",
-    "react-query": "^3.39.3"
+    "react-query": "^3.39.3",
+    "text-encoding": "^0.7.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@types/node": "^18.16.3",
     "@types/react": "18.2.0",
     "@types/react-native": "0.71.8",
+    "@types/text-encoding": "^0.0.39",
     "@typescript-eslint/eslint-plugin": "^6.13.1",
     "@typescript-eslint/parser": "^6.13.1",
     "eslint": "^8.54.0",

--- a/example/src/tests.ts
+++ b/example/src/tests.ts
@@ -888,9 +888,10 @@ test('register and use custom content type transaction reference', async () => {
   const bobConvo = await bob.conversations.newConversation(alice.address)
   const aliceConvo = await alice.conversations.newConversation(bob.address)
 
-  const txRef: TransactionReference =  {
+  const txRef: TransactionReference = {
     networkId: '1',
-    reference: '0x3e66bdd4e4c2694c4571563318857388b430a79c8b7c1c88837ea33b8ef5b338'
+    reference:
+      '0x3e66bdd4e4c2694c4571563318857388b430a79c8b7c1c88837ea33b8ef5b338',
   }
   await bobConvo.send(txRef, {
     contentType: ContentTypeTransactionReference,
@@ -902,22 +903,25 @@ test('register and use custom content type transaction reference', async () => {
   const message = messages[0]
   const messageContent = message.content()
 
-  assert(isTransactionReference(messageContent), 'messageContent does not contain reference')
+  assert(
+    isTransactionReference(messageContent),
+    'messageContent does not contain reference'
+  )
   if (isTransactionReference(messageContent)) {
     console.log('Checking message content')
     assert(
-      messageContent?.reference === '0x3e66bdd4e4c2694c4571563318857388b430a79c8b7c1c88837ea33b8ef5b338',
+      messageContent?.reference ===
+        '0x3e66bdd4e4c2694c4571563318857388b430a79c8b7c1c88837ea33b8ef5b338',
       'did not get content properly: ' + JSON.stringify(messageContent)
     )
   }
-  
+
   assert(
     message.contentTypeId === 'xmtp.org/transactionReference:1.0',
     'Content type is not TransactionReference: ' + message.contentTypeId
   )
   return true
 })
-
 
 test('calls preCreateIdentityCallback when supplied', async () => {
   let isCallbackCalled = false

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2430,6 +2430,11 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
 
+"@types/text-encoding@^0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/text-encoding/-/text-encoding-0.0.39.tgz#6f6436ceb843d96a2306a87dc7e2286e62c2177c"
+  integrity sha512-gRPvgL1aMgP6Pv92Rs310cJvVQ86DSF62E7K30g1FoGmmYWXoNuXT8PV835iAVeiAZkRwr2IW37KuyDn9ljmeA==
+
 "@types/yargs-parser@*":
   version "21.0.3"
   resolved "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz"
@@ -8457,6 +8462,11 @@ terser@^5.15.0:
     acorn "^8.8.2"
     commander "^2.20.0"
     source-map-support "~0.5.20"
+
+text-encoding@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
+  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
 
 text-table@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
We are seeing an issue where `encodedContent` in Custom types is unexpectedly base64 encoded which does not match the behavior on xmtp-js. 

In Addition, the test in this PR shows that encodedContent.content is received as undefined, only on Android. 

The goal in this PR is to fix the two issues caught by the new test `register and use custom content type transaction reference`