### PR TITLE
Encode groups sequentially instead of as async tasks

### DIFF
--- a/example/src/tests/groupPerformanceTests.ts
+++ b/example/src/tests/groupPerformanceTests.ts
@@ -34,9 +34,14 @@ async function createGroups(
 test('testing large group listing with metadata performance', async () => {
   const [alixClient, boClient] = await createClients(2)
 
-  await createGroups(alixClient, [boClient], 10)
+  let numGroups = 100
 
+  console.log('Creating groups')
   let start = Date.now()
+  await createGroups(alixClient, [boClient], numGroups)
+  console.log(`Created groups in ${Date.now() - start}ms`)
+
+  start = Date.now()
   let groups = await alixClient.conversations.listGroups()
   let end = Date.now()
   console.log(`Alix loaded ${groups.length} groups in ${end - start}ms`)


### PR DESCRIPTION
Updating to encode groups sequentially instead of as async tasks in TaskGroup allowed me to go up to 100 groups loaded in 118ms

```
 LOG  Creating groups
 LOG  Created groups in 3017ms
 LOG  Alix loaded 100 groups in 118ms
 LOG  Alix synced 100 groups in 3ms
 LOG  Bo synced 100 groups in 166ms
 LOG  Bo loaded 100 groups in 116ms
```