### PR TITLE
Consent V3

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -1614,7 +1614,7 @@ class XMTPModule : Module() {
             withContext(Dispatchers.IO) {
                 val group = findGroup(inboxId, groupId)
                     ?: throw XMTPException("no group found for $groupId")
-                consentStateToString(Conversation.Group(group).consentState())
+                consentStateToString(group.consentState())
             }
         }
 

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
@@ -2,13 +2,18 @@ package expo.modules.xmtpreactnativesdk.wrappers
 
 import com.google.gson.GsonBuilder
 import org.xmtp.android.library.Client
+import org.xmtp.android.library.ConsentState
 import org.xmtp.android.library.Group
-import org.xmtp.android.library.toHex
 
 class GroupWrapper {
 
     companion object {
         suspend fun encodeToObj(client: Client, group: Group): Map<String, Any> {
+            val consentString = when (group.consentState()) {
+                ConsentState.ALLOWED -> "allowed"
+                ConsentState.DENIED -> "denied"
+                ConsentState.UNKNOWN -> "unknown"
+            }
             return mapOf(
                 "clientAddress" to client.address,
                 "id" to group.id,
@@ -21,7 +26,8 @@ class GroupWrapper {
                 "addedByInboxId" to group.addedByInboxId(),
                 "name" to group.name,
                 "imageUrlSquare" to group.imageUrlSquare,
-                "description" to group.description
+                "description" to group.description,
+                "consentState" to consentString
                 // "pinnedFrameUrl" to group.pinnedFrameUrl
             )
         }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
@@ -1,19 +1,14 @@
 package expo.modules.xmtpreactnativesdk.wrappers
 
 import com.google.gson.GsonBuilder
+import expo.modules.xmtpreactnativesdk.wrappers.ConsentWrapper.Companion.consentStateToString
 import org.xmtp.android.library.Client
-import org.xmtp.android.library.ConsentState
 import org.xmtp.android.library.Group
 
 class GroupWrapper {
 
     companion object {
         suspend fun encodeToObj(client: Client, group: Group): Map<String, Any> {
-            val consentString = when (group.consentState()) {
-                ConsentState.ALLOWED -> "allowed"
-                ConsentState.DENIED -> "denied"
-                ConsentState.UNKNOWN -> "unknown"
-            }
             return mapOf(
                 "clientAddress" to client.address,
                 "id" to group.id,
@@ -27,7 +22,7 @@ class GroupWrapper {
                 "name" to group.name,
                 "imageUrlSquare" to group.imageUrlSquare,
                 "description" to group.description,
-                "consentState" to consentString
+                "consentState" to consentStateToString(group.consentState())
                 // "pinnedFrameUrl" to group.pinnedFrameUrl
             )
         }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/MemberWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/MemberWrapper.kt
@@ -1,7 +1,6 @@
 package expo.modules.xmtpreactnativesdk.wrappers
 
 import com.google.gson.GsonBuilder
-import org.xmtp.android.library.ConsentState
 import org.xmtp.android.library.libxmtp.Member
 import org.xmtp.android.library.libxmtp.PermissionLevel
 
@@ -13,16 +12,11 @@ class MemberWrapper {
                 PermissionLevel.ADMIN -> "admin"
                 PermissionLevel.SUPER_ADMIN -> "super_admin"
             }
-            val consentString = when (member.consentState) {
-                ConsentState.ALLOWED -> "allowed"
-                ConsentState.DENIED -> "denied"
-                ConsentState.UNKNOWN -> "unknown"
-            }
             return mapOf(
                 "inboxId" to member.inboxId,
                 "addresses" to member.addresses,
                 "permissionLevel" to permissionString,
-                "consentState" to consentString
+                "consentState" to ConsentWrapper.consentStateToString(member.consentState)
             )
         }
 

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/MemberWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/MemberWrapper.kt
@@ -1,6 +1,7 @@
 package expo.modules.xmtpreactnativesdk.wrappers
 
 import com.google.gson.GsonBuilder
+import org.xmtp.android.library.ConsentState
 import org.xmtp.android.library.libxmtp.Member
 import org.xmtp.android.library.libxmtp.PermissionLevel
 
@@ -12,10 +13,16 @@ class MemberWrapper {
                 PermissionLevel.ADMIN -> "admin"
                 PermissionLevel.SUPER_ADMIN -> "super_admin"
             }
+            val consentString = when (member.consentState) {
+                ConsentState.ALLOWED -> "allowed"
+                ConsentState.DENIED -> "denied"
+                ConsentState.UNKNOWN -> "unknown"
+            }
             return mapOf(
                 "inboxId" to member.inboxId,
                 "addresses" to member.addresses,
-                "permissionLevel" to permissionString
+                "permissionLevel" to permissionString,
+                "consentState" to consentString
             )
         }
 

--- a/example/ios/xmtpreactnativesdkexample.xcodeproj/project.pbxproj
+++ b/example/ios/xmtpreactnativesdkexample.xcodeproj/project.pbxproj
@@ -294,10 +294,12 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-xmtpreactnativesdkexample/Pods-xmtpreactnativesdkexample-frameworks.sh",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/example/src/tests/v3OnlyTests.ts
+++ b/example/src/tests/v3OnlyTests.ts
@@ -99,7 +99,7 @@ test('can group consent', async () => {
 
   const isAllowed = await boV3.contacts.isGroupAllowed(group.id)
   assert(isAllowed === true, `isAllowed should be true but was ${isAllowed}`)
-  let groupState = await group.consentState
+  let groupState = await group.state
   assert(
     groupState === 'allowed',
     `group state should be allowed but was ${groupState}`
@@ -109,7 +109,7 @@ test('can group consent', async () => {
 
   const isDenied = await boV3.contacts.isGroupDenied(group.id)
   assert(isDenied === true, `isDenied should be true but was ${isDenied}`)
-  groupState = await group.consentState
+  groupState = await group.consentState()
   assert(
     groupState === 'denied',
     `group state should be denied but was ${groupState}`
@@ -119,7 +119,7 @@ test('can group consent', async () => {
 
   const isAllowed2 = await boV3.contacts.isGroupAllowed(group.id)
   assert(isAllowed2 === true, `isAllowed2 should be true but was ${isAllowed2}`)
-  groupState = await group.consentState
+  groupState = await group.consentState()
   assert(
     groupState === 'allowed',
     `group state should be allowed but was ${groupState}`
@@ -145,7 +145,7 @@ test('can allow and deny inbox ids', async () => {
 
   await boV3.contacts.allowInboxes([caroV2V3.inboxId])
 
-  let caroMember = boGroup.members.find(
+  let caroMember = (await boGroup.membersList()).find(
     (member) => member.inboxId === caroV2V3.inboxId
   )
   assert(
@@ -157,11 +157,11 @@ test('can allow and deny inbox ids', async () => {
   isInboxDenied = await boV3.contacts.isInboxDenied(caroV2V3.inboxId)
   assert(
     isInboxAllowed === true,
-    `isInboxAllowed should be true but was ${isInboxAllowed}`
+    `isInboxAllowed2 should be true but was ${isInboxAllowed}`
   )
   assert(
-    isInboxDenied === true,
-    `isInboxDenied should be true but was ${isInboxDenied}`
+    isInboxDenied === false,
+    `isInboxDenied2 should be false but was ${isInboxDenied}`
   )
 
   let isAddressAllowed = await boV3.contacts.isAllowed(caroV2V3.address)
@@ -177,7 +177,7 @@ test('can allow and deny inbox ids', async () => {
 
   await boV3.contacts.denyInboxes([caroV2V3.inboxId])
 
-  caroMember = boGroup.members.find(
+  caroMember = (await boGroup.membersList()).find(
     (member) => member.inboxId === caroV2V3.inboxId
   )
   assert(
@@ -189,11 +189,11 @@ test('can allow and deny inbox ids', async () => {
   isInboxDenied = await boV3.contacts.isInboxDenied(caroV2V3.inboxId)
   assert(
     isInboxAllowed === false,
-    `isInboxAllowed should be false but was ${isInboxAllowed}`
+    `isInboxAllowed3 should be false but was ${isInboxAllowed}`
   )
   assert(
     isInboxDenied === true,
-    `isInboxDenied should be true but was ${isInboxDenied}`
+    `isInboxDenied3 should be true but was ${isInboxDenied}`
   )
 
   await boV3.contacts.allow([alixV2.address])
@@ -202,11 +202,11 @@ test('can allow and deny inbox ids', async () => {
   isAddressDenied = await boV3.contacts.isDenied(alixV2.address)
   assert(
     isAddressAllowed === true,
-    `isAddressAllowed should be true but was ${isAddressAllowed}`
+    `isAddressAllowed2 should be true but was ${isAddressAllowed}`
   )
   assert(
     isAddressDenied === false,
-    `isAddressDenied should be false but was ${isAddressDenied}`
+    `isAddressDenied2 should be false but was ${isAddressDenied}`
   )
 
   return true

--- a/example/src/tests/v3OnlyTests.ts
+++ b/example/src/tests/v3OnlyTests.ts
@@ -93,6 +93,125 @@ test('can send message', async () => {
   return true
 })
 
+test('can group consent', async () => {
+  const [alixV2, boV3, caroV2V3] = await createV3TestingClients()
+  const group = await boV3.conversations.newGroup([caroV2V3.address])
+
+  const isAllowed = await boV3.contacts.isGroupAllowed(group.id)
+  assert(isAllowed === true, `isAllowed should be true but was ${isAllowed}`)
+  let groupState = await group.consentState
+  assert(
+    groupState === 'allowed',
+    `group state should be allowed but was ${groupState}`
+  )
+
+  await boV3.contacts.denyGroups([group.id])
+
+  const isDenied = await boV3.contacts.isGroupDenied(group.id)
+  assert(isDenied === true, `isDenied should be true but was ${isDenied}`)
+  groupState = await group.consentState
+  assert(
+    groupState === 'denied',
+    `group state should be denied but was ${groupState}`
+  )
+
+  await group.updateConsent('allowed')
+
+  const isAllowed2 = await boV3.contacts.isGroupAllowed(group.id)
+  assert(isAllowed2 === true, `isAllowed2 should be true but was ${isAllowed2}`)
+  groupState = await group.consentState
+  assert(
+    groupState === 'allowed',
+    `group state should be allowed but was ${groupState}`
+  )
+
+  return true
+})
+
+test('can allow and deny inbox ids', async () => {
+  const [alixV2, boV3, caroV2V3] = await createV3TestingClients()
+  const boGroup = await boV3.conversations.newGroup([caroV2V3.address])
+
+  let isInboxAllowed = await boV3.contacts.isInboxAllowed(caroV2V3.inboxId)
+  let isInboxDenied = await boV3.contacts.isInboxDenied(caroV2V3.inboxId)
+  assert(
+    isInboxAllowed === false,
+    `isInboxAllowed should be false but was ${isInboxAllowed}`
+  )
+  assert(
+    isInboxDenied === false,
+    `isInboxDenied should be false but was ${isInboxDenied}`
+  )
+
+  await boV3.contacts.allowInboxes([caroV2V3.inboxId])
+
+  let caroMember = boGroup.members.find(
+    (member) => member.inboxId === caroV2V3.inboxId
+  )
+  assert(
+    caroMember?.consentState === 'allowed',
+    `caroMember should be allowed but was ${caroMember?.consentState}`
+  )
+
+  isInboxAllowed = await boV3.contacts.isInboxAllowed(caroV2V3.inboxId)
+  isInboxDenied = await boV3.contacts.isInboxDenied(caroV2V3.inboxId)
+  assert(
+    isInboxAllowed === true,
+    `isInboxAllowed should be true but was ${isInboxAllowed}`
+  )
+  assert(
+    isInboxDenied === true,
+    `isInboxDenied should be true but was ${isInboxDenied}`
+  )
+
+  let isAddressAllowed = await boV3.contacts.isAllowed(caroV2V3.address)
+  let isAddressDenied = await boV3.contacts.isDenied(caroV2V3.address)
+  assert(
+    isAddressAllowed === true,
+    `isAddressAllowed should be true but was ${isAddressAllowed}`
+  )
+  assert(
+    isAddressDenied === false,
+    `isAddressDenied should be false but was ${isAddressDenied}`
+  )
+
+  await boV3.contacts.denyInboxes([caroV2V3.inboxId])
+
+  caroMember = boGroup.members.find(
+    (member) => member.inboxId === caroV2V3.inboxId
+  )
+  assert(
+    caroMember?.consentState === 'denied',
+    `caroMember should be denied but was ${caroMember?.consentState}`
+  )
+
+  isInboxAllowed = await boV3.contacts.isInboxAllowed(caroV2V3.inboxId)
+  isInboxDenied = await boV3.contacts.isInboxDenied(caroV2V3.inboxId)
+  assert(
+    isInboxAllowed === false,
+    `isInboxAllowed should be false but was ${isInboxAllowed}`
+  )
+  assert(
+    isInboxDenied === true,
+    `isInboxDenied should be true but was ${isInboxDenied}`
+  )
+
+  await boV3.contacts.allow([alixV2.address])
+
+  isAddressAllowed = await boV3.contacts.isAllowed(alixV2.address)
+  isAddressDenied = await boV3.contacts.isDenied(alixV2.address)
+  assert(
+    isAddressAllowed === true,
+    `isAddressAllowed should be true but was ${isAddressAllowed}`
+  )
+  assert(
+    isAddressDenied === false,
+    `isAddressDenied should be false but was ${isAddressDenied}`
+  )
+
+  return true
+})
+
 test('can stream all messages', async () => {
   const [alixV2, boV3, caroV2V3] = await createV3TestingClients()
   const conversation = await alixV2.conversations.newConversation(

--- a/ios/Wrappers/GroupWrapper.swift
+++ b/ios/Wrappers/GroupWrapper.swift
@@ -11,14 +11,6 @@ import XMTP
 // Wrapper around XMTP.Group to allow passing these objects back into react native.
 struct GroupWrapper {
 	static func encodeToObj(_ group: XMTP.Group, client: XMTP.Client) async throws -> [String: Any] {
-		let consentString = switch try group.consentState() {
-		case .allowed:
-			"allowed"
-		case .denied:
-			"denied"
-		case .unknown:
-			"unknown"
-		}
 		return [
 			"clientAddress": client.address,
 			"id": group.id,
@@ -32,7 +24,7 @@ struct GroupWrapper {
 			"name": try group.groupName(),
 			"imageUrlSquare": try group.groupImageUrlSquare(),
 			"description": try group.groupDescription(),
-			"consentState": consentString
+			"consentState": ConsentWrapper.consentStateToString(state: try group.consentState())
 			// "pinnedFrameUrl": try group.groupPinnedFrameUrl()
 		]
 	}

--- a/ios/Wrappers/GroupWrapper.swift
+++ b/ios/Wrappers/GroupWrapper.swift
@@ -11,6 +11,14 @@ import XMTP
 // Wrapper around XMTP.Group to allow passing these objects back into react native.
 struct GroupWrapper {
 	static func encodeToObj(_ group: XMTP.Group, client: XMTP.Client) async throws -> [String: Any] {
+		let consentString = switch try group.consentState() {
+		case .allowed:
+			"allowed"
+		case .denied:
+			"denied"
+		case .unknown:
+			"unknown"
+		}
 		return [
 			"clientAddress": client.address,
 			"id": group.id,
@@ -23,7 +31,8 @@ struct GroupWrapper {
 			"addedByInboxId": try group.addedByInboxId(),
 			"name": try group.groupName(),
 			"imageUrlSquare": try group.groupImageUrlSquare(),
-			"description": try group.groupDescription()
+			"description": try group.groupDescription(),
+			"consentState": consentString
 			// "pinnedFrameUrl": try group.groupPinnedFrameUrl()
 		]
 	}

--- a/ios/Wrappers/MemberWrapper.swift
+++ b/ios/Wrappers/MemberWrapper.swift
@@ -11,6 +11,15 @@ import XMTP
 // Wrapper around XMTP.Member to allow passing these objects back into react native.
 struct MemberWrapper {
 	static func encodeToObj(_ member: XMTP.Member) throws -> [String: Any] {
+		let consentString = switch member.consentState {
+		case .allowed:
+			"allowed"
+		case .denied:
+			"denied"
+		case .unknown:
+			"unknown"
+		}
+
 		let permissionString = switch member.permissionLevel {
 			case .Member:
 				"member"
@@ -23,6 +32,7 @@ struct MemberWrapper {
 			"inboxId": member.inboxId,
 			"addresses": member.addresses,
 			"permissionLevel": permissionString,
+			"consentString": consentString
 		]
 	}
 

--- a/ios/Wrappers/MemberWrapper.swift
+++ b/ios/Wrappers/MemberWrapper.swift
@@ -11,15 +11,6 @@ import XMTP
 // Wrapper around XMTP.Member to allow passing these objects back into react native.
 struct MemberWrapper {
 	static func encodeToObj(_ member: XMTP.Member) throws -> [String: Any] {
-		let consentString = switch member.consentState {
-		case .allowed:
-			"allowed"
-		case .denied:
-			"denied"
-		case .unknown:
-			"unknown"
-		}
-
 		let permissionString = switch member.permissionLevel {
 			case .Member:
 				"member"
@@ -32,7 +23,7 @@ struct MemberWrapper {
 			"inboxId": member.inboxId,
 			"addresses": member.addresses,
 			"permissionLevel": permissionString,
-			"consentString": consentString
+			"consentState": ConsentWrapper.consentStateToString(state: member.consentState)
 		]
 	}
 

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -1525,7 +1525,7 @@ public class XMTPModule: Module {
 			guard let group = try await findGroup(inboxId: inboxId, id: groupId) else {
 				throw Error.conversationNotFound("no group found for \(groupId)")
 			}
-			return try ConsentWrapper.consentStateToString(state: await XMTP.Conversation.group(group).consentState())
+			return try ConsentWrapper.consentStateToString(state: await group.consentState())
 		}
 
 		AsyncFunction("consentList") { (inboxId: String) -> [String] in
@@ -1660,7 +1660,7 @@ public class XMTPModule: Module {
 		case "denied":
 			return .denied
 		default:
-			throw .unknown
+			return .unknown
 		}
 	}
 

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -1583,9 +1583,17 @@ public class XMTPModule: Module {
 		
 		AsyncFunction("isGroupDenied") { (inboxId: String, groupId: String) -> Bool in
 		  guard let client = await clientsManager.getClient(key: inboxId) else {
-			throw Error.invalidString
+			throw Error.noClient
 		  }
 		  return try await client.contacts.isGroupDenied(groupId: groupId)
+		}
+		
+		AsyncFunction("updateGroupConsent") { (inboxId: String, groupId: String, state: String) in
+			guard let group = try await findGroup(inboxId: inboxId, id: groupId) else {
+				throw Error.conversationNotFound(groupId)
+			}
+			
+			try await group.updateConsentState(state: getConsentState(state: state))
 		}
         
 		AsyncFunction("exportNativeLogs") { () -> String in
@@ -1630,7 +1638,7 @@ public class XMTPModule: Module {
 	// Helpers
 	//
     
-    private func getPermissionOption(permission: String) async throws -> PermissionOption {
+    private func getPermissionOption(permission: String) throws -> PermissionOption {
         switch permission {
         case "allow":
             return .allow
@@ -1644,6 +1652,17 @@ public class XMTPModule: Module {
             throw Error.invalidPermissionOption
         }
     }
+	
+	private func getConsentState(state: String) throws -> ConsentState {
+		switch state {
+		case "allowed":
+			return .allowed
+		case "denied":
+			return .denied
+		default:
+			throw .unknown
+		}
+	}
 
 	func createClientConfig(env: String, appVersion: String?, preEnableIdentityCallback: PreEventCallback? = nil, preCreateIdentityCallback: PreEventCallback? = nil, preAuthenticateToInboxCallback: PreEventCallback? = nil, enableV3: Bool = false, dbEncryptionKey: Data? = nil, dbDirectory: String? = nil, historySyncUrl: String? = nil) -> XMTP.ClientOptions {
 		// Ensure that all codecs have been registered.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1192,6 +1192,14 @@ export async function isGroupDenied(
   return XMTPModule.isGroupDenied(inboxId, groupId)
 }
 
+export async function updateGroupConsent(
+  inboxId: string,
+  groupId: string,
+  state: string
+): Promise<void> {
+  return XMTPModule.updateGroupConsent(inboxId, groupId, state)
+}
+
 export async function allowInboxes(
   inboxId: string,
   inboxIds: string[]

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -1,4 +1,5 @@
 import { InboxId } from './Client'
+import { ConsentState } from './ConsentListEntry'
 import {
   ConversationVersion,
   ConversationContainer,
@@ -26,6 +27,7 @@ export interface GroupParams {
   addedByInboxId: InboxId
   imageUrlSquare: string
   description: string
+  consentState: ConsentState
 }
 
 export class Group<
@@ -44,6 +46,7 @@ export class Group<
   addedByInboxId: InboxId
   imageUrlSquare: string
   description: string
+  consentState: ConsentState
   // pinnedFrameUrl: string
 
   constructor(
@@ -62,6 +65,7 @@ export class Group<
     this.addedByInboxId = params.addedByInboxId
     this.imageUrlSquare = params.imageUrlSquare
     this.description = params.description
+    this.consentState = params.consentState
     // this.pinnedFrameUrl = params.pinnedFrameUrl
   }
 
@@ -609,8 +613,8 @@ export class Group<
     }
   }
 
-  async consentState(): Promise<'allowed' | 'denied' | 'unknown'> {
-    return await XMTP.groupConsentState(this.client.inboxId, this.id)
+  async updateConsent(state: ConsentState): Promise<void> {
+    return await XMTP.updateGroupConsent(this.client.inboxId, this.id, state)
   }
 
   /**

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -46,7 +46,7 @@ export class Group<
   addedByInboxId: InboxId
   imageUrlSquare: string
   description: string
-  consentState: ConsentState
+  state: ConsentState
   // pinnedFrameUrl: string
 
   constructor(
@@ -65,7 +65,7 @@ export class Group<
     this.addedByInboxId = params.addedByInboxId
     this.imageUrlSquare = params.imageUrlSquare
     this.description = params.description
-    this.consentState = params.consentState
+    this.state = params.consentState
     // this.pinnedFrameUrl = params.pinnedFrameUrl
   }
 
@@ -611,6 +611,10 @@ export class Group<
       console.info('ERROR in processGroupMessage()', e)
       throw e
     }
+  }
+
+  async consentState(): Promise<ConsentState> {
+    return await XMTP.groupConsentState(this.client.inboxId, this.id)
   }
 
   async updateConsent(state: ConsentState): Promise<void> {

--- a/src/lib/Member.ts
+++ b/src/lib/Member.ts
@@ -1,22 +1,33 @@
 import { InboxId } from './Client'
+import { ConsentState } from './ConsentListEntry'
+
+export type PermissionLevel = 'member' | 'admin' | 'super_admin'
 
 export class Member {
   inboxId: InboxId
   addresses: string[]
-  permissionLevel: 'member' | 'admin' | 'super_admin'
+  permissionLevel: PermissionLevel
+  consentState: ConsentState
 
   constructor(
     inboxId: InboxId,
     addresses: string[],
-    permissionLevel: 'member' | 'admin' | 'super_admin'
+    permissionLevel: PermissionLevel,
+    consentState: ConsentState
   ) {
     this.inboxId = inboxId
     this.addresses = addresses
     this.permissionLevel = permissionLevel
+    this.consentState = consentState
   }
 
   static from(json: string): Member {
     const entry = JSON.parse(json)
-    return new Member(entry.inboxId, entry.addresses, entry.permissionLevel)
+    return new Member(
+      entry.inboxId,
+      entry.addresses,
+      entry.permissionLevel,
+      entry.consentState
+    )
   }
 }


### PR DESCRIPTION
Part of https://github.com/xmtp/libxmtp/issues/801

This adds the ability to get and set consent records in V3

Dual sends so we are always setting both V2 and V3 consent. And adds a check to see if a V2Client is present to support pure V3 clients.