### PR TITLE
Speed up build client performance

### DIFF
--- a/.changeset/wet-wasps-search.md
+++ b/.changeset/wet-wasps-search.md
@@ -1,0 +1,8 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+Speed up build client performance
+Adds ability to filter syncAllConversations by consent state
+Fixes potential forked group issues
+Renames senderAddress to senderInboxId

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -296,7 +296,7 @@ class XMTPModule : Module() {
             withContext(Dispatchers.IO) {
                 logV("connectToApiBackend")
                 val api = apiEnvironments(environment, null)
-                val xmtpApiClient = Client().connectToApiBackend(api)
+                val xmtpApiClient = Client.connectToApiBackend(api)
                 apiClient = xmtpApiClient
             }
         }
@@ -310,7 +310,8 @@ class XMTPModule : Module() {
                     authParams,
                     hasPreAuthenticateToInboxCallback,
                 )
-                val randomClient = Client().create(account = privateKey, options = options, apiClient = apiClient)
+                val randomClient =
+                    Client().create(account = privateKey, options = options, apiClient = apiClient)
 
                 ContentJson.Companion
                 clients[randomClient.installationId] = randomClient
@@ -336,7 +337,8 @@ class XMTPModule : Module() {
                     authParams,
                     hasAuthInboxCallback,
                 )
-                val client = Client().create(account = reactSigner, options = options, apiClient = apiClient)
+                val client =
+                    Client().create(account = reactSigner, options = options, apiClient = apiClient)
                 clients[client.installationId] = client
                 apiClient = client.apiClient
                 ContentJson.Companion
@@ -352,7 +354,12 @@ class XMTPModule : Module() {
                     dbEncryptionKey,
                     authParams,
                 )
-                val client = Client().build(address = address, options = options, inboxId = inboxId, apiClient = apiClient)
+                val client = Client().build(
+                    address = address,
+                    options = options,
+                    inboxId = inboxId,
+                    apiClient = apiClient
+                )
                 ContentJson.Companion
                 clients[client.installationId] = client
                 apiClient = client.apiClient
@@ -464,7 +471,8 @@ class XMTPModule : Module() {
                 Client.canMessage(
                     peerAddresses,
                     context,
-                    apiEnvironments(environment, null)
+                    apiEnvironments(environment, null),
+                    apiClient = apiClient
                 )
             }
         }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -59,6 +59,7 @@ import org.xmtp.android.library.messages.PrivateKeyBuilder
 import org.xmtp.android.library.messages.Signature
 import org.xmtp.android.library.push.Service
 import org.xmtp.android.library.push.XMTPPush
+import uniffi.xmtpv3.XmtpApiClient
 import uniffi.xmtpv3.org.xmtp.android.library.libxmtp.GroupPermissionPreconfiguration
 import uniffi.xmtpv3.org.xmtp.android.library.libxmtp.PermissionOption
 import java.io.BufferedReader
@@ -191,6 +192,7 @@ class XMTPModule : Module() {
     }
 
     private var clients: MutableMap<String, Client> = mutableMapOf()
+    private var apiClient: XmtpApiClient? = null
     private var xmtpPush: XMTPPush? = null
     private var signer: ReactNativeSigner? = null
     private val isDebugEnabled = BuildConfig.DEBUG // TODO: consider making this configurable
@@ -290,6 +292,15 @@ class XMTPModule : Module() {
             signer?.handleSCW(id = requestID, signature = signature)
         }
 
+        AsyncFunction("connectToApiBackend") Coroutine { environment: String ->
+            withContext(Dispatchers.IO) {
+                logV("connectToApiBackend")
+                val api = apiEnvironments(environment, null)
+                val xmtpApiClient = Client().connectToApiBackend(api)
+                apiClient = xmtpApiClient
+            }
+        }
+
         AsyncFunction("createRandom") Coroutine { hasPreAuthenticateToInboxCallback: Boolean?, dbEncryptionKey: List<Int>, authParams: String ->
             withContext(Dispatchers.IO) {
                 logV("createRandom")
@@ -299,10 +310,11 @@ class XMTPModule : Module() {
                     authParams,
                     hasPreAuthenticateToInboxCallback,
                 )
-                val randomClient = Client().create(account = privateKey, options = options)
+                val randomClient = Client().create(account = privateKey, options = options, apiClient = apiClient)
 
                 ContentJson.Companion
                 clients[randomClient.installationId] = randomClient
+                apiClient = randomClient.apiClient
                 ClientWrapper.encodeToObj(randomClient)
             }
         }
@@ -324,8 +336,9 @@ class XMTPModule : Module() {
                     authParams,
                     hasAuthInboxCallback,
                 )
-                val client = Client().create(account = reactSigner, options = options)
+                val client = Client().create(account = reactSigner, options = options, apiClient = apiClient)
                 clients[client.installationId] = client
+                apiClient = client.apiClient
                 ContentJson.Companion
                 signer = null
                 sendEvent("authed", ClientWrapper.encodeToObj(client))
@@ -339,9 +352,10 @@ class XMTPModule : Module() {
                     dbEncryptionKey,
                     authParams,
                 )
-                val client = Client().build(address = address, options = options, inboxId = inboxId)
+                val client = Client().build(address = address, options = options, inboxId = inboxId, apiClient = apiClient)
                 ContentJson.Companion
                 clients[client.installationId] = client
+                apiClient = client.apiClient
                 ClientWrapper.encodeToObj(client)
             }
         }

--- a/example/src/tests/groupPerformanceTests.ts
+++ b/example/src/tests/groupPerformanceTests.ts
@@ -88,6 +88,26 @@ test('building and creating', async () => {
   const end3 = performance.now()
   console.log(`Built a client with inboxId in ${end3 - start3}ms`)
 
+  await Client.connectToApiBackend('dev')
+  const start4 = performance.now()
+  await Client.createRandom({
+    env: 'dev',
+    appVersion: 'Testing/0.0.0',
+    dbEncryptionKey: keyBytes,
+    dbDirectory: dbDirPath,
+    codecs: [
+      new ReactionCodec(),
+      new ReplyCodec(),
+      new GroupUpdatedCodec(),
+      new StaticAttachmentCodec(),
+      new RemoteAttachmentCodec(),
+    ],
+  })
+  const end4 = performance.now()
+  console.log(
+    `Created a client after connecting to backend in ${end4 - start4}ms`
+  )
+
   assert(
     end2 - start2 < end1 - start1,
     'building a client should be faster than creating one'
@@ -99,6 +119,10 @@ test('building and creating', async () => {
   assert(
     end3 - start3 < end2 - start2,
     'building a client with an inboxId should be faster than building without'
+  )
+  assert(
+    end4 - start4 < end1 - start1,
+    'creating a client with an apiClient cached should be faster than creating one without'
   )
 
   return true

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,12 @@ export async function receiveSCWSignature(
   return await XMTPModule.receiveSCWSignature(requestID, signature)
 }
 
+export async function connectToApiBackend(
+  environment: XMTPEnvironment
+): Promise<void> {
+  return await XMTPModule.connectToApiBackend(environment)
+}
+
 export async function createRandom(
   environment: 'local' | 'dev' | 'production',
   dbEncryptionKey: Uint8Array,

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -80,6 +80,16 @@ export class Client<
   }
 
   /**
+   * Connects to the XMTP api backend to speed up creating and building future clients.
+   *
+   * @param {XMTPEnvironment} env - Environment to connect to
+   * @returns {Promise<void>} A Promise to let you know the api has been connected
+   */
+  static async connectToApiBackend(env: XMTPEnvironment): Promise<void> {
+    return await XMTPModule.connectToApiBackend(env)
+  }
+
+  /**
    * Creates a new instance of the XMTP Client with a randomly generated address.
    *
    * @param {Partial<ClientOptions>} opts - Configuration options for the Client. Must include encryption key.


### PR DESCRIPTION
Much much faster now by passing in the apiClient.

# Performance Comparison: iOS vs Android

| Metric                                   | Android (ms) | iOS (ms)  | Difference (ms) | Faster Platform |
|------------------------------------------|--------------|-----------|------------------|-----------------|
| Created a new client                     | 1610.02      | 1554.35   | 55.67            | iOS             |
| Built a client                           | 606.24       | 631.59    | 25.35            | Android         |
| Built a client with inboxId              | 122.83       | 109.19    | 13.64            | iOS             |
| Created a client after connecting to backend | 1116.84      | 1062.09   | 54.75            | iOS             |
