### PR TITLE
Add a test for members inconsistencies when creating new installations

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.14.15"
+  implementation "org.xmtp:android:0.14.16"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -56,7 +56,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.71.14)
   - hermes-engine/Pre-built (0.71.14)
   - libevent (2.1.12)
-  - LibXMTP (0.5.6-beta4)
+  - LibXMTP (0.5.6-beta5)
   - Logging (1.0.0)
   - MessagePacker (0.4.7)
   - MMKV (1.3.9):
@@ -449,16 +449,16 @@ PODS:
     - GenericJSON (~> 2.0)
     - Logging (~> 1.0.0)
     - secp256k1.swift (~> 0.1)
-  - XMTP (0.13.15):
+  - XMTP (0.13.16):
     - Connect-Swift (= 0.12.0)
     - GzipSwift
-    - LibXMTP (= 0.5.6-beta4)
+    - LibXMTP (= 0.5.6-beta5)
     - web3.swift
   - XMTPReactNative (0.1.0):
     - ExpoModulesCore
     - MessagePacker
     - secp256k1.swift
-    - XMTP (= 0.13.15)
+    - XMTP (= 0.13.16)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -711,7 +711,7 @@ SPEC CHECKSUMS:
   GzipSwift: 893f3e48e597a1a4f62fafcb6514220fcf8287fa
   hermes-engine: d7cc127932c89c53374452d6f93473f1970d8e88
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  LibXMTP: 2f9297eacd315a027c8655d8fc86f1a0cdde03ac
+  LibXMTP: 66f4809682fa68b744d4fc0ba68ea82e1528e7a8
   Logging: 9ef4ecb546ad3169398d5a723bc9bea1c46bef26
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: 817ba1eea17421547e01e087285606eb270a8dcb
@@ -763,8 +763,8 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   SwiftProtobuf: 407a385e97fd206c4fbe880cc84123989167e0d1
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: d364bb93ef30523ba8a66a3e57c3a39f32e06f5e
-  XMTPReactNative: 9ce794973cfe73271557ae504c99be9d81d80cd2
+  XMTP: 3427d91eb4625ad8724fd79381990e0c96e88d1f
+  XMTPReactNative: 3e03286398ac4ddcb14235ce6bfb2c89d87a4c61
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
 PODFILE CHECKSUM: 95d6ace79946933ecf80684613842ee553dd76a2

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -2076,12 +2076,9 @@ test('can create new installation without breaking group', async () => {
   await client1.conversations.syncGroups()
   await client2.conversations.syncGroups()
 
-  const client1Group = (await client1.conversations.listGroups()).find(
-    (g) => g.id === group.id
-  )
-  const client2Group = (await client2.conversations.listGroups()).find(
-    (g) => g.id === group.id
-  )
+  const client1Group = await client1.conversations.findGroup(group.id)
+  const client2Group = await client2.conversations.findGroup(group.id)
+
   await client1Group?.sync()
   await client2Group?.sync()
 

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -18,6 +18,7 @@ import {
   GroupUpdatedContent,
   GroupUpdatedCodec,
 } from '../../../src/index'
+import { Wallet } from 'ethers'
 
 export const groupTests: Test[] = []
 let counter = 1
@@ -1989,6 +1990,74 @@ test('can list groups does not fork', async () => {
   )
 
   assert(groupCallbacks === 1, 'group stream should have received 1 group')
+
+  return true
+})
+
+test('can create new installation without breaking group', async () => {
+  const keyBytes = new Uint8Array([
+    233, 120, 198, 96, 154, 65, 132, 17, 132, 96, 250, 40, 103, 35, 125, 64,
+    166, 83, 208, 224, 254, 44, 205, 227, 175, 49, 234, 129, 74, 252, 135, 145,
+  ])
+  const wallet1 = new Wallet(
+    '0xc54c62dd3ad018ef94f20f0722cae33919e65270ad74f2d1794291088800f788'
+  )
+  const wallet2 = new Wallet(
+    '0x8d40c1c40473975cc6bbdc0465e70cc2e98f45f3c3474ca9b809caa9c4f53c0b'
+  )
+  const client1 = await Client.create(wallet1, {
+    env: 'local',
+    appVersion: 'Testing/0.0.0',
+    enableV3: true,
+    dbEncryptionKey: keyBytes,
+  })
+  const client2 = await Client.create(wallet2, {
+    env: 'local',
+    appVersion: 'Testing/0.0.0',
+    enableV3: true,
+    dbEncryptionKey: keyBytes,
+  })
+
+  const group = await client1.conversations.newGroup([wallet2.address])
+
+  await client1.conversations.syncGroups()
+  await client2.conversations.syncGroups()
+
+  const client1Group = (await client1.conversations.listGroups()).find(
+    (g) => g.id === group.id
+  )
+  const client2Group = (await client2.conversations.listGroups()).find(
+    (g) => g.id === group.id
+  )
+  await client1Group?.sync()
+  await client2Group?.sync()
+
+  assert(
+    (await client1Group?.members())?.length === 2,
+    `client 1 should see 2 members`
+  )
+
+  assert(
+    (await client2Group?.members())?.length === 2,
+    `client 2 should see 2 members`
+  )
+
+  await client2.dropLocalDatabaseConnection()
+  await client2.deleteLocalDatabase()
+
+  // Recreating a client with wallet 2 (new installation!)
+  await Client.create(wallet2, {
+    env: 'local',
+    appVersion: 'Testing/0.0.0',
+    enableV3: true,
+    dbEncryptionKey: keyBytes,
+  })
+
+  await client1Group?.send('This message will break the group')
+  assert(
+    (await client1Group?.members())?.length === 2,
+    `client 1 should still see the 2 members`
+  )
 
   return true
 })

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
   s.dependency 'secp256k1.swift'
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.13.15"
+  s.dependency "XMTP", "= 0.13.16"
 end


### PR DESCRIPTION
If you create a group with 2 inboxes, and one of those 2 inboxes creates a new installation, then sending a message on the group make it appear like a 1 person group.

This is probably causing a lot of our "group members inconsistencies"

Test fails on Android & iOS, but sometimes on iOS it also fails with  "Pool error timed out" which we know happens on iOS...

<img width="479" alt="Capture d’écran 2024-08-05 à 14 33 51" src="https://github.com/user-attachments/assets/d2270a53-8c50-4184-aee4-565ca2eeabe7">
<img width="477" alt="Capture d’écran 2024-08-05 à 14 33 29" src="https://github.com/user-attachments/assets/3d1be414-da7e-467c-ad26-f245f3b73e73">
