### PR TITLE
fix: do not set pinnedframeurl when initializing group object

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
@@ -20,8 +20,8 @@ class GroupWrapper {
                 "isActive" to group.isActive(),
                 "name" to group.name,
                 "imageUrlSquare" to group.imageUrlSquare,
-                "description" to group.description,
-                "pinnedFrameUrl" to group.pinnedFrameUrl
+                "description" to group.description
+                // "pinnedFrameUrl" to group.pinnedFrameUrl
             )
         }
 

--- a/ios/Wrappers/GroupWrapper.swift
+++ b/ios/Wrappers/GroupWrapper.swift
@@ -22,8 +22,8 @@ struct GroupWrapper {
 			"isActive": try group.isActive(),
 			"name": try group.groupName(),
 			"imageUrlSquare": try group.groupImageUrlSquare(),
-			"description": try group.groupDescription(),
-			"pinnedFrameUrl": try group.groupPinnedFrameUrl()
+			"description": try group.groupDescription()
+			// "pinnedFrameUrl": try group.groupPinnedFrameUrl()
 		]
 	}
 

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -30,7 +30,7 @@ export class Group<
   isGroupActive: boolean
   imageUrlSquare: string
   description: string
-  pinnedFrameUrl: string
+  // pinnedFrameUrl: string
 
   constructor(
     client: XMTP.Client<ContentTypes>,
@@ -44,7 +44,7 @@ export class Group<
       isGroupActive: boolean
       imageUrlSquare: string
       description: string
-      pinnedFrameUrl: string
+      // pinnedFrameUrl: string
     }
   ) {
     this.client = client
@@ -57,7 +57,7 @@ export class Group<
     this.isGroupActive = params.isGroupActive
     this.imageUrlSquare = params.imageUrlSquare
     this.description = params.description
-    this.pinnedFrameUrl = params.pinnedFrameUrl
+    // this.pinnedFrameUrl = params.pinnedFrameUrl
   }
 
   /**


### PR DESCRIPTION
If the group was created before this property was added, we will throw an error. Disabling setting the pinned frame until we potentially update libxmtp to return an empty string when the field is missing. 