### PR TITLE
Noe/fix group streams issues

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -449,7 +449,7 @@ PODS:
     - GenericJSON (~> 2.0)
     - Logging (~> 1.0.0)
     - secp256k1.swift (~> 0.1)
-  - XMTP (0.14.17):
+  - XMTP (0.14.18):
     - Connect-Swift (= 0.12.0)
     - GzipSwift
     - LibXMTP (= 0.5.8-beta7)
@@ -458,7 +458,7 @@ PODS:
     - ExpoModulesCore
     - MessagePacker
     - secp256k1.swift
-    - XMTP (= 0.14.17)
+    - XMTP (= 0.14.18)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -763,8 +763,8 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   SwiftProtobuf: 407a385e97fd206c4fbe880cc84123989167e0d1
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: 64600a3216ef8bfb074a128cffe37458b23c52fd
-  XMTPReactNative: 39e85c5215efa8cb7900285dc95319402758d85b
+  XMTP: ad01d17d7b513704b00033ee72ed544e48d38fcf
+  XMTPReactNative: 4f4256484300b6f1cbbfbdcbbf110c00c5513760
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
 PODFILE CHECKSUM: 0e6fe50018f34e575d38dc6a1fdf1f99c9596cdd

--- a/example/ios/xmtpreactnativesdkexample.xcodeproj/project.pbxproj
+++ b/example/ios/xmtpreactnativesdkexample.xcodeproj/project.pbxproj
@@ -294,12 +294,10 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample-frameworks.sh",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -2323,6 +2323,38 @@ test('only streams groups that can be decrypted', async () => {
   return true
 })
 
+test('can stream groups and messages', async () => {
+  for (let index = 0; index < 15; index++) {
+    console.log(`stream groups & messages: test ${index}`)
+    const [alixClient, boClient] = await createClients(2)
+
+    // Start streaming groups
+    const groups: Group<any>[] = []
+    await alixClient.conversations.streamGroups(async (group: Group<any>) => {
+      groups.push(group)
+    })
+    // Stream messages twice
+    await alixClient.conversations.streamAllMessages(
+      async (message) => {},
+      true
+    )
+    await alixClient.conversations.streamAllMessages(
+      async (message) => {},
+      true
+    )
+
+    // bo creates a group with alix so a stream callback is fired
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    await boClient.conversations.newGroup([alixClient.address])
+    await delayToPropogate(500)
+    if ((groups.length as number) !== 1) {
+      throw Error(`Unexpected num groups (should be 1): ${groups.length}`)
+    }
+  }
+
+  return true
+})
+
 // Commenting this out so it doesn't block people, but nice to have?
 // test('can stream messages for a long time', async () => {
 //   const bo = await Client.createRandom({ env: 'local', enableV3: true })

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -993,6 +993,8 @@ test('can cancel streams', async () => {
     messageCallbacks++
   }, true)
 
+  await delayToPropogate()
+
   await group.send('hello')
   await delayToPropogate()
 

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -3,7 +3,13 @@ import { Platform } from 'expo-modules-core'
 import RNFS from 'react-native-fs'
 import { DecodedMessage } from 'xmtp-react-native-sdk/lib/DecodedMessage'
 
-import { Test, assert, createClients, createGroups, delayToPropogate } from './test-utils'
+import {
+  Test,
+  assert,
+  createClients,
+  createGroups,
+  delayToPropogate,
+} from './test-utils'
 import {
   Client,
   Conversation,
@@ -2107,6 +2113,8 @@ test('can list groups does not fork', async () => {
     boMessages2.length === 5,
     `should have 5 messages on second load received ${boMessages2.length}`
   )
+
+  await delayToPropogate(500)
 
   assert(groupCallbacks === 1, 'group stream should have received 1 group')
 

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
   s.dependency 'secp256k1.swift'
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 0.14.17"
+  s.dependency "XMTP", "= 0.14.18"
 end

--- a/src/lib/Conversations.ts
+++ b/src/lib/Conversations.ts
@@ -146,7 +146,7 @@ export default class Conversations<
     const groupsSubscription = XMTPModule.emitter.addListener(
       EventTypes.Group,
       async ({ inboxId, group }: { inboxId: string; group: GroupParams }) => {
-        if (this.known[group.id] || this.client.inboxId !== inboxId) {
+        if (this.client.inboxId !== inboxId) {
           return
         }
         this.known[group.id] = true


### PR DESCRIPTION
- removed the check for `this.known` when streaming a group because we might call somewhere else `listGroups` which will mark the group as known but we still want it to get streamed. If there are other effects of this check @nplasterer let's discuss!
- added a small delay in a test after streaming to be sure the stream is opened before sending a message
- added a failing test when streaming both messages & groups in iOS, that is fixed by this Swift PR: https://github.com/xmtp/xmtp-ios/pull/406