### PR TITLE
V3 Performance Improvements

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:0.16.0"
+  implementation "org.xmtp:android:0.16.1"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -1179,7 +1179,7 @@ class XMTPModule : Module() {
                 val conversation = client.findConversation(dmId)
                     ?: throw XMTPException("no conversation found for $dmId")
                 val dm = (conversation as Conversation.Dm).dm
-                dm.peerInboxId()
+                dm.peerInboxId
             }
         }
 

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -752,11 +752,20 @@ class XMTPModule : Module() {
                 val params =
                     ConversationParamsWrapper.conversationParamsFromJson(conversationParams ?: "")
                 val order = getConversationSortOrder(sortOrder ?: "")
+                val start = Date()
                 val conversations =
                     client.conversations.listConversations(order = order, limit = limit)
-                conversations.map { conversation ->
+                val end = Date()
+                logV("LOPI Loaded ${conversations.size} DMs in ${end.time - start.time}ms")
+
+                val start2 = Date()
+                val convos = conversations.map { conversation ->
                     ConversationContainerWrapper.encode(client, conversation, params)
                 }
+                val end2 = Date()
+                logV("LOPI Encoded ${convos.size} DMs in ${end2.time - start2.time}ms")
+
+                convos
             }
         }
 

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -752,20 +752,11 @@ class XMTPModule : Module() {
                 val params =
                     ConversationParamsWrapper.conversationParamsFromJson(conversationParams ?: "")
                 val order = getConversationSortOrder(sortOrder ?: "")
-                val start = Date()
                 val conversations =
                     client.conversations.listConversations(order = order, limit = limit)
-                val end = Date()
-                logV("LOPI Loaded ${conversations.size} DMs in ${end.time - start.time}ms")
-
-                val start2 = Date()
-                val convos = conversations.map { conversation ->
+                conversations.map { conversation ->
                     ConversationContainerWrapper.encode(client, conversation, params)
                 }
-                val end2 = Date()
-                logV("LOPI Encoded ${convos.size} DMs in ${end2.time - start2.time}ms")
-
-                convos
             }
         }
 

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DmWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DmWrapper.kt
@@ -21,7 +21,6 @@ class DmWrapper {
                 put("version", "DM")
                 put("topic", dm.topic)
                 put("peerInboxId", dm.peerInboxId)
-                if (dmParams.creatorInboxId) put("creatorInboxId", dm.creatorInboxId())
                 if (dmParams.consentState) {
                     put("consentState", consentStateToString(dm.consentState()))
                 }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DmWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DmWrapper.kt
@@ -21,9 +21,6 @@ class DmWrapper {
                 put("version", "DM")
                 put("topic", dm.topic)
                 put("peerInboxId", dm.peerInboxId())
-                if (dmParams.members) {
-                    put("members", dm.members().map { MemberWrapper.encode(it) })
-                }
                 if (dmParams.creatorInboxId) put("creatorInboxId", dm.creatorInboxId())
                 if (dmParams.consentState) {
                     put("consentState", consentStateToString(dm.consentState()))

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DmWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DmWrapper.kt
@@ -20,7 +20,7 @@ class DmWrapper {
                 put("createdAt", dm.createdAt.time)
                 put("version", "DM")
                 put("topic", dm.topic)
-                put("peerInboxId", dm.peerInboxId())
+                put("peerInboxId", dm.peerInboxId)
                 if (dmParams.members) {
                     put("members", dm.members().map { MemberWrapper.encode(it) })
                 }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
@@ -20,7 +20,6 @@ class GroupWrapper {
                 put("createdAt", group.createdAt.time)
                 put("version", "GROUP")
                 put("topic", group.topic)
-                if (groupParams.creatorInboxId) put("creatorInboxId", group.creatorInboxId())
                 if (groupParams.isActive) put("isActive", group.isActive())
                 if (groupParams.addedByInboxId) put("addedByInboxId", group.addedByInboxId())
                 if (groupParams.name) put("name", group.name)
@@ -51,7 +50,6 @@ class GroupWrapper {
 }
 
 class ConversationParamsWrapper(
-    val creatorInboxId: Boolean = true,
     val isActive: Boolean = true,
     val addedByInboxId: Boolean = true,
     val name: Boolean = true,
@@ -65,7 +63,6 @@ class ConversationParamsWrapper(
             if (conversationParams.isEmpty()) return ConversationParamsWrapper()
             val jsonOptions = JsonParser.parseString(conversationParams).asJsonObject
             return ConversationParamsWrapper(
-                if (jsonOptions.has("creatorInboxId")) jsonOptions.get("creatorInboxId").asBoolean else true,
                 if (jsonOptions.has("isActive")) jsonOptions.get("isActive").asBoolean else true,
                 if (jsonOptions.has("addedByInboxId")) jsonOptions.get("addedByInboxId").asBoolean else true,
                 if (jsonOptions.has("name")) jsonOptions.get("name").asBoolean else true,

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
@@ -20,9 +20,6 @@ class GroupWrapper {
                 put("createdAt", group.createdAt.time)
                 put("version", "GROUP")
                 put("topic", group.topic)
-                if (groupParams.members) {
-                    put("members", group.members().map { MemberWrapper.encode(it) })
-                }
                 if (groupParams.creatorInboxId) put("creatorInboxId", group.creatorInboxId())
                 if (groupParams.isActive) put("isActive", group.isActive())
                 if (groupParams.addedByInboxId) put("addedByInboxId", group.addedByInboxId())
@@ -54,7 +51,6 @@ class GroupWrapper {
 }
 
 class ConversationParamsWrapper(
-    val members: Boolean = true,
     val creatorInboxId: Boolean = true,
     val isActive: Boolean = true,
     val addedByInboxId: Boolean = true,
@@ -69,7 +65,6 @@ class ConversationParamsWrapper(
             if (conversationParams.isEmpty()) return ConversationParamsWrapper()
             val jsonOptions = JsonParser.parseString(conversationParams).asJsonObject
             return ConversationParamsWrapper(
-                if (jsonOptions.has("members")) jsonOptions.get("members").asBoolean else true,
                 if (jsonOptions.has("creatorInboxId")) jsonOptions.get("creatorInboxId").asBoolean else true,
                 if (jsonOptions.has("isActive")) jsonOptions.get("isActive").asBoolean else true,
                 if (jsonOptions.has("addedByInboxId")) jsonOptions.get("addedByInboxId").asBoolean else true,

--- a/example/src/tests/groupPerformanceTests.ts
+++ b/example/src/tests/groupPerformanceTests.ts
@@ -162,300 +162,300 @@ test('test compare V2 and V3 dms', async () => {
   return true
 })
 
-// test('testing large group listings with ordering', async () => {
-//   await beforeAll(1000, 10, 10)
+test('testing large group listings with ordering', async () => {
+  await beforeAll(1000, 10, 10)
 
-//   let start = Date.now()
-//   let groups = await alixClient.conversations.listGroups()
-//   let end = Date.now()
-//   console.log(`Alix loaded ${groups.length} groups in ${end - start}ms`)
+  let start = Date.now()
+  let groups = await alixClient.conversations.listGroups()
+  let end = Date.now()
+  console.log(`Alix loaded ${groups.length} groups in ${end - start}ms`)
 
-//   await groups[5].send({ text: `Alix message` })
-//   await groups[50].send({ text: `Alix message` })
-//   await groups[150].send({ text: `Alix message` })
-//   await groups[500].send({ text: `Alix message` })
-//   await groups[700].send({ text: `Alix message` })
-//   await groups[900].send({ text: `Alix message` })
+  await groups[5].send({ text: `Alix message` })
+  await groups[50].send({ text: `Alix message` })
+  await groups[150].send({ text: `Alix message` })
+  await groups[500].send({ text: `Alix message` })
+  await groups[700].send({ text: `Alix message` })
+  await groups[900].send({ text: `Alix message` })
 
-//   let start2 = Date.now()
-//   let groups2 = await alixClient.conversations.listGroups(
-//     {
-//       members: false,
-//       consentState: false,
-//       description: false,
-//       creatorInboxId: false,
-//       addedByInboxId: false,
-//       isActive: false,
-//       lastMessage: true,
-//     },
-//     'lastMessage'
-//   )
-//   let end2 = Date.now()
-//   console.log(`Alix loaded ${groups2.length} groups in ${end2 - start2}ms`)
-//   assert(
-//     end2 - start2 < end - start,
-//     'listing 1000 groups without certain fields should take less time'
-//   )
+  let start2 = Date.now()
+  let groups2 = await alixClient.conversations.listGroups(
+    {
+      members: false,
+      consentState: false,
+      description: false,
+      creatorInboxId: false,
+      addedByInboxId: false,
+      isActive: false,
+      lastMessage: true,
+    },
+    'lastMessage'
+  )
+  let end2 = Date.now()
+  console.log(`Alix loaded ${groups2.length} groups in ${end2 - start2}ms`)
+  assert(
+    end2 - start2 < end - start,
+    'listing 1000 groups without certain fields should take less time'
+  )
 
-//   start = Date.now()
-//   await alixClient.conversations.syncGroups()
-//   end = Date.now()
-//   console.log(`Alix synced ${groups.length} groups in ${end - start}ms`)
-//   assert(
-//     end - start < 100,
-//     'syncing 1000 cached groups should take less than a .1 second'
-//   )
+  start = Date.now()
+  await alixClient.conversations.syncGroups()
+  end = Date.now()
+  console.log(`Alix synced ${groups.length} groups in ${end - start}ms`)
+  assert(
+    end - start < 100,
+    'syncing 1000 cached groups should take less than a .1 second'
+  )
 
-//   start = Date.now()
-//   await boClient.conversations.syncGroups()
-//   end = Date.now()
-//   console.log(`Bo synced ${groups.length} groups in ${end - start}ms`)
+  start = Date.now()
+  await boClient.conversations.syncGroups()
+  end = Date.now()
+  console.log(`Bo synced ${groups.length} groups in ${end - start}ms`)
 
-//   start = Date.now()
-//   await boClient.conversations.syncAllGroups()
-//   end = Date.now()
-//   console.log(`Bo synced all ${groups.length} groups in ${end - start}ms`)
-//   assert(
-//     end - start < 30000,
-//     'Syncing all 1000 groups should take less than a 30 second'
-//   )
+  start = Date.now()
+  await boClient.conversations.syncAllGroups()
+  end = Date.now()
+  console.log(`Bo synced all ${groups.length} groups in ${end - start}ms`)
+  assert(
+    end - start < 30000,
+    'Syncing all 1000 groups should take less than a 30 second'
+  )
 
-//   start = Date.now()
-//   groups = await boClient.conversations.listGroups()
-//   end = Date.now()
-//   console.log(`Bo loaded ${groups.length} groups in ${end - start}ms`)
+  start = Date.now()
+  groups = await boClient.conversations.listGroups()
+  end = Date.now()
+  console.log(`Bo loaded ${groups.length} groups in ${end - start}ms`)
 
-//   start2 = Date.now()
-//   groups2 = await boClient.conversations.listGroups(
-//     {
-//       members: false,
-//       consentState: false,
-//       description: false,
-//       creatorInboxId: false,
-//       addedByInboxId: false,
-//       isActive: false,
-//       lastMessage: true,
-//     },
-//     'lastMessage'
-//   )
-//   end2 = Date.now()
-//   console.log(`Bo loaded ${groups2.length} groups in ${end2 - start2}ms`)
-//   assert(
-//     end2 - start2 < end - start,
-//     'listing 1000 groups without certain fields should take less time'
-//   )
+  start2 = Date.now()
+  groups2 = await boClient.conversations.listGroups(
+    {
+      members: false,
+      consentState: false,
+      description: false,
+      creatorInboxId: false,
+      addedByInboxId: false,
+      isActive: false,
+      lastMessage: true,
+    },
+    'lastMessage'
+  )
+  end2 = Date.now()
+  console.log(`Bo loaded ${groups2.length} groups in ${end2 - start2}ms`)
+  assert(
+    end2 - start2 < end - start,
+    'listing 1000 groups without certain fields should take less time'
+  )
 
-//   return true
-// })
+  return true
+})
 
-// test('testing large group listings', async () => {
-//   await beforeAll(1000)
+test('testing large group listings', async () => {
+  await beforeAll(1000)
 
-//   let start = Date.now()
-//   let groups = await alixClient.conversations.listGroups()
-//   let end = Date.now()
-//   console.log(`Alix loaded ${groups.length} groups in ${end - start}ms`)
-//   assert(
-//     end - start < 3000,
-//     'listing 1000 groups should take less than a 3 second'
-//   )
+  let start = Date.now()
+  let groups = await alixClient.conversations.listGroups()
+  let end = Date.now()
+  console.log(`Alix loaded ${groups.length} groups in ${end - start}ms`)
+  assert(
+    end - start < 3000,
+    'listing 1000 groups should take less than a 3 second'
+  )
 
-//   start = Date.now()
-//   await alixClient.conversations.syncGroups()
-//   end = Date.now()
-//   console.log(`Alix synced ${groups.length} groups in ${end - start}ms`)
-//   assert(
-//     end - start < 100,
-//     'syncing 1000 cached groups should take less than a .1 second'
-//   )
+  start = Date.now()
+  await alixClient.conversations.syncGroups()
+  end = Date.now()
+  console.log(`Alix synced ${groups.length} groups in ${end - start}ms`)
+  assert(
+    end - start < 100,
+    'syncing 1000 cached groups should take less than a .1 second'
+  )
 
-//   start = Date.now()
-//   await boClient.conversations.syncGroups()
-//   end = Date.now()
-//   console.log(`Bo synced ${groups.length} groups in ${end - start}ms`)
-//   assert(
-//     end - start < 6000,
-//     'syncing 1000 groups should take less than a 6 second'
-//   )
+  start = Date.now()
+  await boClient.conversations.syncGroups()
+  end = Date.now()
+  console.log(`Bo synced ${groups.length} groups in ${end - start}ms`)
+  assert(
+    end - start < 6000,
+    'syncing 1000 groups should take less than a 6 second'
+  )
 
-//   start = Date.now()
-//   groups = await boClient.conversations.listGroups()
-//   end = Date.now()
-//   console.log(`Bo loaded ${groups.length} groups in ${end - start}ms`)
-//   assert(
-//     end - start < 3000,
-//     'loading 1000 groups should take less than a 3 second'
-//   )
+  start = Date.now()
+  groups = await boClient.conversations.listGroups()
+  end = Date.now()
+  console.log(`Bo loaded ${groups.length} groups in ${end - start}ms`)
+  assert(
+    end - start < 3000,
+    'loading 1000 groups should take less than a 3 second'
+  )
 
-//   return true
-// })
+  return true
+})
 
-// test('testing large message listings', async () => {
-//   await beforeAll(1, 2000)
+test('testing large message listings', async () => {
+  await beforeAll(1, 2000)
 
-//   const alixGroup = initialGroups[0]
-//   let start = Date.now()
-//   let messages = await alixGroup.messages()
-//   let end = Date.now()
-//   console.log(`Alix loaded ${messages.length} messages in ${end - start}ms`)
-//   assert(
-//     end - start < 1000,
-//     'listing 2000 self messages should take less than a 1 second'
-//   )
+  const alixGroup = initialGroups[0]
+  let start = Date.now()
+  let messages = await alixGroup.messages()
+  let end = Date.now()
+  console.log(`Alix loaded ${messages.length} messages in ${end - start}ms`)
+  assert(
+    end - start < 1000,
+    'listing 2000 self messages should take less than a 1 second'
+  )
 
-//   start = Date.now()
-//   await alixGroup.sync()
-//   end = Date.now()
-//   console.log(`Alix synced ${messages.length} messages in ${end - start}ms`)
-//   assert(
-//     end - start < 100,
-//     'syncing 2000 self messages should take less than a .1 second'
-//   )
+  start = Date.now()
+  await alixGroup.sync()
+  end = Date.now()
+  console.log(`Alix synced ${messages.length} messages in ${end - start}ms`)
+  assert(
+    end - start < 100,
+    'syncing 2000 self messages should take less than a .1 second'
+  )
 
-//   await boClient.conversations.syncGroups()
-//   const boGroup = await boClient.conversations.findGroup(alixGroup.id)
-//   start = Date.now()
-//   await boGroup!.sync()
-//   end = Date.now()
-//   console.log(`Bo synced ${messages.length} messages in ${end - start}ms`)
-//   assert(
-//     end - start < 3000,
-//     'syncing 2000 messages should take less than a 3 second'
-//   )
+  await boClient.conversations.syncGroups()
+  const boGroup = await boClient.conversations.findGroup(alixGroup.id)
+  start = Date.now()
+  await boGroup!.sync()
+  end = Date.now()
+  console.log(`Bo synced ${messages.length} messages in ${end - start}ms`)
+  assert(
+    end - start < 3000,
+    'syncing 2000 messages should take less than a 3 second'
+  )
 
-//   start = Date.now()
-//   messages = await boGroup!.messages()
-//   end = Date.now()
-//   console.log(`Bo loaded ${messages.length} messages in ${end - start}ms`)
-//   assert(
-//     end - start < 1000,
-//     'loading 2000 messages should take less than a 1 second'
-//   )
+  start = Date.now()
+  messages = await boGroup!.messages()
+  end = Date.now()
+  console.log(`Bo loaded ${messages.length} messages in ${end - start}ms`)
+  assert(
+    end - start < 1000,
+    'loading 2000 messages should take less than a 1 second'
+  )
 
-//   return true
-// })
+  return true
+})
 
-// test('testing large member listings', async () => {
-//   await beforeAll(1, 1, 50)
+test('testing large member listings', async () => {
+  await beforeAll(1, 1, 50)
 
-//   const alixGroup = initialGroups[0]
-//   let start = Date.now()
-//   let members = await alixGroup.members
-//   let end = Date.now()
-//   console.log(`Alix loaded ${members.length} members in ${end - start}ms`)
-//   assert(
-//     end - start < 100,
-//     'listing 50 members should take less than a .1 second'
-//   )
+  const alixGroup = initialGroups[0]
+  let start = Date.now()
+  let members = await alixGroup.members
+  let end = Date.now()
+  console.log(`Alix loaded ${members.length} members in ${end - start}ms`)
+  assert(
+    end - start < 100,
+    'listing 50 members should take less than a .1 second'
+  )
 
-//   start = Date.now()
-//   await alixGroup.sync()
-//   end = Date.now()
-//   console.log(`Alix synced ${members.length} members in ${end - start}ms`)
-//   assert(
-//     end - start < 100,
-//     'syncing 50 members should take less than a .1 second'
-//   )
+  start = Date.now()
+  await alixGroup.sync()
+  end = Date.now()
+  console.log(`Alix synced ${members.length} members in ${end - start}ms`)
+  assert(
+    end - start < 100,
+    'syncing 50 members should take less than a .1 second'
+  )
 
-//   await boClient.conversations.syncGroups()
-//   const boGroup = await boClient.conversations.findGroup(alixGroup.id)
-//   start = Date.now()
-//   await boGroup!.sync()
-//   end = Date.now()
-//   console.log(`Bo synced ${members.length} members in ${end - start}ms`)
-//   assert(
-//     end - start < 100,
-//     'syncing 50 members should take less than a .1 second'
-//   )
+  await boClient.conversations.syncGroups()
+  const boGroup = await boClient.conversations.findGroup(alixGroup.id)
+  start = Date.now()
+  await boGroup!.sync()
+  end = Date.now()
+  console.log(`Bo synced ${members.length} members in ${end - start}ms`)
+  assert(
+    end - start < 100,
+    'syncing 50 members should take less than a .1 second'
+  )
 
-//   start = Date.now()
-//   members = await boGroup!.members
-//   end = Date.now()
-//   console.log(`Bo loaded ${members.length} members in ${end - start}ms`)
-//   assert(
-//     end - start < 100,
-//     'loading 50 members should take less than a .1 second'
-//   )
+  start = Date.now()
+  members = await boGroup!.members
+  end = Date.now()
+  console.log(`Bo loaded ${members.length} members in ${end - start}ms`)
+  assert(
+    end - start < 100,
+    'loading 50 members should take less than a .1 second'
+  )
 
-//   const [davonClient] = await createClients(1)
+  const [davonClient] = await createClients(1)
 
-//   start = Date.now()
-//   await alixGroup.addMembers([davonClient.address])
-//   end = Date.now()
-//   console.log(`Alix added 1 member in ${end - start}ms`)
-//   assert(end - start < 100, 'adding 1 member should take less than a .1 second')
+  start = Date.now()
+  await alixGroup.addMembers([davonClient.address])
+  end = Date.now()
+  console.log(`Alix added 1 member in ${end - start}ms`)
+  assert(end - start < 100, 'adding 1 member should take less than a .1 second')
 
-//   start = Date.now()
-//   members = await alixGroup.members
-//   end = Date.now()
-//   console.log(`Alix loaded ${members.length} members in ${end - start}ms`)
-//   assert(
-//     end - start < 100,
-//     'loading 50 member should take less than a .1 second'
-//   )
+  start = Date.now()
+  members = await alixGroup.members
+  end = Date.now()
+  console.log(`Alix loaded ${members.length} members in ${end - start}ms`)
+  assert(
+    end - start < 100,
+    'loading 50 member should take less than a .1 second'
+  )
 
-//   start = Date.now()
-//   await boGroup!.sync()
-//   end = Date.now()
-//   console.log(`Bo synced ${members.length} members in ${end - start}ms`)
-//   assert(
-//     end - start < 100,
-//     'syncing 50 member should take less than a .1 second'
-//   )
+  start = Date.now()
+  await boGroup!.sync()
+  end = Date.now()
+  console.log(`Bo synced ${members.length} members in ${end - start}ms`)
+  assert(
+    end - start < 100,
+    'syncing 50 member should take less than a .1 second'
+  )
 
-//   start = Date.now()
-//   members = await boGroup!.members
-//   end = Date.now()
-//   console.log(`Bo loaded ${members.length} members in ${end - start}ms`)
-//   assert(
-//     end - start < 100,
-//     'loading 50 member should take less than a .1 second'
-//   )
+  start = Date.now()
+  members = await boGroup!.members
+  end = Date.now()
+  console.log(`Bo loaded ${members.length} members in ${end - start}ms`)
+  assert(
+    end - start < 100,
+    'loading 50 member should take less than a .1 second'
+  )
 
-//   return true
-// })
+  return true
+})
 
-// test('testing sending message in large group', async () => {
-//   await beforeAll(1, 2000, 100)
+test('testing sending message in large group', async () => {
+  await beforeAll(1, 2000, 100)
 
-//   const alixGroup = initialGroups[0]
-//   let start = Date.now()
-//   await alixGroup.send({ text: `Alix message` })
-//   let end = Date.now()
-//   console.log(`Alix sent a message in ${end - start}ms`)
-//   assert(
-//     end - start < 200,
-//     'sending a message should take less than a .2 second'
-//   )
+  const alixGroup = initialGroups[0]
+  let start = Date.now()
+  await alixGroup.send({ text: `Alix message` })
+  let end = Date.now()
+  console.log(`Alix sent a message in ${end - start}ms`)
+  assert(
+    end - start < 200,
+    'sending a message should take less than a .2 second'
+  )
 
-//   await boClient.conversations.syncGroups()
-//   const boGroup = await boClient.conversations.findGroup(alixGroup.id)
-//   start = Date.now()
-//   await boGroup!.prepareMessage({ text: `Bo message` })
-//   end = Date.now()
-//   console.log(`Bo sent a message in ${end - start}ms`)
-//   assert(
-//     end - start < 100,
-//     'preparing a message should take less than a .1 second'
-//   )
+  await boClient.conversations.syncGroups()
+  const boGroup = await boClient.conversations.findGroup(alixGroup.id)
+  start = Date.now()
+  await boGroup!.prepareMessage({ text: `Bo message` })
+  end = Date.now()
+  console.log(`Bo sent a message in ${end - start}ms`)
+  assert(
+    end - start < 100,
+    'preparing a message should take less than a .1 second'
+  )
 
-//   start = Date.now()
-//   await boGroup!.sync()
-//   end = Date.now()
-//   console.log(`Bo synced messages in ${end - start}ms`)
-//   assert(
-//     end - start < 9000,
-//     'syncing 2000 messages should take less than a 9 second'
-//   )
+  start = Date.now()
+  await boGroup!.sync()
+  end = Date.now()
+  console.log(`Bo synced messages in ${end - start}ms`)
+  assert(
+    end - start < 9000,
+    'syncing 2000 messages should take less than a 9 second'
+  )
 
-//   start = Date.now()
-//   await boGroup!.send({ text: `Bo message 2` })
-//   end = Date.now()
-//   console.log(`Bo sent a message in ${end - start}ms`)
-//   assert(
-//     end - start < 100,
-//     'sending a message should take less than a .1 second'
-//   )
+  start = Date.now()
+  await boGroup!.send({ text: `Bo message 2` })
+  end = Date.now()
+  console.log(`Bo sent a message in ${end - start}ms`)
+  assert(
+    end - start < 100,
+    'sending a message should take less than a .1 second'
+  )
 
-//   return true
-// })
+  return true
+})

--- a/example/src/tests/groupPerformanceTests.ts
+++ b/example/src/tests/groupPerformanceTests.ts
@@ -72,6 +72,7 @@ let boClient: Client
 let davonV3Client: Client
 let initialPeers: Client[]
 let initialGroups: Group[]
+let initialV3Peers: Client[]
 // let initialDms: Dm[]
 // let initialV2Convos: Conversation<DefaultContentTypes>[]
 
@@ -86,7 +87,7 @@ async function beforeAll(
   ;[davonV3Client] = await createV3Clients(1)
 
   initialPeers = await createClients(peersSize)
-  const initialV3Peers = await createV3Clients(peersSize)
+  initialV3Peers = await createV3Clients(peersSize)
   boClient = initialPeers[0]
 
   initialGroups = await createGroups(
@@ -123,307 +124,331 @@ test('test compare V2 and V3 dms', async () => {
   console.log(`Davon synced ${v2Convos.length} Dms in ${end - start}ms`)
 
   start = Date.now()
-  const dms = await davonV3Client.conversations.listConversations()
+  let dms = await davonV3Client.conversations.listConversations()
+  end = Date.now()
+  console.log(`Davon loaded ${dms.length} Dms in ${end - start}ms`)
+
+  await createDms(davonV3Client, await createV3Clients(5), 1)
+
+  await createV2Convos(alixClient, await createClients(5), 1)
+
+  start = Date.now()
+  v2Convos = await alixClient.conversations.list()
+  end = Date.now()
+  console.log(`Alix loaded ${v2Convos.length} v2Convos in ${end - start}ms`)
+
+  start = Date.now()
+  v2Convos = await alixClient.conversations.list()
+  end = Date.now()
+  console.log(`Alix 2nd loaded ${v2Convos.length} v2Convos in ${end - start}ms`)
+
+  start = Date.now()
+  await davonV3Client.conversations.syncConversations()
+  end = Date.now()
+  console.log(`Davon synced ${v2Convos.length} Dms in ${end - start}ms`)
+
+  start = Date.now()
+  dms = await davonV3Client.conversations.listConversations()
   end = Date.now()
   console.log(`Davon loaded ${dms.length} Dms in ${end - start}ms`)
 
   return true
 })
 
-test('testing large group listings with ordering', async () => {
-  await beforeAll(1000, 10, 10)
+// test('testing large group listings with ordering', async () => {
+//   await beforeAll(1000, 10, 10)
 
-  let start = Date.now()
-  let groups = await alixClient.conversations.listGroups()
-  let end = Date.now()
-  console.log(`Alix loaded ${groups.length} groups in ${end - start}ms`)
+//   let start = Date.now()
+//   let groups = await alixClient.conversations.listGroups()
+//   let end = Date.now()
+//   console.log(`Alix loaded ${groups.length} groups in ${end - start}ms`)
 
-  await groups[5].send({ text: `Alix message` })
-  await groups[50].send({ text: `Alix message` })
-  await groups[150].send({ text: `Alix message` })
-  await groups[500].send({ text: `Alix message` })
-  await groups[700].send({ text: `Alix message` })
-  await groups[900].send({ text: `Alix message` })
+//   await groups[5].send({ text: `Alix message` })
+//   await groups[50].send({ text: `Alix message` })
+//   await groups[150].send({ text: `Alix message` })
+//   await groups[500].send({ text: `Alix message` })
+//   await groups[700].send({ text: `Alix message` })
+//   await groups[900].send({ text: `Alix message` })
 
-  let start2 = Date.now()
-  let groups2 = await alixClient.conversations.listGroups(
-    {
-      members: false,
-      consentState: false,
-      description: false,
-      creatorInboxId: false,
-      addedByInboxId: false,
-      isActive: false,
-      lastMessage: true,
-    },
-    'lastMessage'
-  )
-  let end2 = Date.now()
-  console.log(`Alix loaded ${groups2.length} groups in ${end2 - start2}ms`)
-  assert(
-    end2 - start2 < end - start,
-    'listing 1000 groups without certain fields should take less time'
-  )
+//   let start2 = Date.now()
+//   let groups2 = await alixClient.conversations.listGroups(
+//     {
+//       members: false,
+//       consentState: false,
+//       description: false,
+//       creatorInboxId: false,
+//       addedByInboxId: false,
+//       isActive: false,
+//       lastMessage: true,
+//     },
+//     'lastMessage'
+//   )
+//   let end2 = Date.now()
+//   console.log(`Alix loaded ${groups2.length} groups in ${end2 - start2}ms`)
+//   assert(
+//     end2 - start2 < end - start,
+//     'listing 1000 groups without certain fields should take less time'
+//   )
 
-  start = Date.now()
-  await alixClient.conversations.syncGroups()
-  end = Date.now()
-  console.log(`Alix synced ${groups.length} groups in ${end - start}ms`)
-  assert(
-    end - start < 100,
-    'syncing 1000 cached groups should take less than a .1 second'
-  )
+//   start = Date.now()
+//   await alixClient.conversations.syncGroups()
+//   end = Date.now()
+//   console.log(`Alix synced ${groups.length} groups in ${end - start}ms`)
+//   assert(
+//     end - start < 100,
+//     'syncing 1000 cached groups should take less than a .1 second'
+//   )
 
-  start = Date.now()
-  await boClient.conversations.syncGroups()
-  end = Date.now()
-  console.log(`Bo synced ${groups.length} groups in ${end - start}ms`)
+//   start = Date.now()
+//   await boClient.conversations.syncGroups()
+//   end = Date.now()
+//   console.log(`Bo synced ${groups.length} groups in ${end - start}ms`)
 
-  start = Date.now()
-  await boClient.conversations.syncAllGroups()
-  end = Date.now()
-  console.log(`Bo synced all ${groups.length} groups in ${end - start}ms`)
-  assert(
-    end - start < 30000,
-    'Syncing all 1000 groups should take less than a 30 second'
-  )
+//   start = Date.now()
+//   await boClient.conversations.syncAllGroups()
+//   end = Date.now()
+//   console.log(`Bo synced all ${groups.length} groups in ${end - start}ms`)
+//   assert(
+//     end - start < 30000,
+//     'Syncing all 1000 groups should take less than a 30 second'
+//   )
 
-  start = Date.now()
-  groups = await boClient.conversations.listGroups()
-  end = Date.now()
-  console.log(`Bo loaded ${groups.length} groups in ${end - start}ms`)
+//   start = Date.now()
+//   groups = await boClient.conversations.listGroups()
+//   end = Date.now()
+//   console.log(`Bo loaded ${groups.length} groups in ${end - start}ms`)
 
-  start2 = Date.now()
-  groups2 = await boClient.conversations.listGroups(
-    {
-      members: false,
-      consentState: false,
-      description: false,
-      creatorInboxId: false,
-      addedByInboxId: false,
-      isActive: false,
-      lastMessage: true,
-    },
-    'lastMessage'
-  )
-  end2 = Date.now()
-  console.log(`Bo loaded ${groups2.length} groups in ${end2 - start2}ms`)
-  assert(
-    end2 - start2 < end - start,
-    'listing 1000 groups without certain fields should take less time'
-  )
+//   start2 = Date.now()
+//   groups2 = await boClient.conversations.listGroups(
+//     {
+//       members: false,
+//       consentState: false,
+//       description: false,
+//       creatorInboxId: false,
+//       addedByInboxId: false,
+//       isActive: false,
+//       lastMessage: true,
+//     },
+//     'lastMessage'
+//   )
+//   end2 = Date.now()
+//   console.log(`Bo loaded ${groups2.length} groups in ${end2 - start2}ms`)
+//   assert(
+//     end2 - start2 < end - start,
+//     'listing 1000 groups without certain fields should take less time'
+//   )
 
-  return true
-})
+//   return true
+// })
 
-test('testing large group listings', async () => {
-  await beforeAll(1000)
+// test('testing large group listings', async () => {
+//   await beforeAll(1000)
 
-  let start = Date.now()
-  let groups = await alixClient.conversations.listGroups()
-  let end = Date.now()
-  console.log(`Alix loaded ${groups.length} groups in ${end - start}ms`)
-  assert(
-    end - start < 3000,
-    'listing 1000 groups should take less than a 3 second'
-  )
+//   let start = Date.now()
+//   let groups = await alixClient.conversations.listGroups()
+//   let end = Date.now()
+//   console.log(`Alix loaded ${groups.length} groups in ${end - start}ms`)
+//   assert(
+//     end - start < 3000,
+//     'listing 1000 groups should take less than a 3 second'
+//   )
 
-  start = Date.now()
-  await alixClient.conversations.syncGroups()
-  end = Date.now()
-  console.log(`Alix synced ${groups.length} groups in ${end - start}ms`)
-  assert(
-    end - start < 100,
-    'syncing 1000 cached groups should take less than a .1 second'
-  )
+//   start = Date.now()
+//   await alixClient.conversations.syncGroups()
+//   end = Date.now()
+//   console.log(`Alix synced ${groups.length} groups in ${end - start}ms`)
+//   assert(
+//     end - start < 100,
+//     'syncing 1000 cached groups should take less than a .1 second'
+//   )
 
-  start = Date.now()
-  await boClient.conversations.syncGroups()
-  end = Date.now()
-  console.log(`Bo synced ${groups.length} groups in ${end - start}ms`)
-  assert(
-    end - start < 6000,
-    'syncing 1000 groups should take less than a 6 second'
-  )
+//   start = Date.now()
+//   await boClient.conversations.syncGroups()
+//   end = Date.now()
+//   console.log(`Bo synced ${groups.length} groups in ${end - start}ms`)
+//   assert(
+//     end - start < 6000,
+//     'syncing 1000 groups should take less than a 6 second'
+//   )
 
-  start = Date.now()
-  groups = await boClient.conversations.listGroups()
-  end = Date.now()
-  console.log(`Bo loaded ${groups.length} groups in ${end - start}ms`)
-  assert(
-    end - start < 3000,
-    'loading 1000 groups should take less than a 3 second'
-  )
+//   start = Date.now()
+//   groups = await boClient.conversations.listGroups()
+//   end = Date.now()
+//   console.log(`Bo loaded ${groups.length} groups in ${end - start}ms`)
+//   assert(
+//     end - start < 3000,
+//     'loading 1000 groups should take less than a 3 second'
+//   )
 
-  return true
-})
+//   return true
+// })
 
-test('testing large message listings', async () => {
-  await beforeAll(1, 2000)
+// test('testing large message listings', async () => {
+//   await beforeAll(1, 2000)
 
-  const alixGroup = initialGroups[0]
-  let start = Date.now()
-  let messages = await alixGroup.messages()
-  let end = Date.now()
-  console.log(`Alix loaded ${messages.length} messages in ${end - start}ms`)
-  assert(
-    end - start < 1000,
-    'listing 2000 self messages should take less than a 1 second'
-  )
+//   const alixGroup = initialGroups[0]
+//   let start = Date.now()
+//   let messages = await alixGroup.messages()
+//   let end = Date.now()
+//   console.log(`Alix loaded ${messages.length} messages in ${end - start}ms`)
+//   assert(
+//     end - start < 1000,
+//     'listing 2000 self messages should take less than a 1 second'
+//   )
 
-  start = Date.now()
-  await alixGroup.sync()
-  end = Date.now()
-  console.log(`Alix synced ${messages.length} messages in ${end - start}ms`)
-  assert(
-    end - start < 100,
-    'syncing 2000 self messages should take less than a .1 second'
-  )
+//   start = Date.now()
+//   await alixGroup.sync()
+//   end = Date.now()
+//   console.log(`Alix synced ${messages.length} messages in ${end - start}ms`)
+//   assert(
+//     end - start < 100,
+//     'syncing 2000 self messages should take less than a .1 second'
+//   )
 
-  await boClient.conversations.syncGroups()
-  const boGroup = await boClient.conversations.findGroup(alixGroup.id)
-  start = Date.now()
-  await boGroup!.sync()
-  end = Date.now()
-  console.log(`Bo synced ${messages.length} messages in ${end - start}ms`)
-  assert(
-    end - start < 3000,
-    'syncing 2000 messages should take less than a 3 second'
-  )
+//   await boClient.conversations.syncGroups()
+//   const boGroup = await boClient.conversations.findGroup(alixGroup.id)
+//   start = Date.now()
+//   await boGroup!.sync()
+//   end = Date.now()
+//   console.log(`Bo synced ${messages.length} messages in ${end - start}ms`)
+//   assert(
+//     end - start < 3000,
+//     'syncing 2000 messages should take less than a 3 second'
+//   )
 
-  start = Date.now()
-  messages = await boGroup!.messages()
-  end = Date.now()
-  console.log(`Bo loaded ${messages.length} messages in ${end - start}ms`)
-  assert(
-    end - start < 1000,
-    'loading 2000 messages should take less than a 1 second'
-  )
+//   start = Date.now()
+//   messages = await boGroup!.messages()
+//   end = Date.now()
+//   console.log(`Bo loaded ${messages.length} messages in ${end - start}ms`)
+//   assert(
+//     end - start < 1000,
+//     'loading 2000 messages should take less than a 1 second'
+//   )
 
-  return true
-})
+//   return true
+// })
 
-test('testing large member listings', async () => {
-  await beforeAll(1, 1, 50)
+// test('testing large member listings', async () => {
+//   await beforeAll(1, 1, 50)
 
-  const alixGroup = initialGroups[0]
-  let start = Date.now()
-  let members = await alixGroup.members
-  let end = Date.now()
-  console.log(`Alix loaded ${members.length} members in ${end - start}ms`)
-  assert(
-    end - start < 100,
-    'listing 50 members should take less than a .1 second'
-  )
+//   const alixGroup = initialGroups[0]
+//   let start = Date.now()
+//   let members = await alixGroup.members
+//   let end = Date.now()
+//   console.log(`Alix loaded ${members.length} members in ${end - start}ms`)
+//   assert(
+//     end - start < 100,
+//     'listing 50 members should take less than a .1 second'
+//   )
 
-  start = Date.now()
-  await alixGroup.sync()
-  end = Date.now()
-  console.log(`Alix synced ${members.length} members in ${end - start}ms`)
-  assert(
-    end - start < 100,
-    'syncing 50 members should take less than a .1 second'
-  )
+//   start = Date.now()
+//   await alixGroup.sync()
+//   end = Date.now()
+//   console.log(`Alix synced ${members.length} members in ${end - start}ms`)
+//   assert(
+//     end - start < 100,
+//     'syncing 50 members should take less than a .1 second'
+//   )
 
-  await boClient.conversations.syncGroups()
-  const boGroup = await boClient.conversations.findGroup(alixGroup.id)
-  start = Date.now()
-  await boGroup!.sync()
-  end = Date.now()
-  console.log(`Bo synced ${members.length} members in ${end - start}ms`)
-  assert(
-    end - start < 100,
-    'syncing 50 members should take less than a .1 second'
-  )
+//   await boClient.conversations.syncGroups()
+//   const boGroup = await boClient.conversations.findGroup(alixGroup.id)
+//   start = Date.now()
+//   await boGroup!.sync()
+//   end = Date.now()
+//   console.log(`Bo synced ${members.length} members in ${end - start}ms`)
+//   assert(
+//     end - start < 100,
+//     'syncing 50 members should take less than a .1 second'
+//   )
 
-  start = Date.now()
-  members = await boGroup!.members
-  end = Date.now()
-  console.log(`Bo loaded ${members.length} members in ${end - start}ms`)
-  assert(
-    end - start < 100,
-    'loading 50 members should take less than a .1 second'
-  )
+//   start = Date.now()
+//   members = await boGroup!.members
+//   end = Date.now()
+//   console.log(`Bo loaded ${members.length} members in ${end - start}ms`)
+//   assert(
+//     end - start < 100,
+//     'loading 50 members should take less than a .1 second'
+//   )
 
-  const [davonClient] = await createClients(1)
+//   const [davonClient] = await createClients(1)
 
-  start = Date.now()
-  await alixGroup.addMembers([davonClient.address])
-  end = Date.now()
-  console.log(`Alix added 1 member in ${end - start}ms`)
-  assert(end - start < 100, 'adding 1 member should take less than a .1 second')
+//   start = Date.now()
+//   await alixGroup.addMembers([davonClient.address])
+//   end = Date.now()
+//   console.log(`Alix added 1 member in ${end - start}ms`)
+//   assert(end - start < 100, 'adding 1 member should take less than a .1 second')
 
-  start = Date.now()
-  members = await alixGroup.members
-  end = Date.now()
-  console.log(`Alix loaded ${members.length} members in ${end - start}ms`)
-  assert(
-    end - start < 100,
-    'loading 50 member should take less than a .1 second'
-  )
+//   start = Date.now()
+//   members = await alixGroup.members
+//   end = Date.now()
+//   console.log(`Alix loaded ${members.length} members in ${end - start}ms`)
+//   assert(
+//     end - start < 100,
+//     'loading 50 member should take less than a .1 second'
+//   )
 
-  start = Date.now()
-  await boGroup!.sync()
-  end = Date.now()
-  console.log(`Bo synced ${members.length} members in ${end - start}ms`)
-  assert(
-    end - start < 100,
-    'syncing 50 member should take less than a .1 second'
-  )
+//   start = Date.now()
+//   await boGroup!.sync()
+//   end = Date.now()
+//   console.log(`Bo synced ${members.length} members in ${end - start}ms`)
+//   assert(
+//     end - start < 100,
+//     'syncing 50 member should take less than a .1 second'
+//   )
 
-  start = Date.now()
-  members = await boGroup!.members
-  end = Date.now()
-  console.log(`Bo loaded ${members.length} members in ${end - start}ms`)
-  assert(
-    end - start < 100,
-    'loading 50 member should take less than a .1 second'
-  )
+//   start = Date.now()
+//   members = await boGroup!.members
+//   end = Date.now()
+//   console.log(`Bo loaded ${members.length} members in ${end - start}ms`)
+//   assert(
+//     end - start < 100,
+//     'loading 50 member should take less than a .1 second'
+//   )
 
-  return true
-})
+//   return true
+// })
 
-test('testing sending message in large group', async () => {
-  await beforeAll(1, 2000, 100)
+// test('testing sending message in large group', async () => {
+//   await beforeAll(1, 2000, 100)
 
-  const alixGroup = initialGroups[0]
-  let start = Date.now()
-  await alixGroup.send({ text: `Alix message` })
-  let end = Date.now()
-  console.log(`Alix sent a message in ${end - start}ms`)
-  assert(
-    end - start < 200,
-    'sending a message should take less than a .2 second'
-  )
+//   const alixGroup = initialGroups[0]
+//   let start = Date.now()
+//   await alixGroup.send({ text: `Alix message` })
+//   let end = Date.now()
+//   console.log(`Alix sent a message in ${end - start}ms`)
+//   assert(
+//     end - start < 200,
+//     'sending a message should take less than a .2 second'
+//   )
 
-  await boClient.conversations.syncGroups()
-  const boGroup = await boClient.conversations.findGroup(alixGroup.id)
-  start = Date.now()
-  await boGroup!.prepareMessage({ text: `Bo message` })
-  end = Date.now()
-  console.log(`Bo sent a message in ${end - start}ms`)
-  assert(
-    end - start < 100,
-    'preparing a message should take less than a .1 second'
-  )
+//   await boClient.conversations.syncGroups()
+//   const boGroup = await boClient.conversations.findGroup(alixGroup.id)
+//   start = Date.now()
+//   await boGroup!.prepareMessage({ text: `Bo message` })
+//   end = Date.now()
+//   console.log(`Bo sent a message in ${end - start}ms`)
+//   assert(
+//     end - start < 100,
+//     'preparing a message should take less than a .1 second'
+//   )
 
-  start = Date.now()
-  await boGroup!.sync()
-  end = Date.now()
-  console.log(`Bo synced messages in ${end - start}ms`)
-  assert(
-    end - start < 9000,
-    'syncing 2000 messages should take less than a 9 second'
-  )
+//   start = Date.now()
+//   await boGroup!.sync()
+//   end = Date.now()
+//   console.log(`Bo synced messages in ${end - start}ms`)
+//   assert(
+//     end - start < 9000,
+//     'syncing 2000 messages should take less than a 9 second'
+//   )
 
-  start = Date.now()
-  await boGroup!.send({ text: `Bo message 2` })
-  end = Date.now()
-  console.log(`Bo sent a message in ${end - start}ms`)
-  assert(
-    end - start < 100,
-    'sending a message should take less than a .1 second'
-  )
+//   start = Date.now()
+//   await boGroup!.send({ text: `Bo message 2` })
+//   end = Date.now()
+//   console.log(`Bo sent a message in ${end - start}ms`)
+//   assert(
+//     end - start < 100,
+//     'sending a message should take less than a .1 second'
+//   )
 
-  return true
-})
+//   return true
+// })

--- a/example/src/tests/groupPerformanceTests.ts
+++ b/example/src/tests/groupPerformanceTests.ts
@@ -128,6 +128,7 @@ test('test compare V2 and V3 dms', async () => {
   let dms = await davonV3Client.conversations.listConversations()
   end = Date.now()
   console.log(`Davon loaded ${dms.length} Dms in ${end - start}ms`)
+  const v3Load = end - start
 
   await createDms(davonV3Client, await createV3Clients(5), 1)
 
@@ -152,7 +153,6 @@ test('test compare V2 and V3 dms', async () => {
   dms = await davonV3Client.conversations.listConversations()
   end = Date.now()
   console.log(`Davon loaded ${dms.length} Dms in ${end - start}ms`)
-  const v3Load = end - start
 
   assert(
     v3Load < v2Load,

--- a/example/src/tests/groupPerformanceTests.ts
+++ b/example/src/tests/groupPerformanceTests.ts
@@ -116,6 +116,7 @@ test('test compare V2 and V3 dms', async () => {
   v2Convos = await alixClient.conversations.list()
   end = Date.now()
   console.log(`Alix 2nd loaded ${v2Convos.length} v2Convos in ${end - start}ms`)
+  const v2Load = end - start
 
   start = Date.now()
   await davonV3Client.conversations.syncConversations()
@@ -126,6 +127,12 @@ test('test compare V2 and V3 dms', async () => {
   const dms = await davonV3Client.conversations.listConversations()
   end = Date.now()
   console.log(`Davon loaded ${dms.length} Dms in ${end - start}ms`)
+  const v3Load = end - start
+
+  assert(
+    v3Load < v2Load,
+    'v3 conversations should load faster than v2 conversations'
+  )
 
   return true
 })

--- a/example/src/tests/groupPerformanceTests.ts
+++ b/example/src/tests/groupPerformanceTests.ts
@@ -180,10 +180,8 @@ test('testing large group listings with ordering', async () => {
   let start2 = Date.now()
   let groups2 = await alixClient.conversations.listGroups(
     {
-      members: false,
       consentState: false,
       description: false,
-      creatorInboxId: false,
       addedByInboxId: false,
       isActive: false,
       lastMessage: true,
@@ -228,10 +226,8 @@ test('testing large group listings with ordering', async () => {
   start2 = Date.now()
   groups2 = await boClient.conversations.listGroups(
     {
-      members: false,
       consentState: false,
       description: false,
-      creatorInboxId: false,
       addedByInboxId: false,
       isActive: false,
       lastMessage: true,

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -556,7 +556,7 @@ test('can get members of a group', async () => {
   const [alixClient, boClient] = await createClients(2)
   const group = await alixClient.conversations.newGroup([boClient.address])
 
-  const members = group.members
+  const members = await group.members()
 
   assert(members.length === 2, `Should be 2 members but was ${members.length}`)
 
@@ -1936,7 +1936,7 @@ test('can allow and deny a inbox id', async () => {
 
   await bo.contacts.allowInboxes([alix.inboxId])
 
-  let alixMember = (await boGroup.membersList()).find(
+  let alixMember = (await boGroup.members()).find(
     (member) => member.inboxId === alix.inboxId
   )
   assert(
@@ -1968,7 +1968,7 @@ test('can allow and deny a inbox id', async () => {
 
   await bo.contacts.denyInboxes([alix.inboxId])
 
-  alixMember = (await boGroup.membersList()).find(
+  alixMember = (await boGroup.members()).find(
     (member) => member.inboxId === alix.inboxId
   )
   assert(
@@ -2266,10 +2266,13 @@ test('can create new installation without breaking group', async () => {
   await client1Group?.sync()
   await client2Group?.sync()
 
-  assert(client1Group?.members?.length === 2, `client 1 should see 2 members`)
+  assert(
+    (await client1Group?.members())?.length === 2,
+    `client 1 should see 2 members`
+  )
 
   assert(
-    (await client2Group?.membersList())?.length === 2,
+    (await client2Group?.members())?.length === 2,
     `client 2 should see 2 members`
   )
 
@@ -2297,13 +2300,13 @@ test('can list many groups members in parallel', async () => {
   const groups: Group[] = await createGroups(alix, [bo], 20)
 
   try {
-    await Promise.all(groups.slice(0, 10).map((g) => g.membersList()))
+    await Promise.all(groups.slice(0, 10).map((g) => g.members()))
   } catch (e) {
     throw new Error(`Failed listing 10 groups members with ${e}`)
   }
 
   try {
-    await Promise.all(groups.slice(0, 20).map((g) => g.membersList()))
+    await Promise.all(groups.slice(0, 20).map((g) => g.members()))
   } catch (e) {
     throw new Error(`Failed listing 20 groups members with ${e}`)
   }

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -1009,7 +1009,7 @@ test('can stream groups', async () => {
     throw Error('Unexpected num groups (should be 1): ' + groups.length)
   }
 
-  assert(groups[0].members.length === 2, 'should be 2')
+  assert((await groups[0].members()).length === 2, 'should be 2')
 
   // bo creates a group with alix so a stream callback is fired
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -2266,14 +2266,16 @@ test('can create new installation without breaking group', async () => {
   await client1Group?.sync()
   await client2Group?.sync()
 
+  const members1 = await client1Group?.members()
   assert(
-    (await client1Group?.members())?.length === 2,
-    `client 1 should see 2 members`
+    members1?.length === 2,
+    `client 1 should see 2 members but was ${members1?.length}`
   )
 
+  const members2 = await client2Group?.members()
   assert(
-    (await client2Group?.members())?.length === 2,
-    `client 2 should see 2 members`
+    members2?.length === 2,
+    `client 2 should see 2 members but was ${members2?.length}`
   )
 
   await client2.deleteLocalDatabase()
@@ -2287,9 +2289,10 @@ test('can create new installation without breaking group', async () => {
   })
 
   await client1Group?.send('This message will break the group')
+  const members3 = await client1Group?.members()
   assert(
-    client1Group?.members?.length === 2,
-    `client 1 should still see the 2 members`
+    members3?.length === 2,
+    `client 1 should still see the 2 members but was ${members3?.length}`
   )
 
   return true

--- a/ios/Wrappers/DmWrapper.swift
+++ b/ios/Wrappers/DmWrapper.swift
@@ -19,10 +19,7 @@ struct DmWrapper {
 			"topic": dm.topic,
 			"peerInboxId": try await dm.peerInboxId
 		]
-		
-		if conversationParams.members {
-			result["members"] = try await dm.members.compactMap { member in return try MemberWrapper.encode(member) }
-		}
+
 		if conversationParams.creatorInboxId {
 			result["creatorInboxId"] = try dm.creatorInboxId()
 		}

--- a/ios/Wrappers/DmWrapper.swift
+++ b/ios/Wrappers/DmWrapper.swift
@@ -20,9 +20,6 @@ struct DmWrapper {
 			"peerInboxId": try await dm.peerInboxId
 		]
 
-		if conversationParams.creatorInboxId {
-			result["creatorInboxId"] = try dm.creatorInboxId()
-		}
 		if conversationParams.consentState {
 			result["consentState"] = ConsentWrapper.consentStateToString(state: try dm.consentState())
 		}

--- a/ios/Wrappers/GroupWrapper.swift
+++ b/ios/Wrappers/GroupWrapper.swift
@@ -18,10 +18,7 @@ struct GroupWrapper {
 			"version": "GROUP",
 			"topic": group.topic
 		]
-		
-		if conversationParams.members {
-			result["members"] = try await group.members.compactMap { member in return try MemberWrapper.encode(member) }
-		}
+
 		if conversationParams.creatorInboxId {
 			result["creatorInboxId"] = try group.creatorInboxId()
 		}
@@ -63,7 +60,6 @@ struct GroupWrapper {
 }
 
 struct ConversationParamsWrapper {
-	let members: Bool
 	let creatorInboxId: Bool
 	let isActive: Bool
 	let addedByInboxId: Bool
@@ -74,7 +70,6 @@ struct ConversationParamsWrapper {
 	let lastMessage: Bool
 	
 	init(
-		members: Bool = true,
 		creatorInboxId: Bool = true,
 		isActive: Bool = true,
 		addedByInboxId: Bool = true,
@@ -84,7 +79,6 @@ struct ConversationParamsWrapper {
 		consentState: Bool = true,
 		lastMessage: Bool = false
 	) {
-		self.members = members
 		self.creatorInboxId = creatorInboxId
 		self.isActive = isActive
 		self.addedByInboxId = addedByInboxId
@@ -103,7 +97,6 @@ struct ConversationParamsWrapper {
 		}
 		
 		return ConversationParamsWrapper(
-			members: jsonDict["members"] as? Bool ?? true,
 			creatorInboxId: jsonDict["creatorInboxId"] as? Bool ?? true,
 			isActive: jsonDict["isActive"] as? Bool ?? true,
 			addedByInboxId: jsonDict["addedByInboxId"] as? Bool ?? true,

--- a/ios/Wrappers/GroupWrapper.swift
+++ b/ios/Wrappers/GroupWrapper.swift
@@ -19,9 +19,6 @@ struct GroupWrapper {
 			"topic": group.topic
 		]
 
-		if conversationParams.creatorInboxId {
-			result["creatorInboxId"] = try group.creatorInboxId()
-		}
 		if conversationParams.isActive {
 			result["isActive"] = try group.isActive()
 		}
@@ -60,7 +57,6 @@ struct GroupWrapper {
 }
 
 struct ConversationParamsWrapper {
-	let creatorInboxId: Bool
 	let isActive: Bool
 	let addedByInboxId: Bool
 	let name: Bool
@@ -70,7 +66,6 @@ struct ConversationParamsWrapper {
 	let lastMessage: Bool
 	
 	init(
-		creatorInboxId: Bool = true,
 		isActive: Bool = true,
 		addedByInboxId: Bool = true,
 		name: Bool = true,
@@ -79,7 +74,6 @@ struct ConversationParamsWrapper {
 		consentState: Bool = true,
 		lastMessage: Bool = false
 	) {
-		self.creatorInboxId = creatorInboxId
 		self.isActive = isActive
 		self.addedByInboxId = addedByInboxId
 		self.name = name
@@ -97,7 +91,6 @@ struct ConversationParamsWrapper {
 		}
 		
 		return ConversationParamsWrapper(
-			creatorInboxId: jsonDict["creatorInboxId"] as? Bool ?? true,
 			isActive: jsonDict["isActive"] as? Bool ?? true,
 			addedByInboxId: jsonDict["addedByInboxId"] as? Bool ?? true,
 			name: jsonDict["name"] as? Bool ?? true,

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -651,20 +651,13 @@ public class XMTPModule: Module {
 
 			let params = ConversationParamsWrapper.conversationParamsFromJson(conversationParams ?? "")
 			let order = getConversationSortOrder(order: sortOrder ?? "")
-			var start = Date()
 			let conversations = try await client.conversations.listConversations(limit: limit, order: order)
-			var end = Date()
-			print("Loaded \(conversations.count) conversations in \(end.timeIntervalSince(start) * 1000)ms from iOS")
 			
 			var results: [String] = []
-			start = Date()
 			for conversation in conversations {
 				let encodedConversationContainer = try await ConversationContainerWrapper.encode(conversation, client: client)
 				results.append(encodedConversationContainer)
 			}
-			end = Date()
-			print("Loaded \(results.count) conversationContainers in \(end.timeIntervalSince(start) * 1000)ms from iOS")
-
 			return results
 		}
 		

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -625,13 +625,19 @@ public class XMTPModule: Module {
 
 			let params = ConversationParamsWrapper.conversationParamsFromJson(conversationParams ?? "")
 			let order = getConversationSortOrder(order: sortOrder ?? "")
+			var start = Date()
 			let conversations = try await client.conversations.listConversations(limit: limit, order: order)
-
+			var end = Date()
+			print("Loaded \(conversations.count) conversations in \(end.timeIntervalSince(start) * 1000)ms from iOS")
+			
 			var results: [String] = []
+			start = Date()
 			for conversation in conversations {
 				let encodedConversationContainer = try await ConversationContainerWrapper.encode(conversation, client: client)
 				results.append(encodedConversationContainer)
 			}
+			end = Date()
+			print("Loaded \(results.count) conversationContainers in \(end.timeIntervalSince(start) * 1000)ms from iOS")
 
 			return results
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,9 +298,10 @@ export async function findOrCreateDm<
   const dm = JSON.parse(
     await XMTPModule.findOrCreateDm(client.inboxId, peerAddress)
   )
-  const members = dm['members']?.map((mem: string) => {
-    return Member.from(mem)
-  })
+  const members =
+    dm['members']?.map((mem: string) => {
+      return Member.from(mem)
+    }) || []
   return new Dm(client, dm, members)
 }
 
@@ -330,9 +331,10 @@ export async function createGroup<
     )
   )
 
-  const members = group['members']?.map((mem: string) => {
-    return Member.from(mem)
-  })
+  const members =
+    group['members']?.map((mem: string) => {
+      return Member.from(mem)
+    }) || []
   return new Group(client, group, members)
 }
 
@@ -361,9 +363,10 @@ export async function createGroupCustomPermissions<
       JSON.stringify(options)
     )
   )
-  const members = group['members']?.map((mem: string) => {
-    return Member.from(mem)
-  })
+  const members =
+    group['members']?.map((mem: string) => {
+      return Member.from(mem)
+    }) || []
   return new Group(client, group, members)
 }
 
@@ -384,9 +387,10 @@ export async function listGroups<
     )
   ).map((json: string) => {
     const group = JSON.parse(json)
-    const members = group['members']?.map((mem: string) => {
-      return Member.from(mem)
-    })
+    const members =
+      group['members']?.map((mem: string) => {
+        return Member.from(mem)
+      }) || []
     const lastMessage = group['lastMessage']
       ? DecodedMessage.from(group['lastMessage'], client)
       : undefined
@@ -411,9 +415,10 @@ export async function listV3Conversations<
     )
   ).map((json: string) => {
     const jsonObj = JSON.parse(json)
-    const members = jsonObj.members.map((mem: string) => {
-      return Member.from(mem)
-    })
+    const members =
+      jsonObj.members?.map((mem: string) => {
+        return Member.from(mem)
+      }) || []
     if (jsonObj.version === ConversationVersion.GROUP) {
       return new Group(client, jsonObj, members)
     } else {
@@ -844,9 +849,10 @@ export async function listAll<
   return list.map((json: string) => {
     const jsonObj = JSON.parse(json)
     if (jsonObj.version === ConversationVersion.GROUP) {
-      const members = jsonObj.members.map((mem: string) => {
-        return Member.from(mem)
-      })
+      const members =
+        jsonObj.members?.map((mem: string) => {
+          return Member.from(mem)
+        }) || []
       return new Group(client, jsonObj, members)
     } else {
       return new Conversation(client, jsonObj)
@@ -1465,9 +1471,10 @@ export async function processWelcomeMessage<
     encryptedMessage
   )
   const group = JSON.parse(json)
-  const members = group['members']?.map((mem: string) => {
-    return Member.from(mem)
-  })
+  const members =
+    group['members']?.map((mem: string) => {
+      return Member.from(mem)
+    }) || []
   return new Group(client, group, members)
 }
 
@@ -1482,9 +1489,10 @@ export async function processConversationWelcomeMessage<
     encryptedMessage
   )
   const conversation = JSON.parse(json)
-  const members = conversation['members']?.map((mem: string) => {
-    return Member.from(mem)
-  })
+  const members =
+    conversation['members']?.map((mem: string) => {
+      return Member.from(mem)
+    }) || []
 
   if (conversation.version === ConversationVersion.GROUP) {
     return new Group(client, conversation, members)

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,11 +298,7 @@ export async function findOrCreateDm<
   const dm = JSON.parse(
     await XMTPModule.findOrCreateDm(client.inboxId, peerAddress)
   )
-  const members =
-    dm['members']?.map((mem: string) => {
-      return Member.from(mem)
-    }) || []
-  return new Dm(client, dm, members)
+  return new Dm(client, dm)
 }
 
 export async function createGroup<
@@ -331,11 +327,7 @@ export async function createGroup<
     )
   )
 
-  const members =
-    group['members']?.map((mem: string) => {
-      return Member.from(mem)
-    }) || []
-  return new Group(client, group, members)
+  return new Group(client, group)
 }
 
 export async function createGroupCustomPermissions<
@@ -363,11 +355,8 @@ export async function createGroupCustomPermissions<
       JSON.stringify(options)
     )
   )
-  const members =
-    group['members']?.map((mem: string) => {
-      return Member.from(mem)
-    }) || []
-  return new Group(client, group, members)
+
+  return new Group(client, group)
 }
 
 export async function listGroups<
@@ -387,14 +376,11 @@ export async function listGroups<
     )
   ).map((json: string) => {
     const group = JSON.parse(json)
-    const members =
-      group['members']?.map((mem: string) => {
-        return Member.from(mem)
-      }) || []
+
     const lastMessage = group['lastMessage']
       ? DecodedMessage.from(group['lastMessage'], client)
       : undefined
-    return new Group(client, group, members, lastMessage)
+    return new Group(client, group, lastMessage)
   })
 }
 
@@ -415,14 +401,15 @@ export async function listV3Conversations<
     )
   ).map((json: string) => {
     const jsonObj = JSON.parse(json)
-    const members =
-      jsonObj.members?.map((mem: string) => {
-        return Member.from(mem)
-      }) || []
+
+    const lastMessage = jsonObj['lastMessage']
+      ? DecodedMessage.from(jsonObj['lastMessage'], client)
+      : undefined
+
     if (jsonObj.version === ConversationVersion.GROUP) {
-      return new Group(client, jsonObj, members)
+      return new Group(client, jsonObj, lastMessage)
     } else {
-      return new Dm(client, jsonObj, members)
+      return new Dm(client, jsonObj, lastMessage)
     }
   })
 }
@@ -520,11 +507,8 @@ export async function findGroup<
   if (!group || Object.keys(group).length === 0) {
     return undefined
   }
-  const members =
-    group['members']?.map((mem: string) => {
-      return Member.from(mem)
-    }) || []
-  return new Group(client, group, members)
+
+  return new Group(client, group)
 }
 
 export async function findConversation<
@@ -538,15 +522,11 @@ export async function findConversation<
   if (!conversation || Object.keys(conversation).length === 0) {
     return undefined
   }
-  const members =
-    conversation['members']?.map((mem: string) => {
-      return Member.from(mem)
-    }) || []
 
   if (conversation.version === ConversationVersion.GROUP) {
-    return new Group(client, conversation, members)
+    return new Group(client, conversation)
   } else {
-    return new Dm(client, conversation, members)
+    return new Dm(client, conversation)
   }
 }
 
@@ -561,15 +541,11 @@ export async function findConversationByTopic<
   if (!conversation || Object.keys(conversation).length === 0) {
     return undefined
   }
-  const members =
-    conversation['members']?.map((mem: string) => {
-      return Member.from(mem)
-    }) || []
 
   if (conversation.version === ConversationVersion.GROUP) {
-    return new Group(client, conversation, members)
+    return new Group(client, conversation)
   } else {
-    return new Dm(client, conversation, members)
+    return new Dm(client, conversation)
   }
 }
 
@@ -584,11 +560,8 @@ export async function findDm<
   if (!dm || Object.keys(dm).length === 0) {
     return undefined
   }
-  const members =
-    dm['members']?.map((mem: string) => {
-      return Member.from(mem)
-    }) || []
-  return new Dm(client, dm, members)
+
+  return new Dm(client, dm)
 }
 
 export async function findV3Message<
@@ -849,11 +822,7 @@ export async function listAll<
   return list.map((json: string) => {
     const jsonObj = JSON.parse(json)
     if (jsonObj.version === ConversationVersion.GROUP) {
-      const members =
-        jsonObj.members?.map((mem: string) => {
-          return Member.from(mem)
-        }) || []
-      return new Group(client, jsonObj, members)
+      return new Group(client, jsonObj)
     } else {
       return new Conversation(client, jsonObj)
     }
@@ -1471,11 +1440,7 @@ export async function processWelcomeMessage<
     encryptedMessage
   )
   const group = JSON.parse(json)
-  const members =
-    group['members']?.map((mem: string) => {
-      return Member.from(mem)
-    }) || []
-  return new Group(client, group, members)
+  return new Group(client, group)
 }
 
 export async function processConversationWelcomeMessage<
@@ -1489,15 +1454,11 @@ export async function processConversationWelcomeMessage<
     encryptedMessage
   )
   const conversation = JSON.parse(json)
-  const members =
-    conversation['members']?.map((mem: string) => {
-      return Member.from(mem)
-    }) || []
 
   if (conversation.version === ConversationVersion.GROUP) {
-    return new Group(client, conversation, members)
+    return new Group(client, conversation)
   } else {
-    return new Dm(client, conversation, members)
+    return new Dm(client, conversation)
   }
 }
 

--- a/src/lib/Conversation.ts
+++ b/src/lib/Conversation.ts
@@ -7,13 +7,13 @@ import {
   ConversationContainer,
 } from './ConversationContainer'
 import { DecodedMessage } from './DecodedMessage'
+import { MessagesOptions } from './types'
 import { ConversationSendPayload } from './types/ConversationCodecs'
 import { DefaultContentTypes } from './types/DefaultContentType'
 import { EventTypes } from './types/EventTypes'
 import { SendOptions } from './types/SendOptions'
 import * as XMTP from '../index'
 import { ConversationContext, PreparedLocalMessage } from '../index'
-import { MessagesOptions } from './types'
 
 export interface ConversationParams {
   createdAt: number
@@ -38,7 +38,7 @@ export class Conversation<ContentTypes extends DefaultContentTypes>
   conversationID?: string | undefined
   id: string
   state: ConsentState
-  
+
   /**
    * Base64 encoded key material for the conversation.
    */
@@ -325,7 +325,12 @@ export class Conversation<ContentTypes extends DefaultContentTypes>
   updateConsent(state: ConsentState): Promise<void> {
     throw new Error('V3 only')
   }
-  processMessage(encryptedMessage: string): Promise<DecodedMessage<ContentTypes>> {
+  processMessage(
+    encryptedMessage: string
+  ): Promise<DecodedMessage<ContentTypes>> {
+    throw new Error('V3 only')
+  }
+  members(): Promise<XMTP.Member[]> {
     throw new Error('V3 only')
   }
 }

--- a/src/lib/ConversationContainer.ts
+++ b/src/lib/ConversationContainer.ts
@@ -2,7 +2,7 @@ import { ConsentState } from './ConsentListEntry'
 import { ConversationSendPayload, MessagesOptions } from './types'
 import { DefaultContentTypes } from './types/DefaultContentType'
 import * as XMTP from '../index'
-import { DecodedMessage } from '../index'
+import { DecodedMessage, Member } from '../index'
 
 export enum ConversationVersion {
   DIRECT = 'DIRECT',
@@ -34,4 +34,5 @@ export interface ConversationContainer<
   processMessage(
     encryptedMessage: string
   ): Promise<DecodedMessage<ContentTypes>>
+  members(): Promise<Member[]>
 }

--- a/src/lib/Conversations.ts
+++ b/src/lib/Conversations.ts
@@ -7,7 +7,7 @@ import {
   ConversationContainer,
 } from './ConversationContainer'
 import { DecodedMessage } from './DecodedMessage'
-import { Dm } from './Dm'
+import { Dm, DmParams } from './Dm'
 import { Group, GroupParams } from './Group'
 import { Member } from './Member'
 import { CreateGroupOptions } from './types/CreateGroupOptions'
@@ -219,10 +219,7 @@ export default class Conversations<
           return
         }
         this.known[group.id] = true
-        const members = group['members'].map((mem: string) => {
-          return Member.from(mem)
-        })
-        await callback(new Group(this.client, group, members))
+        await callback(new Group(this.client, group))
       }
     )
     this.subscriptions[EventTypes.Group] = groupsSubscription
@@ -258,22 +255,12 @@ export default class Conversations<
 
         this.known[conversation.topic] = true
         if (conversation.version === ConversationVersion.GROUP) {
-          const members = conversation['members'].map((mem: string) => {
-            return Member.from(mem)
-          })
           return await callback(
-            new Group(
-              this.client,
-              conversation as unknown as GroupParams,
-              members
-            )
+            new Group(this.client, conversation as unknown as GroupParams)
           )
         } else if (conversation.version === ConversationVersion.DM) {
-          const members = conversation['members'].map((mem: string) => {
-            return Member.from(mem)
-          })
           return await callback(
-            new Dm(this.client, conversation as unknown as GroupParams, members)
+            new Dm(this.client, conversation as unknown as DmParams)
           )
         }
       }
@@ -428,16 +415,10 @@ export default class Conversations<
 
         this.known[conversationContainer.topic] = true
         if (conversationContainer.version === ConversationVersion.GROUP) {
-          const members = conversationContainer['members'].map(
-            (mem: string) => {
-              return Member.from(mem)
-            }
-          )
           return await callback(
             new Group(
               this.client,
               conversationContainer as unknown as GroupParams,
-              members
             )
           )
         } else {

--- a/src/lib/Dm.ts
+++ b/src/lib/Dm.ts
@@ -15,7 +15,6 @@ import * as XMTP from '../index'
 export interface DmParams {
   id: string
   createdAt: number
-  creatorInboxId: InboxId
   topic: string
   consentState: ConsentState
   lastMessage?: DecodedMessage

--- a/src/lib/Dm.ts
+++ b/src/lib/Dm.ts
@@ -15,7 +15,6 @@ import * as XMTP from '../index'
 export interface DmParams {
   id: string
   createdAt: number
-  members: string[]
   creatorInboxId: InboxId
   topic: string
   consentState: ConsentState
@@ -28,7 +27,6 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
   client: XMTP.Client<ContentTypes>
   id: string
   createdAt: number
-  members: Member[]
   version = ConversationVersion.DM
   topic: string
   state: ConsentState
@@ -37,13 +35,11 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
   constructor(
     client: XMTP.Client<ContentTypes>,
     params: DmParams,
-    members: Member[],
     lastMessage?: DecodedMessage<ContentTypes>
   ) {
     this.client = client
     this.id = params.id
     this.createdAt = params.createdAt
-    this.members = members
     this.topic = params.topic
     this.state = params.consentState
     this.lastMessage = lastMessage
@@ -252,7 +248,7 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
    * @returns {Promise<Member[]>} A Promise that resolves to an array of Member objects.
    * To get the latest member list from the network, call sync() first.
    */
-  async membersList(): Promise<Member[]> {
+  async members(): Promise<Member[]> {
     return await XMTP.listConversationMembers(this.client.inboxId, this.id)
   }
 }

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -37,7 +37,6 @@ export class Group<
   client: XMTP.Client<ContentTypes>
   id: string
   createdAt: number
-  members: Member[]
   version = ConversationVersion.GROUP
   topic: string
   creatorInboxId: InboxId
@@ -53,13 +52,11 @@ export class Group<
   constructor(
     client: XMTP.Client<ContentTypes>,
     params: GroupParams,
-    members: Member[],
     lastMessage?: DecodedMessage<ContentTypes>
   ) {
     this.client = client
     this.id = params.id
     this.createdAt = params.createdAt
-    this.members = members
     this.topic = params.topic
     this.creatorInboxId = params.creatorInboxId
     this.name = params.name
@@ -648,7 +645,7 @@ export class Group<
    * @returns {Promise<Member[]>} A Promise that resolves to an array of Member objects.
    * To get the latest member list from the network, call sync() first.
    */
-  async membersList(): Promise<Member[]> {
+  async members(): Promise<Member[]> {
     return await XMTP.listConversationMembers(this.client.inboxId, this.id)
   }
 }

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -19,7 +19,6 @@ export interface GroupParams {
   id: string
   createdAt: number
   members: string[]
-  creatorInboxId: InboxId
   topic: string
   name: string
   isActive: boolean
@@ -39,7 +38,6 @@ export class Group<
   createdAt: number
   version = ConversationVersion.GROUP
   topic: string
-  creatorInboxId: InboxId
   name: string
   isGroupActive: boolean
   addedByInboxId: InboxId
@@ -47,7 +45,6 @@ export class Group<
   description: string
   state: ConsentState
   lastMessage?: DecodedMessage<ContentTypes>
-  // pinnedFrameUrl: string
 
   constructor(
     client: XMTP.Client<ContentTypes>,
@@ -58,7 +55,6 @@ export class Group<
     this.id = params.id
     this.createdAt = params.createdAt
     this.topic = params.topic
-    this.creatorInboxId = params.creatorInboxId
     this.name = params.name
     this.isGroupActive = params.isActive
     this.addedByInboxId = params.addedByInboxId
@@ -66,16 +62,23 @@ export class Group<
     this.description = params.description
     this.state = params.consentState
     this.lastMessage = lastMessage
-    // this.pinnedFrameUrl = params.pinnedFrameUrl
   }
 
   /**
    * This method returns an array of inbox ids associated with the group.
    * To get the latest member inbox ids from the network, call sync() first.
-   * @returns {Promise<DecodedMessage<ContentTypes>[]>} A Promise that resolves to an array of DecodedMessage objects.
+   * @returns {Promise<InboxId[]>} A Promise that resolves to an array of InboxId objects.
    */
   async memberInboxIds(): Promise<InboxId[]> {
     return XMTP.listMemberInboxIds(this.client, this.id)
+  }
+
+  /**
+   * This method returns a inbox id associated with the creator of the group.
+   * @returns {Promise<InboxId>} A Promise that resolves to a InboxId.
+   */
+  async creatorInboxId(): Promise<InboxId> {
+    return XMTP.creatorInboxId(this.client.inboxId, this.id)
   }
 
   /**

--- a/src/lib/types/GroupOptions.ts
+++ b/src/lib/types/GroupOptions.ts
@@ -1,5 +1,4 @@
 export type GroupOptions = {
-  members?: boolean
   creatorInboxId?: boolean
   isActive?: boolean
   addedByInboxId?: boolean

--- a/src/lib/types/GroupOptions.ts
+++ b/src/lib/types/GroupOptions.ts
@@ -1,5 +1,4 @@
 export type GroupOptions = {
-  creatorInboxId?: boolean
   isActive?: boolean
   addedByInboxId?: boolean
   name?: boolean


### PR DESCRIPTION
Remove members and creatorInboxId from the listing of groups because it will never be performant.

Also upgrades to the version of `peerInboxId` that is more performant.

Android still is a good bit slower.

Here is

**iOS**

| Metric                   | V2Alix          | V3Davon         |
|--------------------------|-----------------|-----------------|
| 50 DMs (1st load)        | 116 ms         | 275 ms         |
| 50 DMs (2nd load)        | 25 ms          | 9 ms           |
| 55 DMs (1st load)        | 19 ms          | 34 ms          |
| 55 DMs (2nd load)        | 9 ms           | 9 ms           |

**Android**

| Metric                   | V2Alix          | V3Davon         |
|--------------------------|-----------------|-----------------|
| 50 DMs (1st load)        | 364 ms         | 538 ms         |
| 50 DMs (2nd load)        | 55 ms          | 62 ms          |
| 55 DMs (1st load)        | 56 ms          | 61 ms          |
| 55 DMs (2nd load)        | 25 ms          | 62 ms          |
