### PR TITLE
History Sync tests

### DIFF
--- a/example/src/tests/conversationTests.ts
+++ b/example/src/tests/conversationTests.ts
@@ -1,9 +1,16 @@
+import RNFS from 'react-native-fs'
 import { Test, assert, createClients, delayToPropogate } from './test-utils'
 import {
+  Client,
+  ConsentRecord,
   Conversation,
   ConversationId,
   ConversationVersion,
+  createForLocalTesting,
+  createRandomWalletKeyForLocalTesting,
+  localTestingSyncAllConversations,
 } from '../../../src/index'
+import { Wallet } from 'ethers'
 
 export const conversationTests: Test[] = []
 let counter = 1
@@ -544,6 +551,85 @@ test('can streamAllMessages from multiple clients - swapped', async () => {
       'Unexpected all conversations count for Ali ' + allAliMessages.length
     )
   }
+
+  return true
+})
+
+test('can sync consent', async () => {
+  const [bo] = await createClients(1)
+  const keyBytes = new Uint8Array([
+    233, 120, 198, 96, 154, 65, 132, 17, 132, 96, 250, 40, 103, 35, 125, 64,
+    166, 83, 208, 224, 254, 44, 205, 227, 175, 49, 234, 129, 74, 252, 135, 145,
+  ])
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const dbDirPath = `${RNFS.DocumentDirectoryPath}/xmtp_db`
+  const dbDirPath2 = `${RNFS.DocumentDirectoryPath}/xmtp_db2`
+  const directoryExists = await RNFS.exists(dbDirPath)
+  if (!directoryExists) {
+    await RNFS.mkdir(dbDirPath)
+  }
+  const directoryExists2 = await RNFS.exists(dbDirPath2)
+  if (!directoryExists2) {
+    await RNFS.mkdir(dbDirPath2)
+  }
+  const alixWallet = await createRandomWalletKeyForLocalTesting()
+
+  const alix = await createForLocalTesting(
+    keyBytes,
+    dbDirPath,
+    undefined,
+    alixWallet
+  )
+
+  // Create DM conversation
+  const dm = await alix.conversations.findOrCreateDm(bo.address)
+  await dm.updateConsent('denied')
+  const consentState = await dm.consentState()
+  assert(consentState === 'denied', `Expected 'denied', got ${consentState}`)
+
+  await bo.conversations.sync()
+  const boDm = await bo.conversations.findConversation(dm.id)
+
+  const alix2 = await createForLocalTesting(
+    keyBytes,
+    dbDirPath2,
+    undefined,
+    alixWallet
+  )
+
+  const state = await alix2.inboxState(true)
+  assert(
+    state.installations.length === 2,
+    `Expected 2 installations, got ${state.installations.length}`
+  )
+
+  // Sync conversations
+  await bo.conversations.sync()
+  if (boDm) await boDm.sync()
+  await localTestingSyncAllConversations(alix.installationId)
+  await localTestingSyncAllConversations(alix2.installationId)
+  await alix2.preferences.syncConsent()
+  await localTestingSyncAllConversations(alix.installationId)
+  await delayToPropogate(2000)
+  await localTestingSyncAllConversations(alix2.installationId)
+  await delayToPropogate(2000)
+
+  const dm2 = await alix2.conversations.findConversation(dm.id)
+  const consentState2 = await dm2?.consentState()
+  assert(consentState2 === 'denied', `Expected 'denied', got ${consentState2}`)
+
+  await alix2.preferences.setConsentState(
+    new ConsentRecord(dm2!.id, 'conversation_id', 'allowed')
+  )
+
+  const convoState = await alix2.preferences.conversationConsentState(dm2!.id)
+  assert(convoState === 'allowed', `Expected 'allowed', got ${convoState}`)
+
+  const updatedConsentState = await dm2?.consentState()
+  assert(
+    updatedConsentState === 'allowed',
+    `Expected 'allowed', got ${updatedConsentState}`
+  )
 
   return true
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1053,6 +1053,42 @@ export async function exportNativeLogs() {
   return XMTPModule.exportNativeLogs()
 }
 
+export async function createRandomWalletKeyForLocalTesting(): Promise<Uint8Array> {
+  const walletKey = await XMTPModule.createRandomWalletKeyForLocalTesting()
+  return new Uint8Array(walletKey)
+}
+
+export async function createForLocalTesting(
+  dbEncryptionKey: Uint8Array,
+  dbDirectory?: string | undefined,
+  historySyncUrl?: string | undefined,
+  walletKey?: Uint8Array
+): Promise<Client<DefaultContentTypes>> {
+  const authParams: AuthParams = {
+    environment: 'local',
+    dbDirectory,
+    historySyncUrl,
+  }
+  const privateKey = walletKey ? Array.from(walletKey) : undefined
+  const client = await XMTPModule.createForLocalTesting(
+    Array.from(dbEncryptionKey),
+    JSON.stringify(authParams),
+    privateKey
+  )
+
+  return new Client(
+    client['address'],
+    client['inboxId'],
+    client['installationId'],
+    client['dbPath'],
+    []
+  )
+}
+
+export async function localTestingSyncAllConversations(installationId: string) {
+  return XMTPModule.localTestingSyncAllConversations(installationId)
+}
+
 export const emitter = new EventEmitter(XMTPModule ?? NativeModulesProxy.XMTP)
 
 interface AuthParams {


### PR DESCRIPTION
Adds the ability to test history sync by having multiple installations with the same inboxId running at the same time.

In React Native we keep a map of clients by inboxId in the bridge so that you can easily fetch a client and call it's respective functions on it. This makes it so you can only have one client at a time. Unfortunately when it comes to installations we want a client per installation the two options are to 

1) change our client mapping to be by installationId
2) add very specific tests for history syncing that give access to these multiple installations


My gut is that doing this based on inboxId is going to bite us in the future and that it should really be mapped by installationId. However thats going to be a massive change.