### PR TITLE
Fix iOS timestamp precision on iOS

### DIFF
--- a/example/src/tests/createdAtTests.ts
+++ b/example/src/tests/createdAtTests.ts
@@ -564,20 +564,23 @@ test('group and conversation createdAt has millisecond precision', async () => {
   ])
 
   // Bob creates a conversation
-  const bobConversation = await bobClient.conversations.newConversation(aliceClient.address)
+  const bobConversation = await bobClient.conversations.newConversation(
+    aliceClient.address
+  )
 
   console.log('Group createdAt: ' + aliceGroup.createdAt)
   console.log('Conversation createdAt: ' + bobConversation.createdAt)
   assert(
-    (! bobConversation.createdAt.toString().endsWith('000')),
-    'Group createdAt should have millisecond precision, but it is ' + bobConversation.createdAt
+    !bobConversation.createdAt.toString().endsWith('000'),
+    'Group createdAt should have millisecond precision, but it is ' +
+      bobConversation.createdAt
   )
   assert(
-    (! aliceGroup.createdAt.toString().endsWith('000')),
-    'Group createdAt should have millisecond precision, but it is ' + aliceGroup.createdAt
+    !aliceGroup.createdAt.toString().endsWith('000'),
+    'Group createdAt should have millisecond precision, but it is ' +
+      aliceGroup.createdAt
   )
 
-  
   return true
 })
 
@@ -598,7 +601,9 @@ test('message timestamp has millisecond precision', async () => {
   ])
 
   // Bob creates a conversation
-  const bobConversation = await bobClient.conversations.newConversation(aliceClient.address)
+  const bobConversation = await bobClient.conversations.newConversation(
+    aliceClient.address
+  )
 
   await aliceGroup.send('hello')
   await bobConversation.send('hi')
@@ -609,12 +614,14 @@ test('message timestamp has millisecond precision', async () => {
   console.log('Group message sent: ' + aliceMessage.sent)
   console.log('Conversation message sent: ' + bobMessage.sent)
   assert(
-    (! bobMessage.sent.toString().endsWith('000')),
-    'Conversation message sent should have millisecond precision, but it is ' + bobMessage.sent
+    !bobMessage.sent.toString().endsWith('000'),
+    'Conversation message sent should have millisecond precision, but it is ' +
+      bobMessage.sent
   )
   assert(
-    (! aliceMessage.sent.toString().endsWith('000')),
-    'Group message sent should have millisecond precision, but it is ' + aliceMessage.sent
+    !aliceMessage.sent.toString().endsWith('000'),
+    'Group message sent should have millisecond precision, but it is ' +
+      aliceMessage.sent
   )
 
   return true

--- a/example/src/tests/createdAtTests.ts
+++ b/example/src/tests/createdAtTests.ts
@@ -566,17 +566,18 @@ test('group and conversation createdAt has millisecond precision', async () => {
   // Bob creates a conversation
   const bobConversation = await bobClient.conversations.newConversation(aliceClient.address)
 
+  console.log('Group createdAt: ' + aliceGroup.createdAt)
+  console.log('Conversation createdAt: ' + bobConversation.createdAt)
+  assert(
+    (! bobConversation.createdAt.toString().endsWith('000')),
+    'Group createdAt should have millisecond precision, but it is ' + bobConversation.createdAt
+  )
   assert(
     (! aliceGroup.createdAt.toString().endsWith('000')),
     'Group createdAt should have millisecond precision, but it is ' + aliceGroup.createdAt
   )
-  console.log('Group createdAt: ' + aliceGroup.createdAt)
 
-  assert(
-    (! aliceGroup.createdAt.toString().endsWith('000')),
-    'Group createdAt should have millisecond precision, but it is ' + bobConversation.createdAt
-  )
-  console.log('Conversation createdAt: ' + bobConversation.createdAt)
+  
   return true
 })
 
@@ -605,16 +606,16 @@ test('message timestamp has millisecond precision', async () => {
   const aliceMessage = (await aliceGroup.messages())[0]
   const bobMessage = (await bobConversation.messages())[0]
 
-  assert(
-    (! aliceMessage.sent.toString().endsWith('000')),
-    'Group message sent should have millisecond precision, but it is ' + aliceMessage.sent
-  )
   console.log('Group message sent: ' + aliceMessage.sent)
-
+  console.log('Conversation message sent: ' + bobMessage.sent)
   assert(
     (! bobMessage.sent.toString().endsWith('000')),
     'Conversation message sent should have millisecond precision, but it is ' + bobMessage.sent
   )
-  console.log('Conversation message sent: ' + bobMessage.sent)
+  assert(
+    (! aliceMessage.sent.toString().endsWith('000')),
+    'Group message sent should have millisecond precision, but it is ' + aliceMessage.sent
+  )
+
   return true
 })

--- a/example/src/tests/createdAtTests.ts
+++ b/example/src/tests/createdAtTests.ts
@@ -546,3 +546,75 @@ test('conversation createdAt matches streamAll', async () => {
 
   return true
 })
+
+test('group and conversation createdAt has millisecond precision', async () => {
+  // Create three MLS enabled Clients
+  const aliceClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  const bobClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+
+  // Alice creates a group
+  const aliceGroup = await aliceClient.conversations.newGroup([
+    bobClient.address,
+  ])
+
+  // Bob creates a conversation
+  const bobConversation = await bobClient.conversations.newConversation(aliceClient.address)
+
+  assert(
+    (! aliceGroup.createdAt.toString().endsWith('000')),
+    'Group createdAt should have millisecond precision, but it is ' + aliceGroup.createdAt
+  )
+  console.log('Group createdAt: ' + aliceGroup.createdAt)
+
+  assert(
+    (! aliceGroup.createdAt.toString().endsWith('000')),
+    'Group createdAt should have millisecond precision, but it is ' + bobConversation.createdAt
+  )
+  console.log('Conversation createdAt: ' + bobConversation.createdAt)
+  return true
+})
+
+test('message timestamp has millisecond precision', async () => {
+  // Create three MLS enabled Clients
+  const aliceClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+  const bobClient = await Client.createRandom({
+    env: 'local',
+    enableAlphaMls: true,
+  })
+
+  // Alice creates a group
+  const aliceGroup = await aliceClient.conversations.newGroup([
+    bobClient.address,
+  ])
+
+  // Bob creates a conversation
+  const bobConversation = await bobClient.conversations.newConversation(aliceClient.address)
+
+  await aliceGroup.send('hello')
+  await bobConversation.send('hi')
+
+  const aliceMessage = (await aliceGroup.messages())[0]
+  const bobMessage = (await bobConversation.messages())[0]
+
+  assert(
+    (! aliceMessage.sent.toString().endsWith('000')),
+    'Group message sent should have millisecond precision, but it is ' + aliceMessage.sent
+  )
+  console.log('Group message sent: ' + aliceMessage.sent)
+
+  assert(
+    (! bobMessage.sent.toString().endsWith('000')),
+    'Conversation message sent should have millisecond precision, but it is ' + bobMessage.sent
+  )
+  console.log('Conversation message sent: ' + bobMessage.sent)
+  return true
+})


### PR DESCRIPTION
Test are relevant for the following issue: https://github.com/xmtp/xmtp-react-native/issues/283

The following tests pass on Android but fail on iOS. 

1. "group and conversation createdAt has millisecond precision"
2. "message timestamp has millisecond precision"
