### PR TITLE
Added tests for capturing createdAt values and list function behavior

### DIFF
--- a/example/src/LaunchScreen.tsx
+++ b/example/src/LaunchScreen.tsx
@@ -83,15 +83,26 @@ export default function LaunchScreen(
       <View key="run-tests" style={{ margin: 16 }}>
         <Button
           title="Run All Unit Tests"
-          onPress={() => navigation.navigate('test', { onlyGroups: false })}
+          onPress={() => navigation.navigate('test', { testSelection: 'all' })}
           accessibilityLabel="Unit-tests"
         />
       </View>
       <View key="run-group-tests" style={{ margin: 16 }}>
         <Button
           title="Run Group Unit Tests"
-          onPress={() => navigation.navigate('test', { onlyGroups: true })}
+          onPress={() =>
+            navigation.navigate('test', { testSelection: 'groups' })
+          }
           accessibilityLabel="Unit-group-tests"
+        />
+      </View>
+      <View key="run-created-at-tests" style={{ margin: 16 }}>
+        <Button
+          title="Run Created At Unit Tests"
+          onPress={() =>
+            navigation.navigate('test', { testSelection: 'createdAt' })
+          }
+          accessibilityLabel="Unit-created-at-tests"
         />
       </View>
       <View style={styles.divider} />

--- a/example/src/Navigation.tsx
+++ b/example/src/Navigation.tsx
@@ -2,7 +2,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack'
 
 export type NavigationParamList = {
   launch: undefined
-  test: { onlyGroups?: boolean }
+  test: { testSelection?: 'groups' | 'createdAt' | 'all' }
   home: undefined
   group: { id: string }
   conversation: { topic: string }

--- a/example/src/TestScreen.tsx
+++ b/example/src/TestScreen.tsx
@@ -2,6 +2,7 @@ import { useRoute } from '@react-navigation/native'
 import React, { useEffect, useState } from 'react'
 import { View, Text, Button, ScrollView } from 'react-native'
 
+import { createdAtTests } from './tests/createdAtTests'
 import { groupTests } from './tests/groupTests'
 import { tests, Test } from './tests/tests'
 
@@ -100,16 +101,31 @@ function TestView({
 export default function TestScreen(): JSX.Element {
   const [completedTests, setCompletedTests] = useState<number>(0)
   const route = useRoute()
-  const params = route.params as { onlyGroups: boolean }
-  const allTests = tests.concat(groupTests)
-  const activeTests = params.onlyGroups ? groupTests : allTests
+  const params = route.params as {
+    testSelection: 'groups' | 'createdAt' | 'all'
+  }
+  const allTests = tests.concat(groupTests).concat(createdAtTests)
+  let activeTests, title
+  switch (params.testSelection) {
+    case 'groups':
+      activeTests = groupTests
+      title = 'Group Unit Tests'
+      break
+    case 'createdAt':
+      activeTests = createdAtTests
+      title = 'Created At Unit Tests'
+      break
+    default:
+      activeTests = allTests
+      title = 'All Unit Tests'
+  }
 
   return (
     <ScrollView>
       <View>
         <View style={{ padding: 12 }}>
           <Text testID="Test View" accessible accessibilityLabel="Test View">
-            {params.onlyGroups ? 'Group Unit Tests' : 'All Unit Tests'}
+            {title}
           </Text>
           <View
             style={{ flexDirection: 'row', justifyContent: 'space-between' }}

--- a/example/src/tests/createdAtTests.ts
+++ b/example/src/tests/createdAtTests.ts
@@ -1,6 +1,4 @@
-import { Platform } from 'expo-modules-core'
-
-import { Test, assert, delayToPropogate } from './tests'
+import { Test, assert, delayToPropogate, isIos } from './tests'
 import {
   Client,
   Conversation,
@@ -9,10 +7,6 @@ import {
 } from '../../../src/index'
 
 export const createdAtTests: Test[] = []
-
-function isIos() {
-  return Platform.OS === 'ios'
-}
 
 function test(name: string, perform: () => Promise<boolean>) {
   createdAtTests.push({ name, run: perform })
@@ -166,7 +160,6 @@ test('group createdAt matches streamGroups', async () => {
   const cancelStream = await aliceClient.conversations.streamGroups(
     async (group: Group<any>) => {
       allGroups.push(group)
-      console.log('group', allGroups.length)
     }
   )
 
@@ -236,7 +229,6 @@ test('group createdAt matches streamAll', async () => {
   const cancelStream = await aliceClient.conversations.streamAll(
     async (group: ConversationContainer<any>) => {
       allGroups.push(group)
-      console.log('group', allGroups.length)
     }
   )
 

--- a/example/src/tests/createdAtTests.ts
+++ b/example/src/tests/createdAtTests.ts
@@ -56,19 +56,21 @@ test('group createdAt matches listGroups', async () => {
     'First group returned from listGroups should be the first group created'
   )
   assert(
-    aliceGroups[second].id === bobGroup.id,
-    'Bob group createdAt should match'
-  )
-  assert(
     aliceGroups[first].createdAt === aliceGroup.createdAt,
     'Alice group createdAt should match'
   )
-
-  // Below test fails on Android
+  assert(
+    aliceGroups[second].id === bobGroup.id,
+    'Bob group createdAt should match'
+  )
+  // Below assertion fails on Android
   if (isIos()) {
     assert(
       aliceGroups[second].createdAt === bobGroup.createdAt,
-      'Bob group createdAt should match'
+      'Second group returned from listGroups shows ' +
+      aliceGroups[second].createdAt +
+      ' but should be ' +
+      bobGroup.createdAt
     )
   }
   return true
@@ -170,12 +172,12 @@ test('conversation createdAt matches list', async () => {
   })
   delayToPropogate()
 
-  // Alice creates a group
+  // Alice creates a conversation
   const aliceConversation = await aliceClient.conversations.newConversation(
     bobClient.address
   )
 
-  // Bob creates a group
+  // Bob creates a conversation
   const camConversation = await camClient.conversations.newConversation(
     aliceClient.address
   )

--- a/example/src/tests/createdAtTests.ts
+++ b/example/src/tests/createdAtTests.ts
@@ -195,6 +195,7 @@ test('group createdAt matches streamGroups', async () => {
   )
 
   // CreatedAt returned from stream matches createAt from create function
+  // Assertion below fails on Android
   if (isIos()) {
     assert(
       allGroups[0].createdAt === bobGroup.createdAt,
@@ -264,6 +265,7 @@ test('group createdAt matches streamAll', async () => {
   )
 
   // CreatedAt returned from stream matches createAt from create function
+  // Assertion below fails on Android
   if (isIos()) {
     assert(
       allGroups[0].createdAt === bobGroup.createdAt,

--- a/example/src/tests/createdAtTests.ts
+++ b/example/src/tests/createdAtTests.ts
@@ -1,0 +1,422 @@
+import { Platform } from 'expo-modules-core'
+
+import { Test, assert, delayToPropogate } from './tests'
+import {
+  Client,
+  Conversation,
+  ConversationContainer,
+  Group,
+} from '../../../src/index'
+
+export const createdAtTests: Test[] = []
+
+function isIos() {
+  return Platform.OS === 'ios'
+}
+
+function test(name: string, perform: () => Promise<boolean>) {
+  createdAtTests.push({ name, run: perform })
+}
+
+test('group createdAt matches listGroups', async () => {
+  // Create three MLS enabled Clients
+  const aliceClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  const bobClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  const camClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+
+  // Alice creates a group
+  const aliceGroup = await aliceClient.conversations.newGroup([
+    bobClient.address,
+    camClient.address,
+  ])
+
+  // Bob creates a group
+  const bobGroup = await bobClient.conversations.newGroup([aliceClient.address])
+
+  // Fetch groups using listGroups method
+  await aliceClient.conversations.syncGroups()
+  const aliceGroups = await aliceClient.conversations.listGroups()
+
+  // BUG - List returns in Reverse Chronological order on iOS
+  // and Chronological order on Android
+  const first = isIos() ? 1 : 0
+  const second = isIos() ? 0 : 1
+  assert(aliceGroups.length === 2, 'Alice should have two groups')
+  assert(
+    aliceGroups[first].id === aliceGroup.id,
+    'First group returned from listGroups should be the first group created'
+  )
+  assert(
+    aliceGroups[second].id === bobGroup.id,
+    'Bob group createdAt should match'
+  )
+  assert(
+    aliceGroups[first].createdAt === aliceGroup.createdAt,
+    'Alice group createdAt should match'
+  )
+
+  // Below test fails on Android
+  if (isIos()) {
+    assert(
+      aliceGroups[second].createdAt === bobGroup.createdAt,
+      'Bob group createdAt should match'
+    )
+  }
+  return true
+})
+
+test('group createdAt matches listAll', async () => {
+  // Create three MLS enabled Clients
+  const aliceClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  const bobClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  const camClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+
+  // Alice creates a group
+  const aliceGroup = await aliceClient.conversations.newGroup([
+    bobClient.address,
+    camClient.address,
+  ])
+
+  // Bob creates a group
+  const bobGroup = await bobClient.conversations.newGroup([aliceClient.address])
+
+  // Fetch groups using listGroups method
+  await aliceClient.conversations.syncGroups()
+  const aliceGroups = await aliceClient.conversations.listAll()
+
+  assert(aliceGroups.length === 2, 'Alice should have two groups')
+
+  // Returns reverse Chronological order on Android and iOS
+  const first = 1
+  const second = 0
+  assert(
+    aliceGroups[first].topic === aliceGroup.id,
+    'First group returned from listGroups shows ' +
+      (aliceGroups[1] as Group).id +
+      ' but should be ' +
+      aliceGroup.id
+  )
+  assert(
+    aliceGroups[second].topic === bobGroup.id,
+    'Second group returned from listGroups shows ' +
+      (aliceGroups[0] as Group).id +
+      ' but should be ' +
+      bobGroup.id
+  )
+
+  // Below tests fail on Android
+  if (isIos()) {
+    assert(
+      aliceGroups[first].createdAt === aliceGroup.createdAt,
+      'Alice group returned from listGroups shows createdAt ' +
+        aliceGroups[1].createdAt +
+        ' but should be ' +
+        aliceGroup.createdAt
+    )
+    assert(
+      aliceGroups[second].createdAt === bobGroup.createdAt,
+      'Bob group returned from listGroups shows createdAt ' +
+        aliceGroups[0].createdAt +
+        ' but should be ' +
+        bobGroup.createdAt
+    )
+  }
+  return true
+})
+
+test('group createdAt matches streamGroups', async () => {
+  // TODO
+  return true
+})
+
+test('group createdAt matches streamAll', async () => {
+  // TODO
+  return true
+})
+
+test('conversation createdAt matches list', async () => {
+  // Create three MLS enabled Clients
+  const aliceClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  delayToPropogate()
+  const bobClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  delayToPropogate()
+  const camClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  delayToPropogate()
+
+  // Alice creates a group
+  const aliceConversation = await aliceClient.conversations.newConversation(
+    bobClient.address
+  )
+
+  // Bob creates a group
+  const camConversation = await camClient.conversations.newConversation(
+    aliceClient.address
+  )
+
+  // Fetch conversations using list() method
+  const aliceConversations = await aliceClient.conversations.list()
+  assert(aliceConversations.length === 2, 'Alice should have two conversations')
+
+  // BUG - List returns in Chronological order on iOS
+  // and reverse Chronological order on Android
+  const first = isIos() ? 0 : 1
+  const second = isIos() ? 1 : 0
+
+  assert(
+    aliceConversations[first].topic === aliceConversation.topic,
+    aliceConversations[first].topic + ' != ' + aliceConversation.topic
+  )
+  assert(
+    aliceConversations[second].topic === camConversation.topic,
+    aliceConversations[second].topic + ' != ' + camConversation.topic
+  )
+
+  // CreatedAt returned from list matches createAt from create function
+  assert(
+    aliceConversations[first].createdAt === aliceConversation.createdAt,
+    aliceConversations[first].createdAt + ' != ' + aliceConversation.createdAt
+  )
+  assert(
+    aliceConversations[second].createdAt === camConversation.createdAt,
+    aliceConversations[second].createdAt + ' != ' + camConversation.createdAt
+  )
+
+  return true
+})
+
+test('conversation createdAt matches listAll', async () => {
+  // Create three MLS enabled Clients
+  const aliceClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  delayToPropogate()
+  const bobClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  delayToPropogate()
+  const camClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  delayToPropogate()
+
+  // Alice creates a group
+  const aliceConversation = await aliceClient.conversations.newConversation(
+    bobClient.address
+  )
+
+  // Bob creates a group
+  const camConversation = await camClient.conversations.newConversation(
+    aliceClient.address
+  )
+
+  // Fetch conversations using list() method
+  const aliceConversations = await aliceClient.conversations.listAll()
+  assert(aliceConversations.length === 2, 'Alice should have two conversations')
+
+  // BUG - List returns in Chronological order on iOS
+  // and reverse Chronological order on Android
+  const first = isIos() ? 0 : 1
+  const second = isIos() ? 1 : 0
+
+  // List returns in reverse Chronological order
+  assert(
+    aliceConversations[first].topic === aliceConversation.topic,
+    aliceConversations[first].topic + ' != ' + aliceConversation.topic
+  )
+  assert(
+    aliceConversations[second].topic === camConversation.topic,
+    aliceConversations[second].topic + ' != ' + aliceConversation.topic
+  )
+
+  // CreatedAt returned from list matches createAt from create function
+  assert(
+    aliceConversations[first].createdAt === aliceConversation.createdAt,
+    aliceConversations[first].createdAt + ' != ' + aliceConversation.createdAt
+  )
+  assert(
+    aliceConversations[second].createdAt === camConversation.createdAt,
+    aliceConversations[second].createdAt + ' != ' + camConversation.createdAt
+  )
+
+  return true
+})
+
+test('conversation createdAt matches stream', async () => {
+  // Create three MLS enabled Clients
+  const aliceClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  await delayToPropogate()
+  const bobClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  await delayToPropogate()
+  const camClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  await delayToPropogate()
+
+  // Start streaming conversations
+  const allConversations: Conversation<any>[] = []
+  await aliceClient.conversations.stream(async (conversation) => {
+    allConversations.push(conversation)
+  })
+
+  // Alice creates a group
+  const aliceConversation = await aliceClient.conversations.newConversation(
+    bobClient.address
+  )
+
+  await delayToPropogate()
+
+  // Bob creates a group
+  const camConversation = await camClient.conversations.newConversation(
+    aliceClient.address
+  )
+
+  await delayToPropogate()
+
+  assert(allConversations.length === 2, 'Alice should have two conversations')
+
+  // Stream returns in chronological order
+  assert(
+    allConversations[0].topic === aliceConversation.topic,
+    'list()[1].topic: ' +
+      allConversations[0].topic +
+      ' != ' +
+      aliceConversation.topic
+  )
+  assert(
+    allConversations[1].topic === camConversation.topic,
+    'list()[0].topic: ' +
+      allConversations[1].topic +
+      ' != ' +
+      camConversation.topic
+  )
+
+  // CreatedAt returned from list matches createAt from create function
+  assert(
+    allConversations[0].createdAt === aliceConversation.createdAt,
+    'list()[0].createdAt: ' +
+      allConversations[0].createdAt +
+      ' != ' +
+      aliceConversation.createdAt
+  )
+  assert(
+    allConversations[1].createdAt === camConversation.createdAt,
+    'list()[1].createdAt: ' +
+      allConversations[1].createdAt +
+      ' != ' +
+      camConversation.createdAt
+  )
+
+  return true
+})
+
+test('conversation createdAt matches streamAll', async () => {
+  // Create three MLS enabled Clients
+  const aliceClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  await delayToPropogate()
+  const bobClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  await delayToPropogate()
+  const camClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  await delayToPropogate()
+
+  // Start streaming conversations
+  const allConversations: ConversationContainer<any>[] = []
+  await aliceClient.conversations.streamAll(async (conversation) => {
+    allConversations.push(conversation)
+  })
+
+  // Alice creates a group
+  const aliceConversation = await aliceClient.conversations.newConversation(
+    bobClient.address
+  )
+
+  await delayToPropogate()
+
+  // Bob creates a group
+  const camConversation = await camClient.conversations.newConversation(
+    aliceClient.address
+  )
+
+  await delayToPropogate()
+
+  assert(allConversations.length === 2, 'Alice should have two conversations')
+
+  // Stream returns in chronological order
+  assert(
+    allConversations[0].topic === aliceConversation.topic,
+    'list()[1].topic: ' +
+      allConversations[0].topic +
+      ' != ' +
+      aliceConversation.topic
+  )
+  assert(
+    allConversations[1].topic === camConversation.topic,
+    'list()[0].topic: ' +
+      allConversations[1].topic +
+      ' != ' +
+      camConversation.topic
+  )
+
+  // CreatedAt returned from list matches createAt from create function
+  assert(
+    allConversations[0].createdAt === aliceConversation.createdAt,
+    'list()[0].createdAt: ' +
+      allConversations[0].createdAt +
+      ' != ' +
+      aliceConversation.createdAt
+  )
+  assert(
+    allConversations[1].createdAt === camConversation.createdAt,
+    'list()[1].createdAt: ' +
+      allConversations[1].createdAt +
+      ' != ' +
+      camConversation.createdAt
+  )
+
+  return true
+})

--- a/example/src/tests/createdAtTests.ts
+++ b/example/src/tests/createdAtTests.ts
@@ -112,33 +112,32 @@ test('group createdAt matches listAll', async () => {
   assert(
     aliceGroups[first].topic === aliceGroup.id,
     'First group returned from listGroups shows ' +
-      (aliceGroups[1] as Group).id +
-      ' but should be ' +
-      aliceGroup.id
+    (aliceGroups[1] as Group).id +
+    ' but should be ' +
+    aliceGroup.id
   )
   assert(
     aliceGroups[second].topic === bobGroup.id,
     'Second group returned from listGroups shows ' +
-      (aliceGroups[0] as Group).id +
-      ' but should be ' +
-      bobGroup.id
+    (aliceGroups[0] as Group).id +
+    ' but should be ' +
+    bobGroup.id
   )
-
-  // Below tests fail on Android
+  assert(
+    aliceGroups[first].createdAt === aliceGroup.createdAt,
+    'Alice group returned from listGroups shows createdAt ' +
+    aliceGroups[1].createdAt +
+    ' but should be ' +
+    aliceGroup.createdAt
+  )
+  // Below assertion fail on Android
   if (isIos()) {
-    assert(
-      aliceGroups[first].createdAt === aliceGroup.createdAt,
-      'Alice group returned from listGroups shows createdAt ' +
-        aliceGroups[1].createdAt +
-        ' but should be ' +
-        aliceGroup.createdAt
-    )
     assert(
       aliceGroups[second].createdAt === bobGroup.createdAt,
       'Bob group returned from listGroups shows createdAt ' +
-        aliceGroups[0].createdAt +
-        ' but should be ' +
-        bobGroup.createdAt
+      aliceGroups[0].createdAt +
+      ' but should be ' +
+      bobGroup.createdAt
     )
   }
   return true
@@ -317,32 +316,32 @@ test('conversation createdAt matches stream', async () => {
   assert(
     allConversations[0].topic === aliceConversation.topic,
     'list()[1].topic: ' +
-      allConversations[0].topic +
-      ' != ' +
-      aliceConversation.topic
+    allConversations[0].topic +
+    ' != ' +
+    aliceConversation.topic
   )
   assert(
     allConversations[1].topic === camConversation.topic,
     'list()[0].topic: ' +
-      allConversations[1].topic +
-      ' != ' +
-      camConversation.topic
+    allConversations[1].topic +
+    ' != ' +
+    camConversation.topic
   )
 
   // CreatedAt returned from list matches createAt from create function
   assert(
     allConversations[0].createdAt === aliceConversation.createdAt,
     'list()[0].createdAt: ' +
-      allConversations[0].createdAt +
-      ' != ' +
-      aliceConversation.createdAt
+    allConversations[0].createdAt +
+    ' != ' +
+    aliceConversation.createdAt
   )
   assert(
     allConversations[1].createdAt === camConversation.createdAt,
     'list()[1].createdAt: ' +
-      allConversations[1].createdAt +
-      ' != ' +
-      camConversation.createdAt
+    allConversations[1].createdAt +
+    ' != ' +
+    camConversation.createdAt
   )
 
   return true
@@ -392,32 +391,32 @@ test('conversation createdAt matches streamAll', async () => {
   assert(
     allConversations[0].topic === aliceConversation.topic,
     'list()[1].topic: ' +
-      allConversations[0].topic +
-      ' != ' +
-      aliceConversation.topic
+    allConversations[0].topic +
+    ' != ' +
+    aliceConversation.topic
   )
   assert(
     allConversations[1].topic === camConversation.topic,
     'list()[0].topic: ' +
-      allConversations[1].topic +
-      ' != ' +
-      camConversation.topic
+    allConversations[1].topic +
+    ' != ' +
+    camConversation.topic
   )
 
   // CreatedAt returned from list matches createAt from create function
   assert(
     allConversations[0].createdAt === aliceConversation.createdAt,
     'list()[0].createdAt: ' +
-      allConversations[0].createdAt +
-      ' != ' +
-      aliceConversation.createdAt
+    allConversations[0].createdAt +
+    ' != ' +
+    aliceConversation.createdAt
   )
   assert(
     allConversations[1].createdAt === camConversation.createdAt,
     'list()[1].createdAt: ' +
-      allConversations[1].createdAt +
-      ' != ' +
-      camConversation.createdAt
+    allConversations[1].createdAt +
+    ' != ' +
+    camConversation.createdAt
   )
 
   return true

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -1,6 +1,6 @@
 import { DecodedMessage } from 'xmtp-react-native-sdk/lib/DecodedMessage'
 
-import { Test, assert, delayToPropogate } from './tests'
+import { Test, assert, delayToPropogate, isIos } from './tests'
 import {
   Client,
   Conversation,

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -455,6 +455,7 @@ test('can stream groups', async () => {
 
   // * Note Alice creating a group does not trigger alice conversations
   // group stream. Workaround is to syncGroups after you create and list manually
+  // See https://github.com/xmtp/libxmtp/issues/504
 
   // Alice creates a group
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -491,44 +491,6 @@ test('can stream groups', async () => {
   return true
 })
 
-test('can list all groups', async () => {
-  // Create three MLS enabled Clients
-  const aliceClient = await Client.createRandom({
-    env: 'local',
-    enableAlphaMls: true,
-  })
-  delayToPropogate()
-  const bobClient = await Client.createRandom({
-    env: 'local',
-    enableAlphaMls: true,
-  })
-  delayToPropogate()
-  const camClient = await Client.createRandom({
-    env: 'local',
-    enableAlphaMls: true,
-  })
-  delayToPropogate()
-  const bobGroup = await bobClient.conversations.newGroup([aliceClient.address])
-  const aliceGroup = await aliceClient.conversations.newGroup([
-    camClient.address,
-  ])
-
-  await aliceClient.conversations.syncGroups()
-  delayToPropogate
-
-  const listedGroups = await aliceClient.conversations.listGroups()
-  console.log('BREAK')
-
-  console.log('listedGroups[0].createdAt', listedGroups[0].createdAt)
-  console.log('bob.createdAt', bobGroup.createdAt)
-  console.log('listedGroups[0].createdAt', listedGroups[1].createdAt)
-  console.log('alice.createdAt', aliceGroup.createdAt)
-
-  console.log('BREAK')
-
-  return true
-})
-
 test('can list all groups and conversations', async () => {
   // Create three MLS enabled Clients
   const aliceClient = await Client.createRandom({

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -515,11 +515,15 @@ test('can list all groups and conversations', async () => {
   const listedContainers = await aliceClient.conversations.listAll()
 
   // Verify information in listed containers is correct
+  // BUG - List All returns in Chronological order on iOS
+  // and reverse Chronological order on Android
+  const first = isIos() ? 1 : 0
+  const second = isIos() ? 0 : 1
   if (
-    listedContainers[0].topic !== bobGroup.topic ||
-    listedContainers[0].version !== ConversationVersion.GROUP ||
-    listedContainers[1].version !== ConversationVersion.DIRECT ||
-    listedContainers[1].createdAt !== aliceConversation.createdAt
+    listedContainers[first].topic !== bobGroup.topic ||
+    listedContainers[first].version !== ConversationVersion.GROUP ||
+    listedContainers[second].version !== ConversationVersion.DIRECT ||
+    listedContainers[second].createdAt !== aliceConversation.createdAt
   ) {
     throw Error('Listed containers should match streamed containers')
   }

--- a/example/src/tests/tests.ts
+++ b/example/src/tests/tests.ts
@@ -13,6 +13,7 @@ import {
   RemoteAttachmentCodec,
   RemoteAttachmentContent,
 } from '../../../src/index'
+import { Platform } from 'expo-modules-core'
 
 type EncodedContent = content.EncodedContent
 type ContentTypeId = content.ContentTypeId
@@ -77,6 +78,10 @@ export function assert(condition: boolean, msg: string) {
 export async function delayToPropogate(): Promise<void> {
   // delay 1s to avoid clobbering
   return new Promise((r) => setTimeout(r, 100))
+}
+
+export function isIos() {
+  return Platform.OS === 'ios'
 }
 
 function test(name: string, perform: () => Promise<boolean>) {


### PR DESCRIPTION
This PR adds tests for checking the order returned from `list()`, `listGroups()`, and `listAll()`, `stream()`, `streamGroups()`, and `streamAll()`, and compares `createdAt` field of items returned from list functions to `createdAt` field of items returned by `createGroup/Conversation` functions.


My recommendation is to merge these new tests with the comments they have about where behavior is currently inconsistent between android and iOS. We can then update the tests as the below issues are fixed. 

| Android | iOS |
| ------------- | ------------- |
| <img src="https://github.com/xmtp/xmtp-react-native/assets/1103838/758b0d04-5a15-4f3f-b2e4-a30ce3a76ed2" width="200">   | <img src="https://github.com/xmtp/xmtp-react-native/assets/1103838/69179a1a-eb5f-400f-975f-861afe050c8a" width="200">  |

Issues Documented in the tests:

listGroups issues: See https://github.com/xmtp/xmtp-react-native/issues/276
1. `conversations.listGroups()` returns in reverse chronological on iOS, and chronological order on Android
2. `createdAt` field returned by` listGroups()` does not match the `createdAt` of group returned by `createGroup` function on Android when the group was created by someone other than the client who called `listGroups()`

list / listAll issues: See https://github.com/xmtp/xmtp-react-native/issues/277
1. `conversations.listAll()` sets values to `createdAt` for groups that do not match the values of `createdAt` returned from `createGroup` function.
2. `list()` and `listAll()`  methods for conversations returns in Chronological order for iOS and reverse Chronological order for Android

stream/streamAll issue: See https://github.com/xmtp/xmtp-react-native/issues/278
- Both stream() and streamAll() the `createAt` value of a group returned does not match the `createdAt` value of the group returned by the createGroup() method on Android only. 
