### PR TITLE
Bump to latest versions of libxmtp

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.15.6"
+  implementation "org.xmtp:android:0.15.7"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
   s.dependency 'secp256k1.swift'
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.14.9"
+  s.dependency "XMTP", "= 0.14.10"
 end


### PR DESCRIPTION
## What's Changed
* Stop setting new lifetimes by @neekolas in https://github.com/xmtp/libxmtp/pull/964
* Add libxmtp version to requests by @neekolas in https://github.com/xmtp/libxmtp/pull/1011
* Store or ignore group messages by @neekolas in https://github.com/xmtp/libxmtp/pull/1019
* Fix send update interval ns calculation, move to configuration by @cameronvoell in https://github.com/xmtp/libxmtp/pull/1008
* Create group with initial members by @neekolas in https://github.com/xmtp/libxmtp/pull/1020
* Retry PoolNeedsConnection Errors by @nplasterer in https://github.com/xmtp/libxmtp/pull/1010
* Skip duplicate message processing by @neekolas https://github.com/xmtp/libxmtp/pull/1022