### PR TITLE
Drop / reconnect database connections when app becomes backgrounded/active

### DIFF
--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -62,16 +62,20 @@ public class XMTPModule: Module {
 		// A method to disconnect all dbs
 		func dropAllLocalDatabaseConnections() throws {
 			for (_, client) in clients {
-				// Call the method on each client
-				try client.dropLocalDatabaseConnection()
+				// Call the drop method on each v3 client
+                if (!client.installationID.isEmpty) {
+                    try client.dropLocalDatabaseConnection()
+                }
 			}
 		}
 
 		// A method to reconnect all dbs
 		func reconnectAllLocalDatabaseConnections() async throws {
 			for (_, client) in clients {
-				// Call the method on each client
-				try await client.reconnectLocalDatabase()
+                // Call the reconnect method on each v3 client
+                if (!client.installationID.isEmpty) {
+                    try await client.reconnectLocalDatabase()
+                }
 			}
 		}
 	}

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -1480,12 +1480,6 @@ public class XMTPModule: Module {
 		  }
 		  return await client.contacts.isGroupDenied(groupId: groupId)
 		}
-
-		OnAppBecomesActive {
-			Task {
-				try await clientsManager.reconnectAllLocalDatabaseConnections()
-			}
-		}
         
 		AsyncFunction("exportNativeLogs") { () -> String in
 			var logOutput = ""

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -60,20 +60,20 @@ public class XMTPModule: Module {
 		}
         
         // A method to disconnect all dbs
-        func dropAllLocalDatabaseConnections() throws {
-            for (_, client) in clients {
-                // Call the method on each client
-                try client.dropLocalDatabaseConnection()
-            }
-        }
-        
-        // A method to disconnect all dbs
-        func reconnectAllLocalDatabaseConnections() async throws {
-            for (_, client) in clients {
-                // Call the method on each client
-                try await client.reconnectLocalDatabase()
-            }
-        }
+		func dropAllLocalDatabaseConnections() throws {
+			for (_, client) in clients {
+				// Call the method on each client
+				try client.dropLocalDatabaseConnection()
+			}
+		}
+
+		// A method to disconnect all dbs
+		func reconnectAllLocalDatabaseConnections() async throws {
+			for (_, client) in clients {
+				// Call the method on each client
+				try await client.reconnectLocalDatabase()
+			}
+		}
 	}
 
 	enum Error: Swift.Error {
@@ -1476,6 +1476,12 @@ public class XMTPModule: Module {
 		  }
 		  return await client.contacts.isGroupDenied(groupId: groupId)
 		}
+
+		OnAppBecomesActive {
+			Task {
+				try await clientsManager.reconnectAllLocalDatabaseConnections()
+			}
+		}
         
 		AsyncFunction("exportNativeLogs") { () -> String in
 			var logOutput = ""
@@ -1492,17 +1498,18 @@ public class XMTPModule: Module {
 			return logOutput
 		}
 
-        OnAppBecomesActive {
-            Task {
-                try await clientsManager.reconnectAllLocalDatabaseConnections()
-            }
-        }
-        
-        OnAppEntersBackground {
-            Task {
-                try await clientsManager.dropAllLocalDatabaseConnections()
-            }
-        }
+		OnAppBecomesActive {
+			Task {
+				try await clientsManager.reconnectAllLocalDatabaseConnections()
+			}
+		}
+
+
+		OnAppEntersBackground {
+			Task {
+				try await clientsManager.dropAllLocalDatabaseConnections()
+			}
+		}
 	}
 
 	//

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -59,7 +59,7 @@ public class XMTPModule: Module {
 			return clients[key]
 		}
         
-        // A method to disconnect all dbs
+		// A method to disconnect all dbs
 		func dropAllLocalDatabaseConnections() throws {
 			for (_, client) in clients {
 				// Call the method on each client
@@ -67,7 +67,7 @@ public class XMTPModule: Module {
 			}
 		}
 
-		// A method to disconnect all dbs
+		// A method to reconnect all dbs
 		func reconnectAllLocalDatabaseConnections() async throws {
 			for (_, client) in clients {
 				// Call the method on each client

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -63,19 +63,19 @@ public class XMTPModule: Module {
 		func dropAllLocalDatabaseConnections() throws {
 			for (_, client) in clients {
 				// Call the drop method on each v3 client
-                if (!client.installationID.isEmpty) {
-                    try client.dropLocalDatabaseConnection()
-                }
+				if (!client.installationID.isEmpty) {
+					try client.dropLocalDatabaseConnection()
+				}
 			}
 		}
 
 		// A method to reconnect all dbs
 		func reconnectAllLocalDatabaseConnections() async throws {
 			for (_, client) in clients {
-                // Call the reconnect method on each v3 client
-                if (!client.installationID.isEmpty) {
-                    try await client.reconnectLocalDatabase()
-                }
+				// Call the reconnect method on each v3 client
+				if (!client.installationID.isEmpty) {
+					try await client.reconnectLocalDatabase()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Since we have so many issues with db locks, I suspect we have an issue calling the db disconnect at the right moment.

My thinking is that there are issues either in the Converse code or the XMTP React Native code, that blocks the bridge for too long and we don't manage to actually dicsonnect db before the app is suspended

By adding that code directly in Swift we bypass the bridge and should be able to prevent some of these crashes

Possible improvements:
- add a boolean in the config to enable / disable that feature, because it's an issue only if the db is stored in the shared container. However I don't really see how disabling that feature would bring any value
- implement this in the iOS SDK rather than the RN Module. However swift developers have access to the `Client` instance and can just call the dropDb method themselves!


Also some weirdness: why is `client.reconnectLocalDatabase` async but `client.dropLocalDatabaseConnection` sync?
