### PR TITLE
Fix timeout errors and add more fields to GroupWrapper

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.15.2"
+  implementation "org.xmtp:android:0.15.3"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
@@ -13,7 +13,7 @@ class GroupWrapper {
                 "clientAddress" to client.address,
                 "id" to group.id,
                 "createdAt" to group.createdAt.time,
-//                "members" to group.members().map { MemberWrapper.encode(it) },
+                "members" to group.members().map { MemberWrapper.encode(it) },
                 "version" to "GROUP",
                 "topic" to group.topic,
                 "creatorInboxId" to group.creatorInboxId(),

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
@@ -13,11 +13,12 @@ class GroupWrapper {
                 "clientAddress" to client.address,
                 "id" to group.id,
                 "createdAt" to group.createdAt.time,
-                "peerInboxIds" to group.peerInboxIds(),
+//                "members" to group.members().map { MemberWrapper.encode(it) },
                 "version" to "GROUP",
                 "topic" to group.topic,
                 "creatorInboxId" to group.creatorInboxId(),
                 "isActive" to group.isActive(),
+                "addedByInboxId" to group.addedByInboxId(),
                 "name" to group.name,
                 "imageUrlSquare" to group.imageUrlSquare,
                 "description" to group.description

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -56,7 +56,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.71.14)
   - hermes-engine/Pre-built (0.71.14)
   - libevent (2.1.12)
-  - LibXMTP (0.5.7-beta0)
+  - LibXMTP (0.5.7-beta3)
   - Logging (1.0.0)
   - MessagePacker (0.4.7)
   - MMKV (1.3.9):
@@ -449,16 +449,16 @@ PODS:
     - GenericJSON (~> 2.0)
     - Logging (~> 1.0.0)
     - secp256k1.swift (~> 0.1)
-  - XMTP (0.14.1):
+  - XMTP (0.14.6):
     - Connect-Swift (= 0.12.0)
     - GzipSwift
-    - LibXMTP (= 0.5.7-beta0)
+    - LibXMTP (= 0.5.7-beta3)
     - web3.swift
   - XMTPReactNative (0.1.0):
     - ExpoModulesCore
     - MessagePacker
     - secp256k1.swift
-    - XMTP (= 0.14.1)
+    - XMTP (= 0.14.6)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -711,7 +711,7 @@ SPEC CHECKSUMS:
   GzipSwift: 893f3e48e597a1a4f62fafcb6514220fcf8287fa
   hermes-engine: d7cc127932c89c53374452d6f93473f1970d8e88
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  LibXMTP: d80a1a7c9c748fba81d80b95c62fd075a89224a2
+  LibXMTP: b6b930f9d2394a560d7f83b02be6ccd789472422
   Logging: 9ef4ecb546ad3169398d5a723bc9bea1c46bef26
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: 817ba1eea17421547e01e087285606eb270a8dcb
@@ -763,10 +763,10 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   SwiftProtobuf: 407a385e97fd206c4fbe880cc84123989167e0d1
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: 593cf8bf4e9dc0737a6efc90a0e51fe7602101fd
-  XMTPReactNative: 1ca02155e4583791c8c99a244206ecf8e057abd2
+  XMTP: 0f36b44b3922a5933e3487bf09671655e05dcb8d
+  XMTPReactNative: 71910c6588e526d85583c1f7aeb6c83816747aea
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
-PODFILE CHECKSUM: 0e6fe50018f34e575d38dc6a1fdf1f99c9596cdd
+PODFILE CHECKSUM: 95d6ace79946933ecf80684613842ee553dd76a2
 
 COCOAPODS: 1.15.2

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -452,7 +452,7 @@ test('can get members of a group', async () => {
   const [alixClient, boClient] = await createClients(2)
   const group = await alixClient.conversations.newGroup([boClient.address])
 
-  const members = await group.members()
+  const members = group.members
 
   assert(members.length === 2, `Should be 2 members but was ${members.length}`)
 
@@ -514,10 +514,7 @@ test('can message in a group', async () => {
   if (memberInboxIds.length !== 3) {
     throw new Error('num group members should be 3')
   }
-  const peerInboxIds = await alixGroup.peerInboxIds
-  if (peerInboxIds.length !== 2) {
-    throw new Error('num peer group members should be 2')
-  }
+
   if (
     !(
       memberInboxIds.includes(alixClient.inboxId) &&
@@ -526,15 +523,6 @@ test('can message in a group', async () => {
     )
   ) {
     throw new Error('missing address')
-  }
-
-  if (
-    !(
-      peerInboxIds.includes(boClient.inboxId) &&
-      peerInboxIds.includes(caroClient.inboxId)
-    )
-  ) {
-    throw new Error('should include self')
   }
 
   // alix can send messages
@@ -2077,13 +2065,10 @@ test('can create new installation without breaking group', async () => {
   await client1Group?.sync()
   await client2Group?.sync()
 
-  assert(
-    (await client1Group?.members())?.length === 2,
-    `client 1 should see 2 members`
-  )
+  assert(client1Group?.members?.length === 2, `client 1 should see 2 members`)
 
   assert(
-    (await client2Group?.members())?.length === 2,
+    (await client2Group?.membersList())?.length === 2,
     `client 2 should see 2 members`
   )
 
@@ -2100,7 +2085,7 @@ test('can create new installation without breaking group', async () => {
 
   await client1Group?.send('This message will break the group')
   assert(
-    (await client1Group?.members())?.length === 2,
+    client1Group?.members?.length === 2,
     `client 1 should still see the 2 members`
   )
 
@@ -2112,13 +2097,13 @@ test('can list many groups members in parallel', async () => {
   const groups: Group[] = await createGroups(alix, [bo], 20, 0)
 
   try {
-    await Promise.all(groups.slice(0, 10).map((g) => g.members()))
+    await Promise.all(groups.slice(0, 10).map((g) => g.membersList()))
   } catch (e) {
     throw new Error(`Failed listing 10 groups members with ${e}`)
   }
 
   try {
-    await Promise.all(groups.slice(0, 20).map((g) => g.members()))
+    await Promise.all(groups.slice(0, 20).map((g) => g.membersList()))
   } catch (e) {
     throw new Error(`Failed listing 20 groups members with ${e}`)
   }

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -950,6 +950,8 @@ test('can stream groups', async () => {
     throw Error('Unexpected num groups (should be 1): ' + groups.length)
   }
 
+  assert(groups[0].members.length == 2, "should be 2")
+
   // bo creates a group with alix so a stream callback is fired
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const boGroup = await boClient.conversations.newGroup([alixClient.address])
@@ -2035,12 +2037,9 @@ test('can create new installation without breaking group', async () => {
     233, 120, 198, 96, 154, 65, 132, 17, 132, 96, 250, 40, 103, 35, 125, 64,
     166, 83, 208, 224, 254, 44, 205, 227, 175, 49, 234, 129, 74, 252, 135, 145,
   ])
-  const wallet1 = new Wallet(
-    '0xc54c62dd3ad018ef94f20f0722cae33919e65270ad74f2d1794291088800f788'
-  )
-  const wallet2 = new Wallet(
-    '0x8d40c1c40473975cc6bbdc0465e70cc2e98f45f3c3474ca9b809caa9c4f53c0b'
-  )
+  const wallet1 = Wallet.createRandom()
+  const wallet2 = Wallet.createRandom()
+
   const client1 = await Client.create(wallet1, {
     env: 'local',
     appVersion: 'Testing/0.0.0',

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -2109,44 +2109,58 @@ test('can create new installation without breaking group', async () => {
 
 test('can create 10 groups in parallel', async () => {
   const [client1, client2] = await createClients(2)
-  const groupsPromise: Promise<Group>[] = []
+  const groupsPromise9: Promise<Group>[] = []
 
   // Creating 9 groups in // works
   for (let index = 0; index < 9; index++) {
-    groupsPromise.push(client1.conversations.newGroup([client2.address]))
+    groupsPromise9.push(client1.conversations.newGroup([client2.address]))
   }
   console.log('Creating 9 groups...')
-  await Promise.race([
-    Promise.all(groupsPromise),
-    new Promise((_, reject) =>
-      setTimeout(
-        () =>
-          reject(
-            new Error(
-              'Creating 9 groups took more than 5 secons long to resolve'
-            )
-          ),
-        5000
-      )
-    ),
-  ])
+  await Promise.all(groupsPromise9)
   console.log('Created 9 groups')
 
+  const groupsPromise10: Promise<Group>[] = []
   // Creating 10 groups in // never resolves
   for (let index = 0; index < 10; index++) {
-    groupsPromise.push(client1.conversations.newGroup([client2.address]))
+    groupsPromise10.push(client1.conversations.newGroup([client2.address]))
   }
   console.log('Creating 10 groups...')
-  await Promise.race([
-    Promise.all(groupsPromise),
-    new Promise((_, reject) =>
-      setTimeout(
-        () => reject(new Error('Creating 9 groups worked but not 10 groups')),
-        5000
-      )
-    ),
-  ])
+  await Promise.all(groupsPromise10)
   console.log('Created 10 groups')
+
+  return true
+})
+
+test('can list many groups members in parallel', async () => {
+  const [client1, client2] = await createClients(2)
+  const groups: Group[] = []
+  for (let index = 0; index < 50; index++) {
+    groups.push(await client1.conversations.newGroup([client2.address]))
+    console.log(`Created group ${index + 1}/${50}`)
+  }
+  try {
+    console.log('Listing 10 groups members...')
+    await Promise.all(groups.slice(0, 10).map((g) => g.members()))
+    console.log('Done listing 10 groups members!')
+  } catch (e) {
+    throw new Error(`Failed listing 10 groups members with ${e}`)
+  }
+
+  try {
+    console.log('Listing 20 groups members...')
+    await Promise.all(groups.slice(0, 20).map((g) => g.members()))
+    console.log('Done listing 20 groups members!')
+  } catch (e) {
+    throw new Error(`Failed listing 20 groups members with ${e}`)
+  }
+
+  try {
+    console.log('Listing 50 groups members...')
+    await Promise.all(groups.slice(0, 50).map((g) => g.members()))
+    console.log('Done listing 50 groups members!')
+  } catch (e) {
+    throw new Error(`Failed listing 50 groups members with ${e}`)
+  }
 
   return true
 })

--- a/ios/Wrappers/GroupWrapper.swift
+++ b/ios/Wrappers/GroupWrapper.swift
@@ -20,6 +20,7 @@ struct GroupWrapper {
 			"topic": group.topic,
 			"creatorInboxId": try group.creatorInboxId(),
 			"isActive": try group.isActive(),
+			"addedByInboxId": try group.addedByInboxId(),
 			"name": try group.groupName(),
 			"imageUrlSquare": try group.groupImageUrlSquare(),
 			"description": try group.groupDescription()

--- a/ios/Wrappers/GroupWrapper.swift
+++ b/ios/Wrappers/GroupWrapper.swift
@@ -15,7 +15,7 @@ struct GroupWrapper {
 			"clientAddress": client.address,
 			"id": group.id,
 			"createdAt": UInt64(group.createdAt.timeIntervalSince1970 * 1000),
-			"peerInboxIds": try group.peerInboxIds,
+			"members": try group.members.compactMap { member in return try MemberWrapper.encode(member) },
 			"version": "GROUP",
 			"topic": group.topic,
 			"creatorInboxId": try group.creatorInboxId(),

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
   s.dependency 'secp256k1.swift'
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.14.5"
+  s.dependency "XMTP", "= 0.14.6"
 end

--- a/src/lib/Conversations.ts
+++ b/src/lib/Conversations.ts
@@ -8,6 +8,7 @@ import {
 } from './ConversationContainer'
 import { DecodedMessage } from './DecodedMessage'
 import { Group, GroupParams } from './Group'
+import { Member } from './Member'
 import { CreateGroupOptions } from './types/CreateGroupOptions'
 import { EventTypes } from './types/EventTypes'
 import { PermissionPolicySet } from './types/PermissionPolicySet'
@@ -149,7 +150,10 @@ export default class Conversations<
           return
         }
         this.known[group.id] = true
-        await callback(new Group(this.client, group))
+        const members = group['members'].map((mem: string) => {
+          return Member.from(mem)
+        })
+        await callback(new Group(this.client, group, members))
       }
     )
     this.subscriptions[EventTypes.Group] = groupsSubscription
@@ -286,10 +290,16 @@ export default class Conversations<
 
         this.known[conversationContainer.topic] = true
         if (conversationContainer.version === ConversationVersion.GROUP) {
+          const members = conversationContainer['members'].map(
+            (mem: string) => {
+              return Member.from(mem)
+            }
+          )
           return await callback(
             new Group(
               this.client,
-              conversationContainer as unknown as GroupParams
+              conversationContainer as unknown as GroupParams,
+              members
             )
           )
         } else {

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -18,11 +18,12 @@ export type PermissionUpdateOption = 'allow' | 'deny' | 'admin' | 'super_admin'
 export interface GroupParams {
   id: string
   createdAt: number
-  peerInboxIds: InboxId[]
+  // members: Member[]
   creatorInboxId: InboxId
   topic: string
   name: string
   isActive: boolean
+  addedByInboxId: InboxId
   imageUrlSquare: string
   description: string
 }
@@ -34,12 +35,13 @@ export class Group<
   client: XMTP.Client<ContentTypes>
   id: string
   createdAt: number
-  peerInboxIds: InboxId[]
+  // members: Member[]
   version = ConversationVersion.GROUP
   topic: string
   creatorInboxId: InboxId
   name: string
   isGroupActive: boolean
+  addedByInboxId: InboxId
   imageUrlSquare: string
   description: string
   // pinnedFrameUrl: string
@@ -48,11 +50,12 @@ export class Group<
     this.client = client
     this.id = params.id
     this.createdAt = params.createdAt
-    this.peerInboxIds = params.peerInboxIds
+    // this.members = params.members
     this.topic = params.topic
     this.creatorInboxId = params.creatorInboxId
     this.name = params.name
     this.isGroupActive = params.isActive
+    this.addedByInboxId = params.addedByInboxId
     this.imageUrlSquare = params.imageUrlSquare
     this.description = params.description
     // this.pinnedFrameUrl = params.pinnedFrameUrl
@@ -371,15 +374,6 @@ export class Group<
 
   async isActive(): Promise<boolean> {
     return XMTP.isGroupActive(this.client.inboxId, this.id)
-  }
-
-  /**
-   * Returns the inbox id that added you to the group.
-   * To get the latest added by inbox id from the network, call sync() first.
-   * @returns {Promise<string>} A Promise that resolves to the inbox id that added you to the group.
-   */
-  async addedByInboxId(): Promise<InboxId> {
-    return XMTP.addedByInboxId(this.client.inboxId, this.id)
   }
 
   /**

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -18,6 +18,7 @@ export type PermissionUpdateOption = 'allow' | 'deny' | 'admin' | 'super_admin'
 export interface GroupParams {
   id: string
   createdAt: number
+  members: string[]
   creatorInboxId: InboxId
   topic: string
   name: string

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -18,7 +18,6 @@ export type PermissionUpdateOption = 'allow' | 'deny' | 'admin' | 'super_admin'
 export interface GroupParams {
   id: string
   createdAt: number
-  // members: Member[]
   creatorInboxId: InboxId
   topic: string
   name: string
@@ -35,7 +34,7 @@ export class Group<
   client: XMTP.Client<ContentTypes>
   id: string
   createdAt: number
-  // members: Member[]
+  members: Member[]
   version = ConversationVersion.GROUP
   topic: string
   creatorInboxId: InboxId
@@ -46,11 +45,15 @@ export class Group<
   description: string
   // pinnedFrameUrl: string
 
-  constructor(client: XMTP.Client<ContentTypes>, params: GroupParams) {
+  constructor(
+    client: XMTP.Client<ContentTypes>,
+    params: GroupParams,
+    members: Member[]
+  ) {
     this.client = client
     this.id = params.id
     this.createdAt = params.createdAt
-    // this.members = params.members
+    this.members = members
     this.topic = params.topic
     this.creatorInboxId = params.creatorInboxId
     this.name = params.name
@@ -628,7 +631,7 @@ export class Group<
    * @returns {Promise<Member[]>} A Promise that resolves to an array of Member objects.
    * To get the latest member list from the network, call sync() first.
    */
-  async members(): Promise<Member[]> {
+  async membersList(): Promise<Member[]> {
     return await XMTP.listGroupMembers(this.client.inboxId, this.id)
   }
 }


### PR DESCRIPTION
Exploring the RN thread getting completely locked sometimes, I managed to create 3 reproducible tests:

- creating 10 groups in // : not a real use case but interesting to see that creating 9 groups in // works all of the time, creating 10 groups in // fails all of the time, on iOS + Android
- listing many groups' members in // : this is closer to what we do in Converse and it's interesting to see that Android is able to list 50 groups's members in // while iOS fails at 20
- doing other stuff not linked to the database while we have locked the database => other RN methods should still work, but they get blocked until the timeout throws, the whole thread is blocked

These lock last 30 seconds (I guess that's the duration of the db lock?)
During these 30 seconds, no other call to the SDK resolves (even calls to the SDK that don't rely on the database, like `canMessage` v2 version - the call just does not reach the native code)

Also in Converse it happens in a loop because during the sync process
- try to sync => cause a 30 sec lock & timout
- after 30 sec fail => retries a sync

There is an increasing backoff for retries but it explains why it looks like the app is "bricked" forever, as soon as it gets unlocked, it goes into a lock again.

We should probably understand why these calls cause a timeout and fix it (creating 10 groups should be possible, even if we need to wait a bit for the pool, here it seems we never get back the pool connection and it times out)

We should also understand why if one async call to the sdk is locking, other calls to the sdk, even not using the database, lock as well => should a pool connection awaitance cause a thread lock?

![Capture d’écran 2024-08-15 à 14 25 52](https://github.com/user-attachments/assets/b6019892-b7ff-4fab-b512-7dd12fc68997)
