### PR TITLE
fix: Correctly handle empty/undefined fallbacks

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DecodedMessageWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DecodedMessageWrapper.kt
@@ -13,14 +13,19 @@ class DecodedMessageWrapper {
             return gson.toJson(message)
         }
 
-        fun encodeMap(model: DecryptedMessage): Map<String, Any> = mapOf(
-            "id" to model.id,
-            "topic" to model.topic,
-            "contentTypeId" to model.encodedContent.type.description,
-            "content" to ContentJson(model.encodedContent).toJsonMap(),
-            "senderAddress" to model.senderAddress,
-            "sent" to model.sentAt.time,
-            "fallback" to model.encodedContent.fallback
-        )
+        fun encodeMap(model: DecryptedMessage): Map<String, Any?> {
+            // Kotlin/Java Protos don't support null values and will always put the default ""
+            // Check if there is a fallback, if there is then make it the set fallback, if not null
+            val fallback = if (model.encodedContent.hasFallback()) model.encodedContent.fallback else null
+            return mapOf(
+                "id" to model.id,
+                "topic" to model.topic,
+                "contentTypeId" to model.encodedContent.type.description,
+                "content" to ContentJson(model.encodedContent).toJsonMap(),
+                "senderAddress" to model.senderAddress,
+                "sent" to model.sentAt.time,
+                "fallback" to fallback
+            )
+        }
     }
 }

--- a/ios/Wrappers/DecodedMessageWrapper.swift
+++ b/ios/Wrappers/DecodedMessageWrapper.swift
@@ -5,6 +5,9 @@ import XMTP
 // into react native.
 struct DecodedMessageWrapper {
 	static func encodeToObj(_ model: XMTP.DecryptedMessage, client: Client) throws -> [String: Any] {
+    // Swift Protos don't support null values and will always put the default ""
+    // Check if there is a fallback, if there is then make it the set fallback, if not null
+		let fallback = model.encodedContent.hasFallback ? model.encodedContent.fallback : nil
 		return [
 			"id": model.id,
 			"topic": model.topic,
@@ -12,7 +15,7 @@ struct DecodedMessageWrapper {
 			"content": try ContentJson.fromEncoded(model.encodedContent, client: client).toJsonMap() as Any,
 			"senderAddress": model.senderAddress,
 			"sent": UInt64(model.sentAt.timeIntervalSince1970 * 1000),
-			"fallback": model.encodedContent.fallback,
+			"fallback": fallback,
 		]
 	}
 

--- a/src/lib/DecodedMessage.ts
+++ b/src/lib/DecodedMessage.ts
@@ -1,13 +1,11 @@
+import { Buffer } from 'buffer'
+
 import { Client } from './Client'
 import {
-  ContentCodec,
   JSContentCodec,
   NativeContentCodec,
   NativeMessageContent,
 } from './ContentCodec'
-import { ReplyCodec } from './NativeCodecs/ReplyCodec'
-import { TextCodec } from './NativeCodecs/TextCodec'
-import { Buffer } from 'buffer'
 
 const allowEmptyProperties: (keyof NativeMessageContent)[] = [
   'text',
@@ -81,7 +79,8 @@ export class DecodedMessage<ContentTypes = any> {
     this.senderAddress = senderAddress
     this.sent = sent
     this.nativeContent = content
-    this.fallback = fallback
+    // undefined comes back as null when bridged, ensure undefined so integrators don't have to add a new check for null as well
+    this.fallback = fallback ?? undefined
   }
 
   content(): ContentTypes {


### PR DESCRIPTION
Swift/Kotlin protos always set a default value for optional fields this results in differences between sdks and no real way for an undefined value to be returned even if it is expected and typed

Updated to check if there is a fallback, if there is use it, if not set back to undefined
Closes: https://github.com/xmtp/xmtp-react-native/issues/337 