### PR TITLE
fix: update org.xmtp:android to 0.7.6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.7.5"
+  implementation "org.xmtp:android:0.7.6"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"


### PR DESCRIPTION
Closes: #218 

Bump xmtp-android version to 0.7.6 to get the latest version