### PR TITLE
fix: Streaming timeouts android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.10.2"
+  implementation "org.xmtp:android:0.10.3"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"


### PR DESCRIPTION
Android streams would timeout after 2 minutes. This new version validates that streams don't disconnect even after 10 minutes.