### PR TITLE
fix: prevents NPE on null key material on android

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ConversationWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ConversationWrapper.kt
@@ -26,7 +26,7 @@ class ConversationWrapper {
                 "peerAddress" to conversation.peerAddress,
                 "version" to if (conversation.version == Conversation.Version.V1) "v1" else "v2",
                 "conversationID" to (conversation.conversationId ?: ""),
-                "keyMaterial" to Base64.encodeToString(conversation.keyMaterial, Base64.NO_WRAP)
+                "keyMaterial" to (conversation.keyMaterial?.let { Base64.encodeToString(it, Base64.NO_WRAP) } ?: "")
             )
         }
 


### PR DESCRIPTION
NPE was showing up in the following tests when clicking run unit tests on `main` branch

1. Can send read receipts
2. can Manage Preferences
3. register and use custom content types
4. register and use custom content types when preparing message
5. returns keyMaterial for conversations

NPE was traced to key material sometimes being null during conversation create on Android.

If you re-click "run" for the test, it would usually pass on second run through. 

Though it is strange that re-running the test make key material not null, we want to deal with the null key material gracefully since it is of type ByteArray? in xmtp-android => https://github.com/xmtp/xmtp-android/blob/5da219acc9c14c46fc35020e7a445725b28f5ce5/library/src/main/java/org/xmtp/android/library/Conversation.kt#L82

This PR also adds logging so we can note when keyMaterial is null on Android, so we can troubleshoot why it is null going forward. 

