### PR TITLE
feat: adds ability to export libxmtp logs from native to react native

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -1589,6 +1589,7 @@ class XMTPModule : Module() {
                 }
             }
         }
+    }
 
     //
     // Helpers

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -1,12 +1,8 @@
+import { Wallet } from 'ethers'
 import RNFS from 'react-native-fs'
 import { DecodedMessage } from 'xmtp-react-native-sdk/lib/DecodedMessage'
 
-import {
-  Test,
-  assert,
-  createClients,
-  delayToPropogate,
-} from './test-utils'
+import { Test, assert, createClients, delayToPropogate } from './test-utils'
 import {
   Client,
   Conversation,
@@ -17,7 +13,6 @@ import {
   GroupUpdatedContent,
   GroupUpdatedCodec,
 } from '../../../src/index'
-import { Wallet } from 'ethers'
 
 export const groupTests: Test[] = []
 let counter = 1

--- a/example/src/tests/tests.ts
+++ b/example/src/tests/tests.ts
@@ -8,7 +8,7 @@ import { PrivateKeyAccount } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { DecodedMessage } from 'xmtp-react-native-sdk/lib/DecodedMessage'
 
-import { Test, assert, delayToPropogate } from './test-utils'
+import { Test, assert, createClients, delayToPropogate } from './test-utils'
 import {
   Query,
   JSContentCodec,
@@ -1524,5 +1524,15 @@ test('can start conversations without consent proofs', async () => {
   await delayToPropogate()
   assert(!alixConvo.consentProof, 'consentProof should not exist')
   await delayToPropogate()
+  return true
+})
+
+test('can export logs', async () => {
+  await createClients(2)
+
+  const logs = await Client.exportNativeLogs()
+  console.log(logs)
+  assert(logs.includes('libxmtp'), 'should be able to read libxmtp logs')
+
   return true
 })

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -1464,7 +1464,7 @@ public class XMTPModule: Module {
 		AsyncFunction("exportNativeLogs") { () -> String in
 			var logOutput = ""
 			let logStore = try OSLogStore(scope: .currentProcessIdentifier)
-			let position = logStore.position(timeIntervalSinceLatestBoot: -600) // Last 10 min of logs
+			let position = logStore.position(timeIntervalSinceLatestBoot: -300) // Last 5 min of logs
 			let entries = try logStore.getEntries(at: position)
 
 			for entry in entries {

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -1,6 +1,7 @@
 import ExpoModulesCore
 import XMTP
 import LibXMTP
+import OSLog
 
 extension Conversation {
 	static func cacheKeyForTopic(inboxId: String, topic: String) -> String {
@@ -1458,6 +1459,21 @@ public class XMTPModule: Module {
 			throw Error.invalidString
 		  }
 		  return await client.contacts.isGroupDenied(groupId: groupId)
+		}
+        
+		AsyncFunction("exportNativeLogs") { () -> String in
+			var logOutput = ""
+			let logStore = try OSLogStore(scope: .currentProcessIdentifier)
+			let position = logStore.position(timeIntervalSinceLatestBoot: -600) // Last 10 min of logs
+			let entries = try logStore.getEntries(at: position)
+
+			for entry in entries {
+				if let logEntry = entry as? OSLogEntryLog {
+					logOutput.append("\(logEntry.date): \(logEntry.composedMessage)\n")
+				}
+			}
+			
+			return logOutput
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1149,6 +1149,10 @@ export async function processWelcomeMessage<
   return new Group(client, JSON.parse(json))
 }
 
+export async function exportNativeLogs() {
+  return XMTPModule.exportNativeLogs()
+}
+
 export const emitter = new EventEmitter(XMTPModule ?? NativeModulesProxy.XMTP)
 
 interface AuthParams {

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -147,6 +147,10 @@ export class Client<
     })
   }
 
+  static async exportNativeLogs() {
+    return XMTPModule.exportNativeLogs()
+  }
+
   private static removeAllSubscriptions(
     createSubscription?: Subscription,
     enableSubscription?: Subscription,


### PR DESCRIPTION
New test:

```
test('can export logs', async () => {
  await createClients(2)

  const logs = await Client.exportNativeLogs()
  console.log(logs)
  assert(logs.includes('libxmtp'), 'should be able to read libxmtp logs')

  return true
})
```


Android test console output:
```
08-08 16:56:05.118 14712 14821 V XMTPModule: createRandom
08-08 16:56:05.182 14712 14821 I INFO    : [libxmtp][t:487432580272] Getting inbox_ids for account addresses: ["0xf7c87B408E87233A89cd04a21F669689346F0872"]
08-08 16:56:05.192 14712 14821 I INFO    : [libxmtp][t:487432580272] Creating API client for host: http://10.0.2.2:5556, isSecure: false
08-08 16:56:05.194 14712 14821 I INFO    : [libxmtp][t:487432580272] Creating message store with path: Some("/data/user/0/expo.modules.xmtpreactnativesdk.example/files/xmtp_db/xmtp-LOCAL-c47f0c0f5205fcbfc7ab3c4779b14ae83dd7acf6534d5ec6825acea31a21c932.db3") and encryption key: true of length Some(32)
08-08 16:56:05.195 14712 14821 I INFO    : [libxmtp][t:487432580272] Setting up DB connection pool
08-08 16:56:05.198 14712 14821 I INFO    : [libxmtp][t:487432580272] Running DB migrations
08-08 16:56:05.206 14712 14821 I INFO    : [libxmtp][t:487432580272] sqlite_version=3.45.3
08-08 16:56:05.206 14712 14821 I INFO    : [libxmtp][t:487432580272] Sqlite cipher_version=Some("4.5.7 community"), cipher_provider_version=Some("OpenSSL 3.3.0 9 Apr 2024")
08-08 16:56:05.207 14712 14821 I INFO    : [libxmtp][t:487432580272] Migrations successful
08-08 16:56:05.208 14712 14821 I INFO    : [libxmtp][t:487432580272] Creating XMTP client
08-08 16:56:05.208 14712 14821 I INFO    : [libxmtp][t:487432580272] Initializing identity
08-08 16:56:05.209 14712 14821 I INFO    : [libxmtp][t:487432580272] Getting inbox_ids for account addresses: ["0xf7c87b408e87233a89cd04a21f669689346f0872"]
08-08 16:56:05.213 14712 14821 I INFO    : [libxmtp][t:487432580272] Provided Signer: 39023bdcef86f4b68af4eb67dbc4d317ee5867c29a05671fca4a7a6e613e94c3
08-08 16:56:05.213 14712 14821 I INFO    : [libxmtp][t:487432580272] Missing Signatures: [Installation([57, 2, 59, 220, 239, 134, 244, 182, 138, 244, 235, 103, 219, 196, 211, 23, 238, 88, 103, 194, 154, 5, 103, 31, 202, 74, 122, 110, 97, 62, 148, 195]), Address("0xf7c87b408e87233a89cd04a21f669689346f0872")]
08-08 16:56:05.214 14712 14821 I INFO    : [libxmtp][t:487432580272] Provided Signer: 0xf7c87b408e87233a89cd04a21f669689346f0872
08-08 16:56:05.215 14712 14821 I INFO    : [libxmtp][t:487432580272] Missing Signatures: [Address("0xf7c87b408e87233a89cd04a21f669689346f0872")]
08-08 16:56:05.247 14712 14821 I INFO    : [libxmtp][t:487432580272] Created XMTP client for inbox_id: c47f0c0f5205fcbfc7ab3c4779b14ae83dd7acf6534d5ec6825acea31a21c932
08-08 16:56:05.248 14712 14821 I Client  : LibXMTP Version: 340b0b6
08-08 16:56:05.248 14712 14821 I Client  : Branch: main
08-08 16:56:05.248 14712 14821 I Client  : Date: 2024-08-07 17:24:24 +0000
08-08 16:56:05.270 14712 14821 V XMTPModule: createRandom
08-08 16:56:05.325 14712 14821 I INFO    : [libxmtp][t:487432580272] Getting inbox_ids for account addresses: ["0x72fA03Ba3e0464Dba47Ed187a9ee4C0Ce65Fa476"]
08-08 16:56:05.334 14712 14821 I INFO    : [libxmtp][t:487432580272] Creating API client for host: http://10.0.2.2:5556, isSecure: false
08-08 16:56:05.337 14712 14821 I INFO    : [libxmtp][t:487432580272] Creating message store with path: Some("/data/user/0/expo.modules.xmtpreactnativesdk.example/files/xmtp_db/xmtp-LOCAL-d53479de4486be3232e5a15f52f775a1c30d78efa6bef2f6ae8eba9b63d7cdce.db3") and encryption key: true of length Some(32)
08-08 16:56:05.338 14712 14821 I INFO    : [libxmtp][t:487432580272] Setting up DB connection pool
08-08 16:56:05.343 14712 14821 I INFO    : [libxmtp][t:487432580272] Running DB migrations
08-08 16:56:05.349 14712 14821 I INFO    : [libxmtp][t:487432580272] sqlite_version=3.45.3
08-08 16:56:05.350 14712 14821 I INFO    : [libxmtp][t:487432580272] Sqlite cipher_version=Some("4.5.7 community"), cipher_provider_version=Some("OpenSSL 3.3.0 9 Apr 2024")
08-08 16:56:05.350 14712 14821 I INFO    : [libxmtp][t:487432580272] Migrations successful
08-08 16:56:05.351 14712 14821 I INFO    : [libxmtp][t:487432580272] Creating XMTP client
08-08 16:56:05.351 14712 14821 I INFO    : [libxmtp][t:487432580272] Initializing identity
08-08 16:56:05.352 14712 14821 I INFO    : [libxmtp][t:487432580272] Getting inbox_ids for account addresses: ["0x72fa03ba3e0464dba47ed187a9ee4c0ce65fa476"]
08-08 16:56:05.360 14712 14821 I INFO    : [libxmtp][t:487432580272] Provided Signer: a39fbf2ab0ab46eab577529529411558df8a5568c3706a73b7d31274065daa61
08-08 16:56:05.360 14712 14821 I INFO    : [libxmtp][t:487432580272] Missing Signatures: [Address("0x72fa03ba3e0464dba47ed187a9ee4c0ce65fa476"), Installation([163, 159, 191, 42, 176, 171, 70, 234, 181, 119, 82, 149, 41, 65, 21, 88, 223, 138, 85, 104, 195, 112, 106, 115, 183, 211, 18, 116, 6, 93, 170, 97])]
08-08 16:56:05.361 14712 14821 I INFO    : [libxmtp][t:487432580272] Provided Signer: 0x72fa03ba3e0464dba47ed187a9ee4c0ce65fa476
08-08 16:56:05.362 14712 14821 I INFO    : [libxmtp][t:487432580272] Missing Signatures: [Address("0x72fa03ba3e0464dba47ed187a9ee4c0ce65fa476")]
08-08 16:56:05.388 14712 14964 I INFO    : [libxmtp][t:472446381232] Created XMTP client for inbox_id: d53479de4486be3232e5a15f52f775a1c30d78efa6bef2f6ae8eba9b63d7cdce
08-08 16:56:05.389 14712 14964 I Client  : LibXMTP Version: 340b0b6
08-08 16:56:05.389 14712 14964 I Client  : Branch: main
08-08 16:56:05.389 14712 14964 I Client  : Date: 2024-08-07 17:24:24 +0000
```

iOS test console output:
```
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] Logger initialized
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] Creating API client for host: http://localhost:5556, isSecure: false
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] Creating message store with path: Some("/Users/cameronvoell/Library/Developer/CoreSimulator/Devices/7DCE12A6-F886-4DCB-AD64-D8F036330058/data/Containers/Data/Application/66D2491F-15B9-4D0D-BCCF-EE30A67D4438/Documents/xmtp-localhost:5556-fbb7ad01edc8e8838f730935349ab9b47e70367b8bfa432d08ba79a1671da159.db3") and encryption key: true of length Some(32)
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] Setting up DB connection pool
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] Running DB migrations
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] sqlite_version=3.45.3
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] Sqlite cipher_version=Some("4.5.7 community"), cipher_provider_version=Some("OpenSSL 3.3.0 9 Apr 2024")
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] Migrations successful
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] Creating XMTP client
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] Initializing identity
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] Getting inbox_ids for account addresses: ["0x34da2151c84c58137587fcd59599e34d8d909074"]
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] Provided Signer: b6f66cd0a82b5860a858bc503fb7e521a868fe71bcb96bdc27c3930f26abb8f8
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] Missing Signatures: [Installation([182, 246, 108, 208, 168, 43, 88, 96, 168, 88, 188, 80, 63, 183, 229, 33, 168, 104, 254, 113, 188, 185, 107, 220, 39, 195, 147, 15, 38, 171, 184, 248]), Address("0x34da2151c84c58137587fcd59599e34d8d909074")]
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] Provided Signer: 0x34da2151c84c58137587fcd59599e34d8d909074
2024-08-08 23:58:03 +0000: libxmtp[INFO] - [libxmtp][t:16210948] Missing Signatures: [Address("0x34da2151c84c58137587fcd59599e34d8d909074")]
2024-08-08 23:58:03 +0000: libxmtp[7ad01] - edc8e8838f730935349ab9b47e70367b8bfa432d08ba79a1671da159
2024-08-08 23:58:03 +0000: libxmtp[es: [] - "0xd96e06287f6aAA3572945c80beF9922f9E7324A4"]
2024-08-08 23:58:03 +0000: libxmtp[local] - host:5556, isSecure: false
2024-08-08 23:58:03 +0000: libxmtp[e("/U] - sers/cameronvoell/Library/Developer/CoreSimulator/Devices/7DCE12A6-F886-4DCB-AD64-D8F036330058/data/Containers/Data/Application/66D2491F-15B9-4D0D-BCCF-EE30A67D4438/Documents/xmtp-localhost:5556-10da63e5d056a46141705d91d9de3a3ebf3d3c19ec4d1028873b2df04c1fef8a.db3") and encryption key: true of length Some(32)
2024-08-08 23:58:03 +0000: libxmtp[ibxmt] - p][t:16210948] Creating message store with path: Som
2024-08-08 23:58:03 +0000: libxmtp[t:162] - 10948] Setting up DB connection pool
2024-08-08 23:58:03 +0000: libxmtp[t:162] - 10948] Running DB migrations
2024-08-08 23:58:03 +0000: libxmtp[munit] - y"), cipher_provider_version=Some("OpenSSL 3.3.0 9 Apr 2024")
2024-08-08 23:58:03 +0000: libxmtp[t:162] - 10948] Sqlite cipher_version=Some("4.5.7 com
2024-08-08 23:58:03 +0000: libxmtp[:1621] - 0948] Migrations successful
2024-08-08 23:58:03 +0000: libxmtp[t:162] - 10948] Creating XMTP client
2024-08-08 23:58:03 +0000: libxmtp[es: [] - "0xd96e06287f6aaa3572945c80bef9922f9e7324a4"]
2024-08-08 23:58:03 +0000: libxmtp[0b0d8] - 111b797f673d62abc8defc035059d890840cc42
2024-08-08 23:58:03 +0000: libxmtp[1, 2,] -  239, 216, 59, 171, 214, 234, 64, 101, 11, 13, 129, 17, 183, 151, 246, 115, 214, 42, 188, 141, 239, 192, 53, 5, 157, 137, 8, 64, 204, 66]), Address("0xd96e06287f6aaa3572945c80bef9922f9e7324a4")]
2024-08-08 23:58:03 +0000: libxmtp[945c8] - 0bef9922f9e7324a4
2024-08-08 23:58:03 +0000: libxmtp[6287f] - 6aaa3572945c80bef9922f9e7324a4")]
2024-08-08 23:58:03 +0000: libxmtp[a63e5] - d056a46141705d91d9de3a3ebf3d3c19ec4d1028873b2df04c1fef8a
2024-08-08 23:58:03 +0000: [0x140742110] activating connection: mach=false listener=false peer=false name=com.apple.OSLogService
```