### PR TITLE
Schedules PR of main to beta Mon at 1:05AM PT

### DIFF
--- a/.github/workflows/syncBeta.yml
+++ b/.github/workflows/syncBeta.yml
@@ -1,0 +1,19 @@
+name: Auto PR Creation
+on:
+  schedule:
+    - cron: '5 9 * * 5' # Runs at 1:05 AM PT(-8) every Monday (time in UTC)
+  workflow_dispatch:
+  
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Create Pull Request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "main"
+          destination_branch: "beta"
+          pr_title: "`main` => `beta`"
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Figured we can resolve any conflicts Mondays and start the week with `beta` caught up. Scheduled action will prevent conflicts from piling up if we start being more active on the `beta` branch.

Once this merged, we can also use the actions tab on GitHub to manually generate the PR for syncing beta with main (will be called "Auto PR Creation" => run workflow)