### PR TITLE
feat: Decoded Message Types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   ConversationId,
   ConversationTopic,
 } from './lib/types/ConversationOptions'
+import { DecodedMessageUnion } from './lib/types/DecodedMessageUnion'
 import { DefaultContentTypes } from './lib/types/DefaultContentType'
 import { MessageId, MessageOrder } from './lib/types/MessagesOptions'
 import { PermissionPolicySet } from './lib/types/PermissionPolicySet'
@@ -403,7 +404,7 @@ export async function conversationMessages<
   beforeNs?: number | undefined,
   afterNs?: number | undefined,
   direction?: MessageOrder | undefined
-): Promise<DecodedMessage<ContentTypes>[]> {
+): Promise<DecodedMessageUnion<ContentTypes>[]> {
   const messages = await XMTPModule.conversationMessages(
     client.installationId,
     conversationId,
@@ -418,11 +419,12 @@ export async function conversationMessages<
 }
 
 export async function findMessage<
-  ContentTypes extends DefaultContentTypes = DefaultContentTypes,
+  ContentType extends DefaultContentTypes[number] = DefaultContentTypes[number],
+  ContentTypes extends DefaultContentTypes = [ContentType], // Adjusted to work with arrays
 >(
   client: Client<ContentTypes>,
   messageId: MessageId
-): Promise<DecodedMessage<ContentTypes> | undefined> {
+): Promise<DecodedMessageUnion<ContentTypes> | undefined> {
   const message = await XMTPModule.findMessage(client.installationId, messageId)
   return DecodedMessage.from(message, client)
 }
@@ -958,7 +960,7 @@ export async function processMessage<
   client: Client<ContentTypes>,
   id: ConversationId,
   encryptedMessage: string
-): Promise<DecodedMessage<ContentTypes>> {
+): Promise<DecodedMessageUnion<ContentTypes>> {
   const json = await XMTPModule.processMessage(
     client.installationId,
     id,
@@ -1144,3 +1146,4 @@ export {
   ConversationType,
 } from './lib/types/ConversationOptions'
 export { MessageId, MessageOrder } from './lib/types/MessagesOptions'
+export { DecodedMessageUnion } from './lib/types/DecodedMessageUnion'

--- a/src/lib/Conversation.ts
+++ b/src/lib/Conversation.ts
@@ -1,5 +1,6 @@
 import { ConsentState } from './ConsentRecord'
 import { ConversationSendPayload, MessageId, MessagesOptions } from './types'
+import { DecodedMessageUnion } from './types/DecodedMessageUnion'
 import { DefaultContentTypes } from './types/DefaultContentType'
 import * as XMTP from '../index'
 import { DecodedMessage, Member, Dm, Group } from '../index'
@@ -16,21 +17,23 @@ export interface ConversationBase<ContentTypes extends DefaultContentTypes> {
   version: ConversationVersion
   id: string
   state: ConsentState
-  lastMessage?: DecodedMessage<ContentTypes>
+  lastMessage?: DecodedMessage<ContentTypes[number], ContentTypes>
 
   send<SendContentTypes extends DefaultContentTypes = ContentTypes>(
     content: ConversationSendPayload<SendContentTypes>
   ): Promise<MessageId>
   sync()
-  messages(opts?: MessagesOptions): Promise<DecodedMessage<ContentTypes>[]>
+  messages(opts?: MessagesOptions): Promise<DecodedMessageUnion<ContentTypes>[]>
   streamMessages(
-    callback: (message: DecodedMessage<ContentTypes>) => Promise<void>
+    callback: (
+      message: DecodedMessage<ContentTypes[number], ContentTypes>
+    ) => Promise<void>
   ): Promise<() => void>
   consentState(): Promise<ConsentState>
   updateConsent(state: ConsentState): Promise<void>
   processMessage(
     encryptedMessage: string
-  ): Promise<DecodedMessage<ContentTypes>>
+  ): Promise<DecodedMessage<ContentTypes[number], ContentTypes>>
   members(): Promise<Member[]>
 }
 

--- a/src/lib/types/DecodedMessageUnion.ts
+++ b/src/lib/types/DecodedMessageUnion.ts
@@ -1,0 +1,11 @@
+import { DefaultContentTypes } from './DefaultContentType'
+import { ContentCodec } from '../ContentCodec'
+import { DecodedMessage } from '../DecodedMessage'
+
+export type DecodedMessageUnion<
+  ContentTypes extends DefaultContentTypes = DefaultContentTypes,
+> = {
+  [K in keyof ContentTypes]: ContentTypes[K] extends ContentCodec<any>
+    ? DecodedMessage<ContentTypes[K], ContentTypes>
+    : never
+}[number]


### PR DESCRIPTION

Please enjoy this [Thanksgiving Gif](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExeGVtM2hvNGZwaTMzc3pybWU0N3FyNndhNmR5ZmE3dmxvaml0OXB4YiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/dWknHx8LmjvqCwdK1U/giphy.gif)

Improved Decoded Message types and returns from listing 
Added DecodedMessageUnion utility type to manage returned values from list methods
Added more type tests to help check against type usage

One callout is to really make types work I am using as const for the codecs, I did this rather than requiring readonly array of codecs. This means integrators can still dynamically create codecs but still use types, but this is only needed for the initial type inferencing if done by the client