### PR TITLE
feat: add `shouldPush` to contentTypes messages

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -321,7 +321,7 @@ class XMTPModule : Module() {
             ).toJson()
         }
 
-        AsyncFunction("sendEncodedContent") { clientAddress: String, topic: String, encodedContentData: List<Int> ->
+        AsyncFunction("sendEncodedContent") { clientAddress: String, topic: String, encodedContentData: List<Int>, shouldPush: Boolean ->
             val conversation =
                 findConversation(
                     clientAddress = clientAddress,
@@ -338,8 +338,9 @@ class XMTPModule : Module() {
                     }
                 }
             val encodedContent = EncodedContent.parseFrom(encodedContentDataBytes)
+            val options = SendOptions(contentType = encodedContent.type, __shouldPush = shouldPush)
 
-            conversation.send(encodedContent = encodedContent)
+            conversation.send(encodedContent = encodedContent, options = options)
         }
 
         AsyncFunction("listConversations") { clientAddress: String ->
@@ -456,7 +457,7 @@ class XMTPModule : Module() {
             ).toJson()
         }
 
-        AsyncFunction("prepareEncodedMessage") { clientAddress: String, conversationTopic: String, encodedContentData: List<Int> ->
+        AsyncFunction("prepareEncodedMessage") { clientAddress: String, conversationTopic: String, encodedContentData: List<Int>, shouldPush: Boolean ->
             logV("prepareEncodedMessage")
             val conversation =
                 findConversation(
@@ -478,6 +479,7 @@ class XMTPModule : Module() {
 
             val prepared = conversation.prepareMessage(
                 encodedContent = encodedContent,
+                options = SendOptions(contentType = encodedContent.type, __shouldPush = shouldPush)
             )
             val preparedAtMillis = prepared.envelopes[0].timestampNs / 1_000_000
             val preparedFile = File.createTempFile(prepared.messageId, null)

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DecodedMessageWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DecodedMessageWrapper.kt
@@ -20,7 +20,8 @@ class DecodedMessageWrapper {
             "content" to ContentJson(model.encodedContent).toJsonMap(),
             "senderAddress" to model.senderAddress,
             "sent" to model.sentAt.time,
-            "fallback" to model.encodedContent.fallback
+            "fallback" to model.encodedContent.fallback,
+            "shouldPush" to model.shouldPush as Any
         )
     }
 }

--- a/ios/Wrappers/DecodedMessageWrapper.swift
+++ b/ios/Wrappers/DecodedMessageWrapper.swift
@@ -13,6 +13,7 @@ struct DecodedMessageWrapper {
 			"senderAddress": model.senderAddress,
 			"sent": UInt64(model.sentAt.timeIntervalSince1970 * 1000),
 			"fallback": model.encodedContent.fallback,
+			"shouldPush": model.shouldPush
 		]
 	}
 

--- a/ios/Wrappers/DecodedMessageWrapper.swift
+++ b/ios/Wrappers/DecodedMessageWrapper.swift
@@ -13,7 +13,7 @@ struct DecodedMessageWrapper {
 			"senderAddress": model.senderAddress,
 			"sent": UInt64(model.sentAt.timeIntervalSince1970 * 1000),
 			"fallback": model.encodedContent.fallback,
-			"shouldPush": model.shouldPush
+			"shouldPush": model.shouldPush as Any
 		]
 	}
 

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -233,7 +233,7 @@ public class XMTPModule: Module {
 
 			let encodedContent = try EncodedContent(serializedData: Data(encodedContentData))
 			
-			let options = SendOptions(contentType: encodedContent.type, shouldPush: shouldPush)
+			let options = SendOptions(contentType: encodedContent.type, __shouldPush: shouldPush)
 
 			return try await conversation.send(encodedContent: encodedContent, options: options)
 		}
@@ -404,7 +404,7 @@ public class XMTPModule: Module {
 
 			let prepared = try await conversation.prepareMessage(
 				encodedContent: encodedContent,
-				options: SendOptions(contentType: contentType, shouldPush: shouldPush)
+				options: SendOptions(contentType: contentType, __shouldPush: shouldPush)
 			)
 			let preparedAtMillis = prepared.envelopes[0].timestampNs / 1_000_000
 			let preparedData = try prepared.serializedData()

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,12 +235,14 @@ export async function sendWithContentType<T>(
   } else {
     const encodedContent = codec.encode(content)
     encodedContent.fallback = codec.fallback(content)
+    const shouldPush = codec.shouldPush(content)
     const encodedContentData = EncodedContent.encode(encodedContent).finish()
 
     return await XMTPModule.sendEncodedContent(
       clientAddress,
       conversationTopic,
-      Array.from(encodedContentData)
+      Array.from(encodedContentData),
+      shouldPush
     )
   }
 }
@@ -287,11 +289,13 @@ export async function prepareMessageWithContentType<T>(
   }
   const encodedContent = codec.encode(content)
   encodedContent.fallback = codec.fallback(content)
+  const shouldPush = codec.shouldPush(content)
   const encodedContentData = EncodedContent.encode(encodedContent).finish()
   const preparedJson = await XMTPModule.prepareEncodedMessage(
     clientAddress,
     conversationTopic,
-    Array.from(encodedContentData)
+    Array.from(encodedContentData),
+    shouldPush
   )
   return JSON.parse(preparedJson)
 }

--- a/src/lib/ContentCodec.ts
+++ b/src/lib/ContentCodec.ts
@@ -101,6 +101,7 @@ export interface JSContentCodec<T> {
   encode(content: T): EncodedContent
   decode(encodedContent: EncodedContent): T
   fallback(content: T): string | undefined
+  shouldPush(content: T): boolean
 }
 
 export interface NativeContentCodec<T> {
@@ -109,6 +110,7 @@ export interface NativeContentCodec<T> {
   encode(content: T): NativeMessageContent
   decode(nativeContent: NativeMessageContent): T
   fallback(content: T): string | undefined
+  shouldPush(content: T): boolean
 }
 
 export type ContentCodec<T> = JSContentCodec<T> | NativeContentCodec<T>

--- a/src/lib/DecodedMessage.ts
+++ b/src/lib/DecodedMessage.ts
@@ -18,6 +18,7 @@ export class DecodedMessage<ContentTypes = any> {
   sent: number // timestamp in milliseconds
   nativeContent: NativeMessageContent
   fallback: string | undefined
+  shouldPush: boolean
 
   static from<ContentTypes>(
     json: string,
@@ -32,7 +33,8 @@ export class DecodedMessage<ContentTypes = any> {
       decoded.senderAddress,
       decoded.sent,
       decoded.content,
-      decoded.fallback
+      decoded.fallback,
+      decoded.shouldPush
     )
   }
 
@@ -45,6 +47,7 @@ export class DecodedMessage<ContentTypes = any> {
       sent: number // timestamp in milliseconds
       content: any
       fallback: string | undefined
+      shouldPush: boolean
     },
     client: Client<ContentTypes>
   ): DecodedMessage<ContentTypes> {
@@ -56,7 +59,8 @@ export class DecodedMessage<ContentTypes = any> {
       object.senderAddress,
       object.sent,
       object.content,
-      object.fallback
+      object.fallback,
+      object.shouldPush
     )
   }
 
@@ -68,7 +72,8 @@ export class DecodedMessage<ContentTypes = any> {
     senderAddress: string,
     sent: number,
     content: any,
-    fallback: string | undefined
+    fallback: string | undefined,
+    shouldPush: boolean
   ) {
     this.client = client
     this.id = id
@@ -78,6 +83,7 @@ export class DecodedMessage<ContentTypes = any> {
     this.sent = sent
     this.nativeContent = content
     this.fallback = fallback
+    this.shouldPush = shouldPush
   }
 
   content(): ContentTypes {

--- a/src/lib/NativeCodecs/ReactionCodec.ts
+++ b/src/lib/NativeCodecs/ReactionCodec.ts
@@ -35,4 +35,15 @@ export class ReactionCodec implements NativeContentCodec<ReactionContent> {
         return undefined
     }
   }
+
+  shouldPush(content: ReactionContent): boolean {
+    switch (content.action) {
+      case 'added':
+        return true
+      case 'removed':
+        return false
+      default:
+        return false
+    }
+  }
 }

--- a/src/lib/NativeCodecs/ReadReceiptCodec.ts
+++ b/src/lib/NativeCodecs/ReadReceiptCodec.ts
@@ -30,4 +30,8 @@ export class ReadReceiptCodec
   fallback(content: object): string | undefined {
     return undefined
   }
+
+  shouldPush(content: object): boolean {
+    return false
+  }
 }

--- a/src/lib/NativeCodecs/RemoteAttachmentCodec.ts
+++ b/src/lib/NativeCodecs/RemoteAttachmentCodec.ts
@@ -30,4 +30,8 @@ export class RemoteAttachmentCodec
   fallback(content: RemoteAttachmentContent): string | undefined {
     return `Can’t display "${content.filename}". This app doesn’t support attachments.`
   }
+
+  shouldPush(content: RemoteAttachmentContent): boolean {
+    return true
+  }
 }

--- a/src/lib/NativeCodecs/ReplyCodec.ts
+++ b/src/lib/NativeCodecs/ReplyCodec.ts
@@ -36,4 +36,8 @@ export class ReplyCodec implements NativeContentCodec<ReplyContent> {
     }
     return 'Replied to an earlier message'
   }
+
+  shouldPush(content: ReplyContent): boolean {
+    return true
+  }
 }

--- a/src/lib/NativeCodecs/StaticAttachmentCodec.ts
+++ b/src/lib/NativeCodecs/StaticAttachmentCodec.ts
@@ -30,4 +30,8 @@ export class StaticAttachmentCodec
   fallback(content: StaticAttachmentContent): string | undefined {
     return `Can’t display "${content.filename}". This app doesn’t support attachments.`
   }
+
+  shouldPush(content: StaticAttachmentContent): boolean {
+    return true
+  }
 }

--- a/src/lib/NativeCodecs/TextCodec.ts
+++ b/src/lib/NativeCodecs/TextCodec.ts
@@ -27,4 +27,8 @@ export class TextCodec implements NativeContentCodec<string> {
   fallback(content: string): string | undefined {
     return content
   }
+
+  shouldPush(content: string): boolean {
+    return true
+  }
 }


### PR DESCRIPTION
depends on https://github.com/xmtp/xmtp-ios/pull/231 & https://github.com/xmtp/xmtp-android/pull/184

closes https://github.com/xmtp/xmtp-react-native/issues/236

- [x] added `shouldPush` to ContentCodec type
- [x] added `shouldPush` method to Codecs
- [x] send and get the value from native
