### PR TITLE
Remove hard requirement on encryption key

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -449,7 +449,7 @@ PODS:
     - GenericJSON (~> 2.0)
     - Logging (~> 1.0.0)
     - secp256k1.swift (~> 0.1)
-  - XMTP (0.10.10):
+  - XMTP (0.10.11):
     - Connect-Swift (= 0.12.0)
     - GzipSwift
     - LibXMTP (= 0.4.4-beta5)
@@ -458,7 +458,7 @@ PODS:
     - ExpoModulesCore
     - MessagePacker
     - secp256k1.swift
-    - XMTP (= 0.10.10)
+    - XMTP (= 0.10.11)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -763,8 +763,8 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   SwiftProtobuf: 407a385e97fd206c4fbe880cc84123989167e0d1
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: 13907da1638c2b1a23f38ef246091c7a88c33108
-  XMTPReactNative: 9ae92e4df220d4043a6583a6c05673a698390ee8
+  XMTP: 1deb40ac712ba315dcfdecd590a9b924d8c2241a
+  XMTPReactNative: a7d7c609861e0b31ca7f624f58969dcb92c19990
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
 PODFILE CHECKSUM: 95d6ace79946933ecf80684613842ee553dd76a2

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -26,15 +26,10 @@ function test(name: string, perform: () => Promise<boolean>) {
 
 test('can make a MLS V3 client', async () => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const keyBytes = new Uint8Array([
-    233, 120, 198, 96, 154, 65, 132, 17, 132, 96, 250, 40, 103, 35, 125, 64,
-    166, 83, 208, 224, 254, 44, 205, 227, 175, 49, 234, 129, 74, 252, 135, 145,
-  ])
   const client = await Client.createRandom({
     env: 'local',
     appVersion: 'Testing/0.0.0',
     enableAlphaMls: true,
-    dbEncryptionKey: keyBytes,
   })
 
   return true

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
   s.dependency 'secp256k1.swift'
 	s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.10.10"
+  s.dependency "XMTP", "= 0.10.11"
 end

--- a/src/hooks/useClient.ts
+++ b/src/hooks/useClient.ts
@@ -7,7 +7,7 @@ import { DefaultContentTypes } from '../lib/types/DefaultContentType'
 
 interface InitializeClientOptions {
   signer: Signer | null
-  options: ClientOptions
+  options?: ClientOptions
 }
 
 export const useClient = <


### PR DESCRIPTION
Undoes the hard requirement set here: https://github.com/xmtp/xmtp-react-native/pull/373 to hopefully unblock https://github.com/xmtp/xmtp-ios/issues/336
