### PR TITLE
feat: added static function for clearing a client for a given inboxId from memory

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -371,6 +371,13 @@ class XMTPModule : Module() {
             }
         }
 
+        AsyncFunction("dropClient") Coroutine { inboxId: String ->
+            withContext(Dispatchers.IO) {
+                logV("dropClient")
+                clients.remove(inboxId)
+            }
+        }
+
         AsyncFunction("sign") Coroutine { inboxId: String, digest: List<Int>, keyType: String, preKeyIndex: Int ->
             withContext(Dispatchers.IO) {
                 logV("sign")

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -1,6 +1,5 @@
 import { Wallet } from 'ethers'
 import { Platform } from 'expo-modules-core'
-import RNFS from 'react-native-fs'
 import { DecodedMessage } from 'xmtp-react-native-sdk/lib/DecodedMessage'
 
 import { Test, assert, createClients, delayToPropogate } from './test-utils'
@@ -291,6 +290,23 @@ test('can drop a local database', async () => {
     return true
   }
   throw new Error('should throw when local database not connected')
+})
+
+test('can drop client from memory', async () => {
+  const [client, anotherClient] = await createClients(2)
+  await client.dropLocalDatabaseConnection()
+  await anotherClient.dropLocalDatabaseConnection()
+
+  await client.reconnectLocalDatabase()
+  await Client.dropClient(anotherClient.inboxId)
+  try {
+    await anotherClient.reconnectLocalDatabase()
+    return false
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (error) {
+    // We cannot reconnect anotherClient because it was successfully dropped
+    return true
+  }
 })
 
 test('can get a inboxId from an address', async () => {
@@ -988,7 +1004,7 @@ test('can stream groups', async () => {
     throw Error('Unexpected num groups (should be 1): ' + groups.length)
   }
 
-  assert(groups[0].members.length == 2, 'should be 2')
+  assert(groups[0].members.length === 2, 'should be 2')
 
   // bo creates a group with alix so a stream callback is fired
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -53,6 +53,11 @@ public class XMTPModule: Module {
 			ContentJson.initCodecs(client: client)
 			clients[key] = client
 		}
+        
+        // A method to drop client for a given key from memory
+        func dropClient(key: String) {
+            clients[key] = nil
+        }
 
 		// A method to retrieve a client
 		func getClient(key: String) -> XMTP.Client? {
@@ -271,10 +276,15 @@ public class XMTPModule: Module {
 				await clientsManager.updateClient(key: client.inboxID, client: client)
 				return try ClientWrapper.encodeToObj(client)
 			} catch {
-				print("ERRO! Failed to create client: \(error)")
+				print("ERROR! Failed to create client: \(error)")
 				throw error
 			}
 		}
+        
+        // Remove a client from memory for a given inboxId
+        AsyncFunction("dropClient") { (inboxId: String) in
+            await clientsManager.dropClient(key: inboxId)
+        }
 		
 		AsyncFunction("sign") { (inboxId: String, digest: [UInt8], keyType: String, preKeyIndex: Int) -> [UInt8] in
 			guard let client = await clientsManager.getClient(key: inboxId) else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,6 +178,10 @@ export async function createFromKeyBundle(
   )
 }
 
+export async function dropClient(inboxId: string) {
+  return await XMTPModule.dropClient(inboxId)
+}
+
 export async function createGroup<
   ContentTypes extends DefaultContentTypes = DefaultContentTypes,
 >(

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -254,6 +254,13 @@ export class Client<
   }
 
   /**
+   * Drop the client from memory. Use when you want to remove the client from memory and are done with it.
+   */
+  static async dropClient(inboxId: string) {
+    return await XMTPModule.dropClient(inboxId)
+  }
+
+  /**
    * Static method to determine if the address is currently in our network.
    *
    * This method checks if the specified peer has signed up for XMTP.


### PR DESCRIPTION
New function is particularly useful for iOS apps that automatically try and reconnect all local database connections for all cached clients when their app becomes active:

https://github.com/xmtp/xmtp-react-native/blob/795f14e44046bb022ff49a27a3cc91fa4fa6ce2a/ios/XMTPModule.swift#L1544C3-L1548C4


See test for usage:

```typescript
test('can drop client from memory', async () => {
  const [client, anotherClient] = await createClients(2)
  await client.dropLocalDatabaseConnection()
  await anotherClient.dropLocalDatabaseConnection()

  await client.reconnectLocalDatabase()
  await Client.dropClient(anotherClient.inboxId)
  try {
    await anotherClient.reconnectLocalDatabase()
    return false
    // eslint-disable-next-line @typescript-eslint/no-unused-vars
  } catch (error) {
    // We cannot reconnect anotherClient because it was successfully dropped
    return true
  }
})
```