### PR TITLE
Default Sync for group methods

### DIFF
--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -106,7 +106,7 @@ test('can message in a group', async () => {
   })
 
   // Alice's num groups start at 0
-  let aliceGroups = await aliceClient.conversations.listGroups(false)
+  let aliceGroups = await aliceClient.conversations.listGroups()
   if (aliceGroups.length !== 0) {
     throw new Error('num groups should be 0')
   }

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -378,7 +378,6 @@ test('can remove members from a group', async () => {
     throw new Error('num group members should be 2')
   }
 
-
   if (await camGroups[0].isActive()) {
     throw new Error('cams group should not be active')
   }

--- a/example/src/tests/tests.ts
+++ b/example/src/tests/tests.ts
@@ -1,5 +1,6 @@
 import { FramesClient } from '@xmtp/frames-client'
 import { content } from '@xmtp/proto'
+import { Platform } from 'expo-modules-core'
 import ReactNativeBlobUtil from 'react-native-blob-util'
 import { TextEncoder, TextDecoder } from 'text-encoding'
 import { DecodedMessage } from 'xmtp-react-native-sdk/lib/DecodedMessage'
@@ -13,7 +14,6 @@ import {
   RemoteAttachmentCodec,
   RemoteAttachmentContent,
 } from '../../../src/index'
-import { Platform } from 'expo-modules-core'
 
 type EncodedContent = content.EncodedContent
 type ContentTypeId = content.ContentTypeId

--- a/src/lib/Conversations.ts
+++ b/src/lib/Conversations.ts
@@ -72,7 +72,10 @@ export default class Conversations<
    *
    * @returns {Promise<Group[]>} A Promise that resolves to an array of Group objects.
    */
-  async listGroups(): Promise<Group<ContentTypes>[]> {
+  async listGroups(skipSync = false): Promise<Group<ContentTypes>[]> {
+    if (!skipSync) {
+      await this.syncGroups()
+    }
     const result = await XMTPModule.listGroups(this.client)
 
     for (const group of result) {

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -38,7 +38,10 @@ export class Group<
     return this.client.address
   }
 
-  async memberAddresses(): Promise<string[]> {
+  async memberAddresses(skipSync = false): Promise<string[]> {
+    if (!skipSync) {
+      await this.sync()
+    }
     return XMTP.listMemberAddresses(this.client, this.id)
   }
 
@@ -76,7 +79,10 @@ export class Group<
     }
   }
 
-  async messages(): Promise<DecodedMessage<ContentTypes>[]> {
+  async messages(skipSync = false): Promise<DecodedMessage<ContentTypes>[]> {
+    if (!skipSync) {
+      await this.sync()
+    }
     return await XMTP.groupMessages(this.client, this.id)
   }
 
@@ -135,7 +141,10 @@ export class Group<
     return XMTP.removeGroupMembers(this.client.address, this.id, addresses)
   }
 
-  async isActive(): Promise<boolean> {
+  async isActive(skipSync = false): Promise<boolean> {
+    if (!skipSync) {
+      await this.sync()
+    }
     return XMTP.isGroupActive(this.client.address, this.id)
   }
 }


### PR DESCRIPTION
Closes #263 

All tests are still passing even though all `group.sync()` and `conversation.syncGroups()` calls have been removed from tests. 