### PR TITLE
fix: client facing errors

### DIFF
--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
   s.dependency 'secp256k1.swift'
 	s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.9.1"
+  s.dependency "XMTP", "= 0.9.2"
 end


### PR DESCRIPTION
Bump iOS SDK to refactor ApiClientError in this [PR](https://github.com/xmtp/xmtp-ios/pull/285).