### PR TITLE
Failing test group members formatting

### DIFF
--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -2261,6 +2261,24 @@ test('can sync all groups', async () => {
   return true
 })
 
+test('group members and 1:1 peerAddresses should have same formatting', async () => {
+  const [alix, bo] = await createClients(2)
+  const convo1v1 = await alix.conversations.newConversation(bo.address)
+  assert(
+    convo1v1.peerAddress === bo.address,
+    '1:1 peerAddress is not well formatted'
+  )
+
+  const group = await alix.conversations.newGroup([bo.address])
+  assert(
+    group.members.some((m) => m.addresses.includes(bo.address)) &&
+      group.members.some((m) => m.addresses.includes(alix.address)),
+    'group members addresses are not well formatted'
+  )
+
+  return true
+})
+
 // Commenting this out so it doesn't block people, but nice to have?
 // test('can stream messages for a long time', async () => {
 //   const bo = await Client.createRandom({ env: 'local', enableV3: true })


### PR DESCRIPTION
Investigating failing profiles on Converse I saw that while `client.address` and `1v1conversation.peerAddress` return formatted addresses  while group members return lowercased addresses

I think it would be best to match what has existed in the SDK for a long time and have formatted addresses for group members as well because we rely a lot on string comparison!

N.B: maybe this needs to be fixed at a lower lever than RN (not sure how it's handled in native SDKs/libxmtp)