### PR TITLE
FAILING test in dev env for streaming groups and messages at the same time

### DIFF
--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -1248,29 +1248,23 @@ test('can stream all groups and conversations', async () => {
 })
 
 test('can stream groups and messages', async () => {
-  for (const env of ['local', 'dev'] as const) {
-    const [alixClient, boClient] = await createClients(2, env)
+  const [alixClient, boClient] = await createClients(2)
 
-    // Start streaming groups
-    const groups: Group<any>[] = []
-    await alixClient.conversations.streamGroups(async (group: Group<any>) => {
-      groups.push(group)
-    })
-    // Also stream messages
-    await alixClient.conversations.streamAllMessages(
-      async (message) => {},
-      true
-    )
+  // Start streaming groups
+  const groups: Group<any>[] = []
+  await alixClient.conversations.streamGroups(async (group: Group<any>) => {
+    groups.push(group)
+  })
+  // Stream messages twice
+  await alixClient.conversations.streamAllMessages(async (message) => {}, true)
+  await alixClient.conversations.streamAllMessages(async (message) => {}, true)
 
-    // bo creates a group with alix so a stream callback is fired
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    await boClient.conversations.newGroup([alixClient.address])
-    await delayToPropogate()
-    if ((groups.length as number) !== 1) {
-      throw Error(
-        `Test fails in env ${env}: Unexpected num groups (should be 1): ${groups.length}`
-      )
-    }
+  // bo creates a group with alix so a stream callback is fired
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  await boClient.conversations.newGroup([alixClient.address])
+  await delayToPropogate(2000)
+  if ((groups.length as number) !== 1) {
+    throw Error(`Unexpected num groups (should be 1): ${groups.length}`)
   }
 
   return true

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -1247,6 +1247,35 @@ test('can stream all groups and conversations', async () => {
   return true
 })
 
+test('can stream groups and messages', async () => {
+  for (const env of ['local', 'dev'] as const) {
+    const [alixClient, boClient] = await createClients(2, env)
+
+    // Start streaming groups
+    const groups: Group<any>[] = []
+    await alixClient.conversations.streamGroups(async (group: Group<any>) => {
+      groups.push(group)
+    })
+    // Also stream messages
+    await alixClient.conversations.streamAllMessages(
+      async (message) => {},
+      true
+    )
+
+    // bo creates a group with alix so a stream callback is fired
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    await boClient.conversations.newGroup([alixClient.address])
+    await delayToPropogate()
+    if ((groups.length as number) !== 1) {
+      throw Error(
+        `Test fails in env ${env}: Unexpected num groups (should be 1): ${groups.length}`
+      )
+    }
+  }
+
+  return true
+})
+
 test('canMessage', async () => {
   const [bo, alix, caro] = await createClients(3)
 

--- a/example/src/tests/test-utils.ts
+++ b/example/src/tests/test-utils.ts
@@ -21,10 +21,7 @@ export function assert(condition: boolean, msg: string) {
   }
 }
 
-export async function createClients(
-  numClients: number,
-  env: 'dev' | 'local' | 'production' = 'local'
-): Promise<Client[]> {
+export async function createClients(numClients: number): Promise<Client[]> {
   const clients = []
   for (let i = 0; i < numClients; i++) {
     const keyBytes = new Uint8Array([
@@ -33,7 +30,7 @@ export async function createClients(
       145,
     ])
     const client = await Client.createRandom({
-      env,
+      env: 'local',
       enableV3: true,
       dbEncryptionKey: keyBytes,
     })

--- a/example/src/tests/test-utils.ts
+++ b/example/src/tests/test-utils.ts
@@ -21,7 +21,10 @@ export function assert(condition: boolean, msg: string) {
   }
 }
 
-export async function createClients(numClients: number): Promise<Client[]> {
+export async function createClients(
+  numClients: number,
+  env: 'dev' | 'local' | 'production' = 'local'
+): Promise<Client[]> {
   const clients = []
   for (let i = 0; i < numClients; i++) {
     const keyBytes = new Uint8Array([
@@ -30,7 +33,7 @@ export async function createClients(numClients: number): Promise<Client[]> {
       145,
     ])
     const client = await Client.createRandom({
-      env: 'local',
+      env,
       enableV3: true,
       dbEncryptionKey: keyBytes,
     })


### PR DESCRIPTION
While working on group invite links, I noticed that when joining a group, sometimes Converse didn't detect the new group that had just been joined and did not redirect to it
By commenting parts of the code it seems to be linked to streaming groups & messages at the same time
I actually can make the attached test fail in `dev` env but not in `local`: if I streamAllMessages, I can't stream groups anymore!

![Capture d’écran 2024-09-12 à 15 59 53](https://github.com/user-attachments/assets/4641052a-bf9a-445f-8bdc-63e8857ca46d)
