### PR TITLE
fix: Revert Java Version Upgrade

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,17 +66,17 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 34)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
   if (agpVersion.tokenize('.')[0].toInteger() < 8) {
     compileOptions {
-      sourceCompatibility JavaVersion.VERSION_17
-      targetCompatibility JavaVersion.VERSION_17
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_17.majorVersion
+      jvmTarget = JavaVersion.VERSION_11.majorVersion
     }
   }
 


### PR DESCRIPTION
Revert java version upgrade until React Native 0.73 is more widly used