### PR TITLE
Add custom content types for preparing a message

### DIFF
--- a/.changeset/fifty-drinks-type.md
+++ b/.changeset/fifty-drinks-type.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+Add custom content types for preparing a message

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:3.0.14"
+  implementation "org.xmtp:android:3.0.15"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -713,6 +713,26 @@ class XMTPModule : Module() {
             }
         }
 
+        AsyncFunction("prepareEncodedMessage") Coroutine { installationId: String, conversationId: String, encodedContentData: List<Int> ->
+            withContext(Dispatchers.IO) {
+                logV("prepareEncodedMessage")
+                val client = clients[installationId] ?: throw XMTPException("No client")
+                val conversation = client.findConversation(conversationId)
+                    ?: throw XMTPException("no conversation found for $conversationId")
+                val encodedContentDataBytes =
+                    encodedContentData.foldIndexed(ByteArray(encodedContentData.size)) { i, a, v ->
+                        a.apply {
+                            set(
+                                i,
+                                v.toByte()
+                            )
+                        }
+                    }
+                val encodedContent = EncodedContent.parseFrom(encodedContentDataBytes)
+                conversation.prepareMessage(encodedContent = encodedContent)
+            }
+        }
+
         AsyncFunction("findOrCreateDm") Coroutine { installationId: String, peerAddress: String ->
             withContext(Dispatchers.IO) {
                 logV("findOrCreateDm")

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -448,18 +448,18 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (3.0.15):
+  - XMTP (3.0.16):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - CSecp256k1 (~> 0.2)
     - LibXMTP (= 3.0.10)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (3.1.1):
+  - XMTPReactNative (3.1.2):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 3.0.15)
+    - XMTP (= 3.0.16)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -762,8 +762,8 @@ SPEC CHECKSUMS:
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: 8b0c84096edf74642c5780e4fca9ebbc848fdcf2
-  XMTPReactNative: fa98630d85a3947eccfde6062916bcf3de9c32e2
+  XMTP: ce70e4a8e71db02af15bf4a0c230f5990c619281
+  XMTPReactNative: 00f79e4244439587ade2f7d65900e0dc9bd2634f
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
 PODFILE CHECKSUM: 0e6fe50018f34e575d38dc6a1fdf1f99c9596cdd

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -721,7 +721,7 @@ public class XMTPModule: Module {
 				return nil
 			}
 		}
-		
+
 		AsyncFunction("sendEncodedContent") {
 			(
 				installationId: String, conversationId: String,
@@ -807,6 +807,30 @@ public class XMTPModule: Module {
 				content: sending.content,
 				options: SendOptions(contentType: sending.type)
 			)
+		}
+
+		AsyncFunction("prepareEncodedMessage") {
+			(
+				installationId: String,
+				conversationId: String,
+				encodedContentData: [UInt8]
+			) -> String in
+			guard
+				let client = await clientsManager.getClient(key: installationId)
+			else {
+				throw Error.noClient
+			}
+			guard
+				let conversation = try client.findConversation(
+					conversationId: conversationId)
+			else {
+				throw Error.conversationNotFound(
+					"no conversation found for \(conversationId)")
+			}
+			let encodedContent = try EncodedContent(
+				serializedBytes: Data(encodedContentData))
+			return try await conversation.prepareMessage(
+				encodedContent: encodedContent)
 		}
 
 		AsyncFunction("findOrCreateDm") {

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 3.0.15"
+  s.dependency "XMTP", "= 3.0.16"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/src/index.ts
+++ b/src/index.ts
@@ -596,6 +596,25 @@ export async function prepareMessage(
   )
 }
 
+export async function prepareMessageWithContentType<T>(
+  installationId: InstallationId,
+  conversationId: ConversationId,
+  content: any,
+  codec: ContentCodec<T>
+): Promise<MessageId> {
+  if ('contentKey' in codec) {
+    return prepareMessage(installationId, conversationId, content)
+  }
+  const encodedContent = codec.encode(content)
+  encodedContent.fallback = codec.fallback(content)
+  const encodedContentData = EncodedContent.encode(encodedContent).finish()
+  return await XMTPModule.prepareEncodedMessage(
+    installationId,
+    conversationId,
+    Array.from(encodedContentData)
+  )
+}
+
 export async function findOrCreateDm<
   ContentTypes extends DefaultContentTypes = DefaultContentTypes,
 >(

--- a/src/lib/Conversation.ts
+++ b/src/lib/Conversation.ts
@@ -28,6 +28,10 @@ export interface ConversationBase<ContentTypes extends DefaultContentTypes> {
     content: ConversationSendPayload<SendContentTypes>,
     opts?: SendOptions
   ): Promise<MessageId>
+  prepareMessage<SendContentTypes extends DefaultContentTypes = ContentTypes>(
+    content: ConversationSendPayload<SendContentTypes>,
+    opts?: SendOptions
+  ): Promise<MessageId>
   sync()
   messages(opts?: MessagesOptions): Promise<DecodedMessageUnion<ContentTypes>[]>
   streamMessages(


### PR DESCRIPTION
Fixes https://github.com/xmtp/xmtp-react-native/issues/567

Adds the ability to send custom content types for prepareMessage as well.