### PR TITLE
Import static libxmtp libraries from libxmtp-swift podspec update

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -50,8 +50,8 @@ target 'xmtpreactnativesdkexample' do
 
   # See https://github.com/margelo/react-native-quick-crypto/issues/189#issuecomment-1711561970
   pod "OpenSSL-Universal", "1.1.2200"
-  pod "XMTP", :git => 'https://github.com/xmtp/xmtp-ios.git', :commit => '08dde6aed8d4db71714c9690ce70d16e494e9251'
-  pod 'LibXMTP', :podspec => 'https://raw.githubusercontent.com/xmtp/libxmtp-swift/58e80a641f45ed6b5033e220f982efeb5c3dbe86/LibXMTP.podspec'
+  pod "XMTP", :git => 'https://github.com/xmtp/xmtp-ios.git', :commit => 'a82cc44d09d795f104cec85df1bc287cff826435'
+  pod 'LibXMTP', :podspec => 'https://raw.githubusercontent.com/xmtp/libxmtp-swift/8eec299e23caa2945dc30cc2cecdf0a95c1ff1c3/LibXMTP.podspec'
 
   use_react_native!(
     :path => config[:reactNativePath],

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -50,8 +50,8 @@ target 'xmtpreactnativesdkexample' do
 
   # See https://github.com/margelo/react-native-quick-crypto/issues/189#issuecomment-1711561970
   pod "OpenSSL-Universal", "1.1.2200"
-  pod "XMTP", :git => 'https://github.com/xmtp/xmtp-ios.git', :commit => 'a82cc44d09d795f104cec85df1bc287cff826435'
-  pod 'LibXMTP', :podspec => 'https://raw.githubusercontent.com/xmtp/libxmtp-swift/8eec299e23caa2945dc30cc2cecdf0a95c1ff1c3/LibXMTP.podspec'
+  pod "XMTP", :git => 'https://github.com/xmtp/xmtp-ios.git', :commit => '88995613060223bf9214418ad4230d07e767ead6'
+  pod 'LibXMTP', :podspec => 'https://raw.githubusercontent.com/xmtp/libxmtp-swift/476de4b3be970f7f7bd7a39066022e83b9fad455/LibXMTP.podspec'
 
   use_react_native!(
     :path => config[:reactNativePath],

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -50,8 +50,6 @@ target 'xmtpreactnativesdkexample' do
 
   # See https://github.com/margelo/react-native-quick-crypto/issues/189#issuecomment-1711561970
   pod "OpenSSL-Universal", "1.1.2200"
-  pod "XMTP", :git => 'https://github.com/xmtp/xmtp-ios.git', :commit => '88995613060223bf9214418ad4230d07e767ead6'
-  pod 'LibXMTP', :podspec => 'https://raw.githubusercontent.com/xmtp/libxmtp-swift/476de4b3be970f7f7bd7a39066022e83b9fad455/LibXMTP.podspec'
 
   use_react_native!(
     :path => config[:reactNativePath],

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -50,6 +50,8 @@ target 'xmtpreactnativesdkexample' do
 
   # See https://github.com/margelo/react-native-quick-crypto/issues/189#issuecomment-1711561970
   pod "OpenSSL-Universal", "1.1.2200"
+  pod "XMTP", :git => 'https://github.com/xmtp/xmtp-ios.git', :commit => '08dde6aed8d4db71714c9690ce70d16e494e9251'
+  pod 'LibXMTP', :podspec => 'https://raw.githubusercontent.com/xmtp/libxmtp-swift/58e80a641f45ed6b5033e220f982efeb5c3dbe86/LibXMTP.podspec'
 
   use_react_native!(
     :path => config[:reactNativePath],

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -56,7 +56,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.71.14)
   - hermes-engine/Pre-built (0.71.14)
   - libevent (2.1.12)
-  - LibXMTP (0.0.1-timeout0)
+  - LibXMTP (0.4.1)
   - Logging (1.0.0)
   - MessagePacker (0.4.7)
   - MMKV (1.3.3):
@@ -442,17 +442,16 @@ PODS:
     - GenericJSON (~> 2.0)
     - Logging (~> 1.0.0)
     - secp256k1.swift (~> 0.1)
-  - XMTP (0.7.6-alpha0):
+  - XMTP (0.7.7-alpha0):
     - Connect-Swift (= 0.3.0)
     - GzipSwift
-    - LibXMTP (= 0.0.1-timeout0)
+    - LibXMTP (= 0.4.1)
     - web3.swift
   - XMTPReactNative (0.1.0):
     - ExpoModulesCore
-    - LibXMTP (= 0.0.1-timeout0)
     - MessagePacker
     - secp256k1.swift
-    - XMTP (= 0.7.6-alpha0)
+    - XMTP (= 0.7.7-alpha0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -477,7 +476,7 @@ DEPENDENCIES:
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
-  - LibXMTP (from `https://raw.githubusercontent.com/xmtp/libxmtp-swift/cv/staticlib/LibXMTP.podspec`)
+  - LibXMTP (from `https://raw.githubusercontent.com/xmtp/libxmtp-swift/8eec299e23caa2945dc30cc2cecdf0a95c1ff1c3/LibXMTP.podspec`)
   - OpenSSL-Universal (= 1.1.2200)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -520,7 +519,7 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
-  - XMTP (from `https://github.com/xmtp/xmtp-ios.git`, commit `08dde6aed8d4db71714c9690ce70d16e494e9251`)
+  - XMTP (from `https://github.com/xmtp/xmtp-ios.git`, commit `a82cc44d09d795f104cec85df1bc287cff826435`)
   - XMTPReactNative (from `../../ios`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -584,7 +583,7 @@ EXTERNAL SOURCES:
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
   LibXMTP:
-    :podspec: https://raw.githubusercontent.com/xmtp/libxmtp-swift/cv/staticlib/LibXMTP.podspec
+    :podspec: https://raw.githubusercontent.com/xmtp/libxmtp-swift/8eec299e23caa2945dc30cc2cecdf0a95c1ff1c3/LibXMTP.podspec
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -666,7 +665,7 @@ EXTERNAL SOURCES:
   RNSVG:
     :path: "../node_modules/react-native-svg"
   XMTP:
-    :commit: 08dde6aed8d4db71714c9690ce70d16e494e9251
+    :commit: a82cc44d09d795f104cec85df1bc287cff826435
     :git: https://github.com/xmtp/xmtp-ios.git
   XMTPReactNative:
     :path: "../../ios"
@@ -678,7 +677,7 @@ CHECKOUT OPTIONS:
     :commit: 58e80a641f45ed6b5033e220f982efeb5c3dbe86
     :git: https://github.com/xmtp/libxmtp-swift.git
   XMTP:
-    :commit: 08dde6aed8d4db71714c9690ce70d16e494e9251
+    :commit: a82cc44d09d795f104cec85df1bc287cff826435
     :git: https://github.com/xmtp/xmtp-ios.git
 
 SPEC CHECKSUMS:
@@ -709,7 +708,7 @@ SPEC CHECKSUMS:
   GzipSwift: 893f3e48e597a1a4f62fafcb6514220fcf8287fa
   hermes-engine: d7cc127932c89c53374452d6f93473f1970d8e88
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  LibXMTP: 700256424096c766f72b190bfc096bd2cfbc8d76
+  LibXMTP: e705bcaaa64aaa89998f718e807662647cbc9d4b
   Logging: 9ef4ecb546ad3169398d5a723bc9bea1c46bef26
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: f902fb6719da13c2ab0965233d8963a59416f911
@@ -758,10 +757,10 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   SwiftProtobuf: b02b5075dcf60c9f5f403000b3b0c202a11b6ae1
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: 2dae903c8932f6ff7395808f6142f9e88b2ff466
-  XMTPReactNative: 2bda83a1b21efcfce157182395eed8725f5aafc4
+  XMTP: 6ad8ec5fe9e4ea6d7029f25ee3935e646227fa20
+  XMTPReactNative: 01231fe57639ea936b081f02a2a73abe78d4de35
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
-PODFILE CHECKSUM: cfb4315bae880f8da8c8588ef2ebe1ac1c93c94e
+PODFILE CHECKSUM: 735365d52debb37b1871b7e98cede3d9f187e907
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.14.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -56,6 +56,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.71.14)
   - hermes-engine/Pre-built (0.71.14)
   - libevent (2.1.12)
+  - LibXMTP (0.0.1-timeout0)
   - Logging (1.0.0)
   - MessagePacker (0.4.7)
   - MMKV (1.3.3):
@@ -441,17 +442,17 @@ PODS:
     - GenericJSON (~> 2.0)
     - Logging (~> 1.0.0)
     - secp256k1.swift (~> 0.1)
-  - XMTP (0.7.7-alpha0):
+  - XMTP (0.7.6-alpha0):
     - Connect-Swift (= 0.3.0)
     - GzipSwift
+    - LibXMTP (= 0.0.1-timeout0)
     - web3.swift
-    - XMTPRust (= 0.3.7-beta0)
   - XMTPReactNative (0.1.0):
     - ExpoModulesCore
+    - LibXMTP (= 0.0.1-timeout0)
     - MessagePacker
     - secp256k1.swift
-    - XMTP (= 0.7.7-alpha0)
-  - XMTPRust (0.3.7-beta0)
+    - XMTP (= 0.7.6-alpha0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -476,6 +477,7 @@ DEPENDENCIES:
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
+  - LibXMTP (from `https://raw.githubusercontent.com/xmtp/libxmtp-swift/cv/staticlib/LibXMTP.podspec`)
   - OpenSSL-Universal (= 1.1.2200)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -518,6 +520,7 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
+  - XMTP (from `https://github.com/xmtp/xmtp-ios.git`, commit `08dde6aed8d4db71714c9690ce70d16e494e9251`)
   - XMTPReactNative (from `../../ios`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -538,8 +541,6 @@ SPEC REPOS:
     - secp256k1.swift
     - SwiftProtobuf
     - web3.swift
-    - XMTP
-    - XMTPRust
 
 EXTERNAL SOURCES:
   boost:
@@ -582,6 +583,8 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
+  LibXMTP:
+    :podspec: https://raw.githubusercontent.com/xmtp/libxmtp-swift/cv/staticlib/LibXMTP.podspec
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -662,10 +665,21 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-screens"
   RNSVG:
     :path: "../node_modules/react-native-svg"
+  XMTP:
+    :commit: 08dde6aed8d4db71714c9690ce70d16e494e9251
+    :git: https://github.com/xmtp/xmtp-ios.git
   XMTPReactNative:
     :path: "../../ios"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
+
+CHECKOUT OPTIONS:
+  LibXMTP:
+    :commit: 58e80a641f45ed6b5033e220f982efeb5c3dbe86
+    :git: https://github.com/xmtp/libxmtp-swift.git
+  XMTP:
+    :commit: 08dde6aed8d4db71714c9690ce70d16e494e9251
+    :git: https://github.com/xmtp/xmtp-ios.git
 
 SPEC CHECKSUMS:
   BigInt: 74b4d88367b0e819d9f77393549226d36faeb0d8
@@ -695,6 +709,7 @@ SPEC CHECKSUMS:
   GzipSwift: 893f3e48e597a1a4f62fafcb6514220fcf8287fa
   hermes-engine: d7cc127932c89c53374452d6f93473f1970d8e88
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
+  LibXMTP: 700256424096c766f72b190bfc096bd2cfbc8d76
   Logging: 9ef4ecb546ad3169398d5a723bc9bea1c46bef26
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: f902fb6719da13c2ab0965233d8963a59416f911
@@ -743,11 +758,10 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   SwiftProtobuf: b02b5075dcf60c9f5f403000b3b0c202a11b6ae1
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: b2488aa96eced55fd41a5aece1334be6b5ab622d
-  XMTPReactNative: 01231fe57639ea936b081f02a2a73abe78d4de35
-  XMTPRust: 8848a2ba761b2c961d666632f2ad27d1082faa93
+  XMTP: 2dae903c8932f6ff7395808f6142f9e88b2ff466
+  XMTPReactNative: 2bda83a1b21efcfce157182395eed8725f5aafc4
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
-PODFILE CHECKSUM: 95d6ace79946933ecf80684613842ee553dd76a2
+PODFILE CHECKSUM: cfb4315bae880f8da8c8588ef2ebe1ac1c93c94e
 
 COCOAPODS: 1.14.3

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -56,7 +56,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.71.14)
   - hermes-engine/Pre-built (0.71.14)
   - libevent (2.1.12)
-  - LibXMTP (0.4.1)
+  - LibXMTP (0.4.1-beta0)
   - Logging (1.0.0)
   - MessagePacker (0.4.7)
   - MMKV (1.3.3):
@@ -445,7 +445,7 @@ PODS:
   - XMTP (0.7.7-alpha0):
     - Connect-Swift (= 0.3.0)
     - GzipSwift
-    - LibXMTP (= 0.4.1)
+    - LibXMTP (= 0.4.1-beta0)
     - web3.swift
   - XMTPReactNative (0.1.0):
     - ExpoModulesCore
@@ -476,7 +476,7 @@ DEPENDENCIES:
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
-  - LibXMTP (from `https://raw.githubusercontent.com/xmtp/libxmtp-swift/8eec299e23caa2945dc30cc2cecdf0a95c1ff1c3/LibXMTP.podspec`)
+  - LibXMTP (from `https://raw.githubusercontent.com/xmtp/libxmtp-swift/476de4b3be970f7f7bd7a39066022e83b9fad455/LibXMTP.podspec`)
   - OpenSSL-Universal (= 1.1.2200)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -519,7 +519,7 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
-  - XMTP (from `https://github.com/xmtp/xmtp-ios.git`, commit `a82cc44d09d795f104cec85df1bc287cff826435`)
+  - XMTP (from `https://github.com/xmtp/xmtp-ios.git`, commit `88995613060223bf9214418ad4230d07e767ead6`)
   - XMTPReactNative (from `../../ios`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -583,7 +583,7 @@ EXTERNAL SOURCES:
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
   LibXMTP:
-    :podspec: https://raw.githubusercontent.com/xmtp/libxmtp-swift/8eec299e23caa2945dc30cc2cecdf0a95c1ff1c3/LibXMTP.podspec
+    :podspec: https://raw.githubusercontent.com/xmtp/libxmtp-swift/476de4b3be970f7f7bd7a39066022e83b9fad455/LibXMTP.podspec
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -665,7 +665,7 @@ EXTERNAL SOURCES:
   RNSVG:
     :path: "../node_modules/react-native-svg"
   XMTP:
-    :commit: a82cc44d09d795f104cec85df1bc287cff826435
+    :commit: 88995613060223bf9214418ad4230d07e767ead6
     :git: https://github.com/xmtp/xmtp-ios.git
   XMTPReactNative:
     :path: "../../ios"
@@ -677,7 +677,7 @@ CHECKOUT OPTIONS:
     :commit: 58e80a641f45ed6b5033e220f982efeb5c3dbe86
     :git: https://github.com/xmtp/libxmtp-swift.git
   XMTP:
-    :commit: a82cc44d09d795f104cec85df1bc287cff826435
+    :commit: 88995613060223bf9214418ad4230d07e767ead6
     :git: https://github.com/xmtp/xmtp-ios.git
 
 SPEC CHECKSUMS:
@@ -708,7 +708,7 @@ SPEC CHECKSUMS:
   GzipSwift: 893f3e48e597a1a4f62fafcb6514220fcf8287fa
   hermes-engine: d7cc127932c89c53374452d6f93473f1970d8e88
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  LibXMTP: e705bcaaa64aaa89998f718e807662647cbc9d4b
+  LibXMTP: a3bb8d00c275034e55f1f7bf632335821c792d3c
   Logging: 9ef4ecb546ad3169398d5a723bc9bea1c46bef26
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: f902fb6719da13c2ab0965233d8963a59416f911
@@ -757,10 +757,10 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   SwiftProtobuf: b02b5075dcf60c9f5f403000b3b0c202a11b6ae1
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: 6ad8ec5fe9e4ea6d7029f25ee3935e646227fa20
+  XMTP: 8926867bbf042724a610814b753adad048f42133
   XMTPReactNative: 01231fe57639ea936b081f02a2a73abe78d4de35
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
-PODFILE CHECKSUM: 735365d52debb37b1871b7e98cede3d9f187e907
+PODFILE CHECKSUM: b9d95dda52bd1c6ad58495485b2cee58e20a31d3
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.14.3

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -442,7 +442,7 @@ PODS:
     - GenericJSON (~> 2.0)
     - Logging (~> 1.0.0)
     - secp256k1.swift (~> 0.1)
-  - XMTP (0.7.7-alpha0):
+  - XMTP (0.7.8-alpha0):
     - Connect-Swift (= 0.3.0)
     - GzipSwift
     - LibXMTP (= 0.4.1-beta0)
@@ -451,7 +451,7 @@ PODS:
     - ExpoModulesCore
     - MessagePacker
     - secp256k1.swift
-    - XMTP (= 0.7.7-alpha0)
+    - XMTP (= 0.7.8-alpha0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -476,7 +476,6 @@ DEPENDENCIES:
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
-  - LibXMTP (from `https://raw.githubusercontent.com/xmtp/libxmtp-swift/476de4b3be970f7f7bd7a39066022e83b9fad455/LibXMTP.podspec`)
   - OpenSSL-Universal (= 1.1.2200)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -519,7 +518,6 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
-  - XMTP (from `https://github.com/xmtp/xmtp-ios.git`, commit `88995613060223bf9214418ad4230d07e767ead6`)
   - XMTPReactNative (from `../../ios`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -532,6 +530,7 @@ SPEC REPOS:
     - GenericJSON
     - GzipSwift
     - libevent
+    - LibXMTP
     - Logging
     - MessagePacker
     - MMKV
@@ -540,6 +539,7 @@ SPEC REPOS:
     - secp256k1.swift
     - SwiftProtobuf
     - web3.swift
+    - XMTP
 
 EXTERNAL SOURCES:
   boost:
@@ -582,8 +582,6 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
-  LibXMTP:
-    :podspec: https://raw.githubusercontent.com/xmtp/libxmtp-swift/476de4b3be970f7f7bd7a39066022e83b9fad455/LibXMTP.podspec
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -664,21 +662,10 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-screens"
   RNSVG:
     :path: "../node_modules/react-native-svg"
-  XMTP:
-    :commit: 88995613060223bf9214418ad4230d07e767ead6
-    :git: https://github.com/xmtp/xmtp-ios.git
   XMTPReactNative:
     :path: "../../ios"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
-
-CHECKOUT OPTIONS:
-  LibXMTP:
-    :commit: 58e80a641f45ed6b5033e220f982efeb5c3dbe86
-    :git: https://github.com/xmtp/libxmtp-swift.git
-  XMTP:
-    :commit: 88995613060223bf9214418ad4230d07e767ead6
-    :git: https://github.com/xmtp/xmtp-ios.git
 
 SPEC CHECKSUMS:
   BigInt: 74b4d88367b0e819d9f77393549226d36faeb0d8
@@ -757,10 +744,10 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   SwiftProtobuf: b02b5075dcf60c9f5f403000b3b0c202a11b6ae1
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: 8926867bbf042724a610814b753adad048f42133
-  XMTPReactNative: 01231fe57639ea936b081f02a2a73abe78d4de35
+  XMTP: 7c308fde3213aa0b0ad8198c9984932260f22b65
+  XMTPReactNative: 0a5a691e0e54c7be2e9f276eaac37f9ad6a8e90a
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
-PODFILE CHECKSUM: b9d95dda52bd1c6ad58495485b2cee58e20a31d3
+PODFILE CHECKSUM: bed59df1a015d67be871b27fb59f30a782dbf17c
 
 COCOAPODS: 1.14.3

--- a/example/ios/xmtpreactnativesdkexample.xcodeproj/project.pbxproj
+++ b/example/ios/xmtpreactnativesdkexample.xcodeproj/project.pbxproj
@@ -12,9 +12,9 @@
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
 		A6A5DB882A00551E001DF8C2 /* xmtpreactnativesdkexampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A5DB872A00551E001DF8C2 /* xmtpreactnativesdkexampleUITests.swift */; };
+		ADCA1E36251B81A7BC205863 /* libPods-xmtpreactnativesdkexample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F3E8C195D6CF59548039D6CE /* libPods-xmtpreactnativesdkexample.a */; };
 		B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
-		C0DFBF16270720FF7F5E5A66 /* libPods-xmtpreactnativesdkexample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E33AFF2A4A26E91DA99B18B9 /* libPods-xmtpreactnativesdkexample.a */; };
 		C90474A97E544153BED95C2A /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF0078FD601458DA88B0565 /* noop-file.swift */; };
 /* End PBXBuildFile section */
 
@@ -36,15 +36,15 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = xmtpreactnativesdkexample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = xmtpreactnativesdkexample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = xmtpreactnativesdkexample/main.m; sourceTree = "<group>"; };
-		5F3FEA377C3DF177CE6ABFBC /* Pods-xmtpreactnativesdkexample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtpreactnativesdkexample.debug.xcconfig"; path = "Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample.debug.xcconfig"; sourceTree = "<group>"; };
+		1DE95CEE50C872088FB08BDF /* Pods-xmtpreactnativesdkexample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtpreactnativesdkexample.debug.xcconfig"; path = "Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample.debug.xcconfig"; sourceTree = "<group>"; };
 		A6A5DB852A00551E001DF8C2 /* xmtpreactnativesdkexampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = xmtpreactnativesdkexampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6A5DB872A00551E001DF8C2 /* xmtpreactnativesdkexampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = xmtpreactnativesdkexampleUITests.swift; sourceTree = "<group>"; };
 		A6AE8C832A49F1F300BD4E8B /* libMessagePack.swift.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libMessagePack.swift.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		A7240CBC2A42999763CB58CF /* Pods-xmtpreactnativesdkexample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtpreactnativesdkexample.release.xcconfig"; path = "Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample.release.xcconfig"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = xmtpreactnativesdkexample/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
-		E33AFF2A4A26E91DA99B18B9 /* libPods-xmtpreactnativesdkexample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-xmtpreactnativesdkexample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		F3E8C195D6CF59548039D6CE /* libPods-xmtpreactnativesdkexample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-xmtpreactnativesdkexample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F864C3802C16B05DCA52D2D4 /* Pods-xmtpreactnativesdkexample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtpreactnativesdkexample.release.xcconfig"; path = "Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample.release.xcconfig"; sourceTree = "<group>"; };
 		FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-xmtpreactnativesdkexample/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		FDF0078FD601458DA88B0565 /* noop-file.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "noop-file.swift"; path = "xmtpreactnativesdkexample/noop-file.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -54,7 +54,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C0DFBF16270720FF7F5E5A66 /* libPods-xmtpreactnativesdkexample.a in Frameworks */,
+				ADCA1E36251B81A7BC205863 /* libPods-xmtpreactnativesdkexample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -89,7 +89,7 @@
 			children = (
 				A6AE8C832A49F1F300BD4E8B /* libMessagePack.swift.a */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				E33AFF2A4A26E91DA99B18B9 /* libPods-xmtpreactnativesdkexample.a */,
+				F3E8C195D6CF59548039D6CE /* libPods-xmtpreactnativesdkexample.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -154,8 +154,8 @@
 		D65327D7A22EEC0BE12398D9 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				5F3FEA377C3DF177CE6ABFBC /* Pods-xmtpreactnativesdkexample.debug.xcconfig */,
-				A7240CBC2A42999763CB58CF /* Pods-xmtpreactnativesdkexample.release.xcconfig */,
+				1DE95CEE50C872088FB08BDF /* Pods-xmtpreactnativesdkexample.debug.xcconfig */,
+				F864C3802C16B05DCA52D2D4 /* Pods-xmtpreactnativesdkexample.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -175,14 +175,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "xmtpreactnativesdkexample" */;
 			buildPhases = (
-				0A95196962F88B34BE80B068 /* [CP] Check Pods Manifest.lock */,
+				E52C5317E52AE08D6778F66A /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				0962691E57DCEE70EC9ACE66 /* [CP] Embed Pods Frameworks */,
-				FC6B9C3849E0ACB7DFA1E031 /* [CP] Copy Pods Resources */,
+				43B676AF69247AAD2D19EC95 /* [CP] Embed Pods Frameworks */,
+				038BDAE7703F825148B9DBE4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -286,7 +286,27 @@
 			shellPath = /bin/sh;
 			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" $PROJECT_ROOT ios relative | tail -n 1)\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
 		};
-		0962691E57DCEE70EC9ACE66 /* [CP] Embed Pods Frameworks */ = {
+		038BDAE7703F825148B9DBE4 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		43B676AF69247AAD2D19EC95 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -306,7 +326,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		0A95196962F88B34BE80B068 /* [CP] Check Pods Manifest.lock */ = {
+		E52C5317E52AE08D6778F66A /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -326,26 +346,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		FC6B9C3849E0ACB7DFA1E031 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
@@ -402,7 +402,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5F3FEA377C3DF177CE6ABFBC /* Pods-xmtpreactnativesdkexample.debug.xcconfig */;
+			baseConfigurationReference = 1DE95CEE50C872088FB08BDF /* Pods-xmtpreactnativesdkexample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -435,7 +435,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A7240CBC2A42999763CB58CF /* Pods-xmtpreactnativesdkexample.release.xcconfig */;
+			baseConfigurationReference = F864C3802C16B05DCA52D2D4 /* Pods-xmtpreactnativesdkexample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/example/ios/xmtpreactnativesdkexample.xcodeproj/project.pbxproj
+++ b/example/ios/xmtpreactnativesdkexample.xcodeproj/project.pbxproj
@@ -14,8 +14,8 @@
 		A6A5DB882A00551E001DF8C2 /* xmtpreactnativesdkexampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A5DB872A00551E001DF8C2 /* xmtpreactnativesdkexampleUITests.swift */; };
 		B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+		C0DFBF16270720FF7F5E5A66 /* libPods-xmtpreactnativesdkexample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E33AFF2A4A26E91DA99B18B9 /* libPods-xmtpreactnativesdkexample.a */; };
 		C90474A97E544153BED95C2A /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF0078FD601458DA88B0565 /* noop-file.swift */; };
-		FD38E403931970F81205A40A /* libPods-xmtpreactnativesdkexample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78B76F8B6347E6AE6088DF9B /* libPods-xmtpreactnativesdkexample.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,14 +36,14 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = xmtpreactnativesdkexample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = xmtpreactnativesdkexample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = xmtpreactnativesdkexample/main.m; sourceTree = "<group>"; };
-		6AF9BAAAC2041F823F5E5BC1 /* Pods-xmtpreactnativesdkexample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtpreactnativesdkexample.release.xcconfig"; path = "Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample.release.xcconfig"; sourceTree = "<group>"; };
-		78B76F8B6347E6AE6088DF9B /* libPods-xmtpreactnativesdkexample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-xmtpreactnativesdkexample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		80323D3D45487AD85F64F249 /* Pods-xmtpreactnativesdkexample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtpreactnativesdkexample.debug.xcconfig"; path = "Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample.debug.xcconfig"; sourceTree = "<group>"; };
+		5F3FEA377C3DF177CE6ABFBC /* Pods-xmtpreactnativesdkexample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtpreactnativesdkexample.debug.xcconfig"; path = "Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample.debug.xcconfig"; sourceTree = "<group>"; };
 		A6A5DB852A00551E001DF8C2 /* xmtpreactnativesdkexampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = xmtpreactnativesdkexampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6A5DB872A00551E001DF8C2 /* xmtpreactnativesdkexampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = xmtpreactnativesdkexampleUITests.swift; sourceTree = "<group>"; };
 		A6AE8C832A49F1F300BD4E8B /* libMessagePack.swift.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libMessagePack.swift.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A7240CBC2A42999763CB58CF /* Pods-xmtpreactnativesdkexample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtpreactnativesdkexample.release.xcconfig"; path = "Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample.release.xcconfig"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = xmtpreactnativesdkexample/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		E33AFF2A4A26E91DA99B18B9 /* libPods-xmtpreactnativesdkexample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-xmtpreactnativesdkexample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-xmtpreactnativesdkexample/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		FDF0078FD601458DA88B0565 /* noop-file.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "noop-file.swift"; path = "xmtpreactnativesdkexample/noop-file.swift"; sourceTree = "<group>"; };
@@ -54,7 +54,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FD38E403931970F81205A40A /* libPods-xmtpreactnativesdkexample.a in Frameworks */,
+				C0DFBF16270720FF7F5E5A66 /* libPods-xmtpreactnativesdkexample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -89,7 +89,7 @@
 			children = (
 				A6AE8C832A49F1F300BD4E8B /* libMessagePack.swift.a */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				78B76F8B6347E6AE6088DF9B /* libPods-xmtpreactnativesdkexample.a */,
+				E33AFF2A4A26E91DA99B18B9 /* libPods-xmtpreactnativesdkexample.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -154,8 +154,8 @@
 		D65327D7A22EEC0BE12398D9 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				80323D3D45487AD85F64F249 /* Pods-xmtpreactnativesdkexample.debug.xcconfig */,
-				6AF9BAAAC2041F823F5E5BC1 /* Pods-xmtpreactnativesdkexample.release.xcconfig */,
+				5F3FEA377C3DF177CE6ABFBC /* Pods-xmtpreactnativesdkexample.debug.xcconfig */,
+				A7240CBC2A42999763CB58CF /* Pods-xmtpreactnativesdkexample.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -175,14 +175,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "xmtpreactnativesdkexample" */;
 			buildPhases = (
-				6C915E5D412569A84EA861EC /* [CP] Check Pods Manifest.lock */,
+				0A95196962F88B34BE80B068 /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				94CA905D5A9B66E6F6A747C8 /* [CP] Copy Pods Resources */,
-				0F8BF66945EEB514F253516D /* [CP] Embed Pods Frameworks */,
+				0962691E57DCEE70EC9ACE66 /* [CP] Embed Pods Frameworks */,
+				FC6B9C3849E0ACB7DFA1E031 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -286,7 +286,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" $PROJECT_ROOT ios relative | tail -n 1)\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
 		};
-		0F8BF66945EEB514F253516D /* [CP] Embed Pods Frameworks */ = {
+		0962691E57DCEE70EC9ACE66 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -306,7 +306,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6C915E5D412569A84EA861EC /* [CP] Check Pods Manifest.lock */ = {
+		0A95196962F88B34BE80B068 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -328,7 +328,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		94CA905D5A9B66E6F6A747C8 /* [CP] Copy Pods Resources */ = {
+		FC6B9C3849E0ACB7DFA1E031 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -402,7 +402,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 80323D3D45487AD85F64F249 /* Pods-xmtpreactnativesdkexample.debug.xcconfig */;
+			baseConfigurationReference = 5F3FEA377C3DF177CE6ABFBC /* Pods-xmtpreactnativesdkexample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -435,7 +435,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6AF9BAAAC2041F823F5E5BC1 /* Pods-xmtpreactnativesdkexample.release.xcconfig */;
+			baseConfigurationReference = A7240CBC2A42999763CB58CF /* Pods-xmtpreactnativesdkexample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/example/ios/xmtpreactnativesdkexample.xcodeproj/project.pbxproj
+++ b/example/ios/xmtpreactnativesdkexample.xcodeproj/project.pbxproj
@@ -11,8 +11,8 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		9453E5BA4D9E60C6B21EAF55 /* libPods-xmtpreactnativesdkexample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A15D051C53AD0CEEBB4113F5 /* libPods-xmtpreactnativesdkexample.a */; };
 		A6A5DB882A00551E001DF8C2 /* xmtpreactnativesdkexampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A5DB872A00551E001DF8C2 /* xmtpreactnativesdkexampleUITests.swift */; };
-		ADCA1E36251B81A7BC205863 /* libPods-xmtpreactnativesdkexample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F3E8C195D6CF59548039D6CE /* libPods-xmtpreactnativesdkexample.a */; };
 		B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		C90474A97E544153BED95C2A /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF0078FD601458DA88B0565 /* noop-file.swift */; };
@@ -36,15 +36,15 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = xmtpreactnativesdkexample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = xmtpreactnativesdkexample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = xmtpreactnativesdkexample/main.m; sourceTree = "<group>"; };
-		1DE95CEE50C872088FB08BDF /* Pods-xmtpreactnativesdkexample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtpreactnativesdkexample.debug.xcconfig"; path = "Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample.debug.xcconfig"; sourceTree = "<group>"; };
+		74E1B7F7695132E36345D810 /* Pods-xmtpreactnativesdkexample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtpreactnativesdkexample.release.xcconfig"; path = "Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample.release.xcconfig"; sourceTree = "<group>"; };
+		A15D051C53AD0CEEBB4113F5 /* libPods-xmtpreactnativesdkexample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-xmtpreactnativesdkexample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6A5DB852A00551E001DF8C2 /* xmtpreactnativesdkexampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = xmtpreactnativesdkexampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6A5DB872A00551E001DF8C2 /* xmtpreactnativesdkexampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = xmtpreactnativesdkexampleUITests.swift; sourceTree = "<group>"; };
 		A6AE8C832A49F1F300BD4E8B /* libMessagePack.swift.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libMessagePack.swift.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = xmtpreactnativesdkexample/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
-		F3E8C195D6CF59548039D6CE /* libPods-xmtpreactnativesdkexample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-xmtpreactnativesdkexample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		F864C3802C16B05DCA52D2D4 /* Pods-xmtpreactnativesdkexample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtpreactnativesdkexample.release.xcconfig"; path = "Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample.release.xcconfig"; sourceTree = "<group>"; };
+		ED9CBB83C05BBF316FC66508 /* Pods-xmtpreactnativesdkexample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtpreactnativesdkexample.debug.xcconfig"; path = "Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample.debug.xcconfig"; sourceTree = "<group>"; };
 		FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-xmtpreactnativesdkexample/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		FDF0078FD601458DA88B0565 /* noop-file.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "noop-file.swift"; path = "xmtpreactnativesdkexample/noop-file.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -54,7 +54,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ADCA1E36251B81A7BC205863 /* libPods-xmtpreactnativesdkexample.a in Frameworks */,
+				9453E5BA4D9E60C6B21EAF55 /* libPods-xmtpreactnativesdkexample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -89,7 +89,7 @@
 			children = (
 				A6AE8C832A49F1F300BD4E8B /* libMessagePack.swift.a */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				F3E8C195D6CF59548039D6CE /* libPods-xmtpreactnativesdkexample.a */,
+				A15D051C53AD0CEEBB4113F5 /* libPods-xmtpreactnativesdkexample.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -154,8 +154,8 @@
 		D65327D7A22EEC0BE12398D9 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				1DE95CEE50C872088FB08BDF /* Pods-xmtpreactnativesdkexample.debug.xcconfig */,
-				F864C3802C16B05DCA52D2D4 /* Pods-xmtpreactnativesdkexample.release.xcconfig */,
+				ED9CBB83C05BBF316FC66508 /* Pods-xmtpreactnativesdkexample.debug.xcconfig */,
+				74E1B7F7695132E36345D810 /* Pods-xmtpreactnativesdkexample.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -175,14 +175,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "xmtpreactnativesdkexample" */;
 			buildPhases = (
-				E52C5317E52AE08D6778F66A /* [CP] Check Pods Manifest.lock */,
+				1A3E35BABB8B52C80119AEF4 /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				43B676AF69247AAD2D19EC95 /* [CP] Embed Pods Frameworks */,
-				038BDAE7703F825148B9DBE4 /* [CP] Copy Pods Resources */,
+				0A30FD7A4347963420162925 /* [CP] Embed Pods Frameworks */,
+				E72368AA4D83F2FC000573E5 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -286,27 +286,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" $PROJECT_ROOT ios relative | tail -n 1)\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
 		};
-		038BDAE7703F825148B9DBE4 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		43B676AF69247AAD2D19EC95 /* [CP] Embed Pods Frameworks */ = {
+		0A30FD7A4347963420162925 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -326,7 +306,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E52C5317E52AE08D6778F66A /* [CP] Check Pods Manifest.lock */ = {
+		1A3E35BABB8B52C80119AEF4 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -346,6 +326,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E72368AA4D83F2FC000573E5 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
@@ -402,7 +402,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1DE95CEE50C872088FB08BDF /* Pods-xmtpreactnativesdkexample.debug.xcconfig */;
+			baseConfigurationReference = ED9CBB83C05BBF316FC66508 /* Pods-xmtpreactnativesdkexample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -435,7 +435,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F864C3802C16B05DCA52D2D4 /* Pods-xmtpreactnativesdkexample.release.xcconfig */;
+			baseConfigurationReference = 74E1B7F7695132E36345D810 /* Pods-xmtpreactnativesdkexample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
   s.dependency 'secp256k1.swift'
 	s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.7.7-alpha0"
+  s.dependency "XMTP", "= 0.7.6-alpha0"
 end

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
   s.dependency 'secp256k1.swift'
 	s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.7.6-alpha0"
+  s.dependency "XMTP", "= 0.7.7-alpha0"
 end

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
   s.dependency 'secp256k1.swift'
 	s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.7.7-alpha0"
+  s.dependency "XMTP", "= 0.7.8-alpha0"
 end


### PR DESCRIPTION
Fixes #221 

This PR is related to 

- libxmtp: https://github.com/xmtp/libxmtp/pull/433
- libxmtp-swift: https://github.com/xmtp/libxmtp-swift/pull/4
- xmtp-ios: https://github.com/xmtp/xmtp-ios/pull/225
- xmtp-ios: https://github.com/xmtp/xmtp-ios/pull/223

Once all those PRs are merged, the reference to the libxmtp-swift podspec can be updated in this branch and it will be re-tested before merging. 
