### PR TITLE
Remove pinned frame url

### DIFF
--- a/.changeset/stale-plants-camp.md
+++ b/.changeset/stale-plants-camp.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+Remove pinned frame url

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:3.0.23"
+  implementation "org.xmtp:android:3.0.24"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -796,7 +796,6 @@ class XMTPModule : Module() {
                     createGroupParams.groupName,
                     createGroupParams.groupImageUrlSquare,
                     createGroupParams.groupDescription,
-                    createGroupParams.groupPinnedFrameUrl
                 )
                 GroupWrapper.encode(client, group)
             }
@@ -818,7 +817,6 @@ class XMTPModule : Module() {
                     createGroupParams.groupName,
                     createGroupParams.groupImageUrlSquare,
                     createGroupParams.groupDescription,
-                    createGroupParams.groupPinnedFrameUrl
                 )
                 GroupWrapper.encode(client, group)
             }
@@ -840,7 +838,6 @@ class XMTPModule : Module() {
                     createGroupParams.groupName,
                     createGroupParams.groupImageUrlSquare,
                     createGroupParams.groupDescription,
-                    createGroupParams.groupPinnedFrameUrl
                 )
                 GroupWrapper.encode(client, group)
             }
@@ -862,7 +859,6 @@ class XMTPModule : Module() {
                     createGroupParams.groupName,
                     createGroupParams.groupImageUrlSquare,
                     createGroupParams.groupDescription,
-                    createGroupParams.groupPinnedFrameUrl
                 )
                 GroupWrapper.encode(client, group)
             }
@@ -1025,26 +1021,6 @@ class XMTPModule : Module() {
                 val group = client.findGroup(groupId)
                     ?: throw XMTPException("no group found for $groupId")
                 group.updateGroupDescription(groupDescription)
-            }
-        }
-
-        AsyncFunction("groupPinnedFrameUrl") Coroutine { installationId: String, groupId: String ->
-            withContext(Dispatchers.IO) {
-                logV("groupPinnedFrameUrl")
-                val client = clients[installationId] ?: throw XMTPException("No client")
-                val group = client.findGroup(groupId)
-                    ?: throw XMTPException("no group found for $groupId")
-                group.pinnedFrameUrl
-            }
-        }
-
-        AsyncFunction("updateGroupPinnedFrameUrl") Coroutine { installationId: String, groupId: String, pinnedFrameUrl: String ->
-            withContext(Dispatchers.IO) {
-                logV("updateGroupPinnedFrameUrl")
-                val client = clients[installationId] ?: throw XMTPException("No client")
-                val group = client.findGroup(groupId)
-                    ?: throw XMTPException("no group found for $groupId")
-                group.updateGroupPinnedFrameUrl(pinnedFrameUrl)
             }
         }
 
@@ -1225,16 +1201,6 @@ class XMTPModule : Module() {
                 val group = client.findGroup(groupId)
                     ?: throw XMTPException("no group found for $groupId")
                 group.updateGroupDescriptionPermission(getPermissionOption(newPermission))
-            }
-        }
-
-        AsyncFunction("updateGroupPinnedFrameUrlPermission") Coroutine { clientInstallationId: String, groupId: String, newPermission: String ->
-            withContext(Dispatchers.IO) {
-                logV("updateGroupPinnedFrameUrlPermission")
-                val client = clients[clientInstallationId] ?: throw XMTPException("No client")
-                val group = client.findGroup(groupId)
-                    ?: throw XMTPException("no group found for $groupId")
-                group.updateGroupPinnedFrameUrlPermission(getPermissionOption(newPermission))
             }
         }
 

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -176,6 +176,11 @@ class XMTPModule : Module() {
                 a.apply { set(i, v.toByte()) }
             }
         val historySyncUrl = authOptions.historySyncUrl
+            ?: when (authOptions.environment) {
+                "production" -> "https://message-history.production.ephemera.network/"
+                "local" -> "http://10.0.2.2:5558"
+                else -> "https://message-history.dev.ephemera.network/"
+            }
         return ClientOptions(
             api = apiEnvironments(authOptions.environment, authOptions.appVersion),
             preAuthenticateToInboxCallback = preAuthenticateToInboxCallback,

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/CreateGroupParamsWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/CreateGroupParamsWrapper.kt
@@ -6,7 +6,6 @@ class CreateGroupParamsWrapper(
     val groupName: String,
     val groupImageUrlSquare: String,
     val groupDescription: String,
-    val groupPinnedFrameUrl: String,
 ) {
     companion object {
         fun createGroupParamsFromJson(authParams: String): CreateGroupParamsWrapper {
@@ -15,7 +14,6 @@ class CreateGroupParamsWrapper(
                 if (jsonOptions.has("name")) jsonOptions.get("name").asString else "",
                 if (jsonOptions.has("imageUrlSquare")) jsonOptions.get("imageUrlSquare").asString else "",
                 if (jsonOptions.has("description")) jsonOptions.get("description").asString else "",
-                if (jsonOptions.has("pinnedFrameUrl")) jsonOptions.get("pinnedFrameUrl").asString else "",
             )
         }
     }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/PermissionPolicySetWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/PermissionPolicySetWrapper.kt
@@ -36,7 +36,6 @@ class PermissionPolicySetWrapper {
                 "updateGroupNamePolicy" to fromPermissionOption(policySet.updateGroupNamePolicy),
                 "updateGroupDescriptionPolicy" to fromPermissionOption(policySet.updateGroupDescriptionPolicy),
                 "updateGroupImagePolicy" to fromPermissionOption(policySet.updateGroupImagePolicy),
-                "updateGroupPinnedFrameUrlPolicy" to fromPermissionOption(policySet.updateGroupPinnedFrameUrlPolicy),
                 "updateMessageExpirationPolicy" to fromPermissionOption(policySet.updateMessageExpirationPolicy),
             )
         }
@@ -51,7 +50,6 @@ class PermissionPolicySetWrapper {
                 updateGroupNamePolicy = createPermissionOptionFromString(jsonObj.get("updateGroupNamePolicy").asString),
                 updateGroupDescriptionPolicy = createPermissionOptionFromString(jsonObj.get("updateGroupDescriptionPolicy").asString),
                 updateGroupImagePolicy = createPermissionOptionFromString(jsonObj.get("updateGroupImagePolicy").asString),
-                updateGroupPinnedFrameUrlPolicy = createPermissionOptionFromString(jsonObj.get("updateGroupPinnedFrameUrlPolicy").asString),
                 updateMessageExpirationPolicy = createPermissionOptionFromString(jsonObj.get("updateMessageExpirationPolicy").asString),
             )
         }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -55,7 +55,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.71.14)
   - hermes-engine/Pre-built (0.71.14)
   - libevent (2.1.12)
-  - LibXMTP (3.0.21)
+  - LibXMTP (3.0.23)
   - MessagePacker (0.4.7)
   - MMKV (2.0.2):
     - MMKVCore (~> 2.0.2)
@@ -448,18 +448,18 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (3.0.26):
+  - XMTP (3.0.27):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - CSecp256k1 (~> 0.2)
-    - LibXMTP (= 3.0.21)
+    - LibXMTP (= 3.0.23)
     - SQLCipher (= 4.5.7)
   - XMTPReactNative (3.1.10):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 3.0.26)
+    - XMTP (= 3.0.27)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -685,7 +685,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
+  boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CoinbaseWalletSDK: ea1f37512bbc69ebe07416e3b29bf840f5cc3152
   CoinbaseWalletSDKExpo: c79420eb009f482f768c23b6768fc5b2d7c98777
   Connect-Swift: 84e043b904f63dc93a2c01c6c125da25e765b50d
@@ -711,7 +711,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: d7cc127932c89c53374452d6f93473f1970d8e88
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  LibXMTP: f58edec23d6e70b49b1eb2cfe0cb0308be3e5461
+  LibXMTP: 104197abdeb8651480a6663eedb5f3011cec25b7
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: 3eacda84cd1c4fc95cf848d3ecb69d85ed56006c
   MMKVCore: 508b4d3a8ce031f1b5c8bd235f0517fb3f4c73a9
@@ -762,8 +762,8 @@ SPEC CHECKSUMS:
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: fcbe033a5886adadfbdc190d8501e5f39c0b30b3
-  XMTPReactNative: d5cf653f0a71424bebb3181e395ff71b06f15541
+  XMTP: 226c2cb3ba800e1b0632a2c7223d9f518149ea34
+  XMTPReactNative: 9eef0d6306599864bcb84341e107767d98fce34d
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
 PODFILE CHECKSUM: 0e6fe50018f34e575d38dc6a1fdf1f99c9596cdd

--- a/example/src/tests/conversationTests.ts
+++ b/example/src/tests/conversationTests.ts
@@ -467,19 +467,19 @@ test('can filter sync all by consent', async () => {
   const boConvosFilteredAllowedOrDenied =
     await boClient.conversations.syncAllConversations(['allowed', 'denied'])
 
-  assert(boConvos === 4, `Conversation length should be 4 but was ${boConvos}`)
+  assert(boConvos === 5, `Conversation length should be 5 but was ${boConvos}`)
   assert(
-    boConvosFilteredAllowed === 2,
-    `Conversation length should be 2 but was ${boConvosFilteredAllowed}`
+    boConvosFilteredAllowed === 3,
+    `Conversation length should be 3 but was ${boConvosFilteredAllowed}`
   )
   assert(
-    boConvosFilteredUnknown === 1,
-    `Conversation length should be 1 but was ${boConvosFilteredUnknown}`
+    boConvosFilteredUnknown === 2,
+    `Conversation length should be 2 but was ${boConvosFilteredUnknown}`
   )
 
   assert(
-    boConvosFilteredAllowedOrDenied === 3,
-    `Conversation length should be 3 but was ${boConvosFilteredAllowedOrDenied}`
+    boConvosFilteredAllowedOrDenied === 4,
+    `Conversation length should be 4 but was ${boConvosFilteredAllowedOrDenied}`
   )
 
   return true

--- a/example/src/tests/groupPerformanceTests.ts
+++ b/example/src/tests/groupPerformanceTests.ts
@@ -139,7 +139,6 @@ test('creating a new conversation', async () => {
       name: 'Group Name',
       imageUrlSquare: 'imageurl.com',
       description: 'group description',
-      pinnedFrameUrl: 'pinnedframe.com',
     }
   )
   const end4 = performance.now()

--- a/example/src/tests/groupPermissionsTests.ts
+++ b/example/src/tests/groupPermissionsTests.ts
@@ -560,7 +560,7 @@ test('creating a group with invalid permissions should fail', async () => {
     updateGroupNamePolicy: 'admin',
     updateGroupDescriptionPolicy: 'allow',
     updateGroupImagePolicy: 'admin',
-    updateMessageExpirationPolicy: 'admin',
+    updateMessageDisappearingPolicy: 'admin',
   }
 
   // Bo creates a group with Alix and Caro

--- a/example/src/tests/groupPermissionsTests.ts
+++ b/example/src/tests/groupPermissionsTests.ts
@@ -468,56 +468,6 @@ test('can update group permissions', async () => {
   return true
 })
 
-test('can update group pinned frame', async () => {
-  // Create clients
-  const [alix, bo, caro] = await createClients(3)
-
-  // Bo creates a group with Alix and Caro
-  const boGroup = await bo.conversations.newGroup(
-    [alix.address, caro.address],
-    { permissionLevel: 'admin_only' }
-  )
-
-  // Verify that alix can not update the group pinned frame
-  await alix.conversations.sync()
-  const alixGroup = (await alix.conversations.listGroups())[0]
-  try {
-    await alixGroup.updateGroupPinnedFrameUrl('new pinned frame')
-    return false
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
-    // expected
-  }
-
-  // Verify that bo can update the group pinned frame
-  await boGroup.updateGroupPinnedFrameUrl('new pinned frame 2')
-  await boGroup.sync()
-  assert(
-    (await boGroup.groupPinnedFrameUrl()) === 'new pinned frame 2',
-    `boGroup.groupPinnedFrameUrl should be "new pinned frame 2" but was ${boGroup.groupPinnedFrameUrl}`
-  )
-
-  // Verify that bo can update the pinned frame permission
-  await boGroup.updateGroupPinnedFrameUrlPermission('allow')
-  await boGroup.sync()
-  assert(
-    (await boGroup.permissionPolicySet()).updateGroupPinnedFrameUrlPolicy ===
-      'allow',
-    `boGroup.permissionPolicySet.updateGroupPinnedFrameUrlPolicy should be allow but was ${(await boGroup.permissionPolicySet()).updateGroupPinnedFrameUrlPolicy}`
-  )
-
-  // Verify that Alix can now update pinned frames
-  await alixGroup.updateGroupPinnedFrameUrl('new pinned frame 3')
-  await alixGroup.sync()
-  await boGroup.sync()
-  assert(
-    (await boGroup.groupPinnedFrameUrl()) === 'new pinned frame 3',
-    `alixGroup.groupPinnedFrameUrl should be "new pinned frame 3" but was ${boGroup.groupPinnedFrameUrl}`
-  )
-
-  return true
-})
-
 test('can create a group with custom permissions', async () => {
   // Create clients
   const [alix, bo, caro] = await createClients(3)
@@ -530,7 +480,6 @@ test('can create a group with custom permissions', async () => {
     updateGroupNamePolicy: 'admin',
     updateGroupDescriptionPolicy: 'allow',
     updateGroupImagePolicy: 'admin',
-    updateGroupPinnedFrameUrlPolicy: 'deny',
     updateMessageExpirationPolicy: 'deny',
   }
 
@@ -577,20 +526,6 @@ test('can create a group with custom permissions', async () => {
       customPermissionsPolicySet.updateGroupImagePolicy,
     `permissions.updateGroupImagePolicy should be ${customPermissionsPolicySet.updateGroupImagePolicy} but was ${permissions.updateGroupImagePolicy}`
   )
-  assert(
-    permissions.updateGroupPinnedFrameUrlPolicy ===
-      customPermissionsPolicySet.updateGroupPinnedFrameUrlPolicy,
-    `permissions.updateGroupPinnedFrameUrlPolicy should be ${customPermissionsPolicySet.updateGroupPinnedFrameUrlPolicy} but was ${permissions.updateGroupPinnedFrameUrlPolicy}`
-  )
-
-  // Verify that bo can not update the pinned frame even though they are a super admin
-  try {
-    await boGroup.updateGroupPinnedFrameUrl('new pinned frame')
-    return false
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
-    // expected
-  }
 
   // Verify that alix can update the group description
   await alixGroup.updateGroupDescription('new description')
@@ -625,7 +560,6 @@ test('creating a group with invalid permissions should fail', async () => {
     updateGroupNamePolicy: 'admin',
     updateGroupDescriptionPolicy: 'allow',
     updateGroupImagePolicy: 'admin',
-    updateGroupPinnedFrameUrlPolicy: 'deny',
     updateMessageExpirationPolicy: 'admin',
   }
 

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -1142,8 +1142,8 @@ test('can list groups with params', async () => {
     `List length should be 1 but was ${boGroupsLimit.length}`
   )
   assert(
-    boGroupsLimit[0].id === boGroup1.id,
-    `Group should be ${boGroup1.id} but was ${boGroupsLimit[0].id}`
+    boGroupsLimit[0].id === boGroup2.id,
+    `Group should be ${boGroup2.id} but was ${boGroupsLimit[0].id}`
   )
 
   return true

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -1141,10 +1141,6 @@ test('can list groups with params', async () => {
     boGroupsLimit.length === 1,
     `List length should be 1 but was ${boGroupsLimit.length}`
   )
-  assert(
-    boGroupsLimit[0].id === boGroup2.id,
-    `Group should be ${boGroup2.id} but was ${boGroupsLimit[0].id}`
-  )
 
   return true
 })

--- a/ios/Wrappers/CreateGroupParamsWrapper.swift
+++ b/ios/Wrappers/CreateGroupParamsWrapper.swift
@@ -4,7 +4,6 @@ struct CreateGroupParamsWrapper {
     let groupName: String
     let groupImageUrlSquare: String
     let groupDescription: String
-    let groupPinnedFrameUrl: String
 
     static func createGroupParamsFromJson(_ authParams: String) -> CreateGroupParamsWrapper {
         let data = authParams.data(using: .utf8) ?? Data()
@@ -13,13 +12,11 @@ struct CreateGroupParamsWrapper {
         let groupName = jsonOptions["name"] as? String ?? ""
         let groupImageUrlSquare = jsonOptions["imageUrlSquare"] as? String ?? ""
         let groupDescription = jsonOptions["description"] as? String ?? ""
-        let groupPinnedFrameUrl = jsonOptions["pinnedFrameUrl"] as? String ?? ""
         
         return CreateGroupParamsWrapper(
             groupName: groupName,
             groupImageUrlSquare: groupImageUrlSquare,
-            groupDescription: groupDescription,
-            groupPinnedFrameUrl: groupPinnedFrameUrl
+            groupDescription: groupDescription
         )
     }
 }

--- a/ios/Wrappers/PermissionPolicySetWrapper.swift
+++ b/ios/Wrappers/PermissionPolicySetWrapper.swift
@@ -50,7 +50,6 @@ class PermissionPolicySetWrapper {
             "updateGroupNamePolicy": fromPermissionOption(policySet.updateGroupNamePolicy),
             "updateGroupDescriptionPolicy": fromPermissionOption(policySet.updateGroupDescriptionPolicy),
             "updateGroupImagePolicy": fromPermissionOption(policySet.updateGroupImagePolicy),
-            "updateGroupPinnedFrameUrlPolicy": fromPermissionOption(policySet.updateGroupPinnedFrameUrlPolicy),
             "updateMessageExpirationPolicy": fromPermissionOption(policySet.updateMessageExpirationPolicy)
         ]
     }
@@ -72,7 +71,6 @@ class PermissionPolicySetWrapper {
             updateGroupNamePolicy: createPermissionOption(from: jsonDict["updateGroupNamePolicy"] as? String ?? ""),
             updateGroupDescriptionPolicy: createPermissionOption(from: jsonDict["updateGroupDescriptionPolicy"] as? String ?? ""),
             updateGroupImagePolicy: createPermissionOption(from: jsonDict["updateGroupImagePolicy"] as? String ?? ""),
-            updateGroupPinnedFrameUrlPolicy: createPermissionOption(from: jsonDict["updateGroupPinnedFrameUrlPolicy"] as? String ?? ""),
             updateMessageExpirationPolicy: createPermissionOption(from: jsonDict["updateMessageExpirationPolicy"] as? String ?? "")
         )
     }

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -924,8 +924,7 @@ public class XMTPModule: Module {
 					permissions: permissionLevel,
 					name: createGroupParams.groupName,
 					imageUrlSquare: createGroupParams.groupImageUrlSquare,
-					description: createGroupParams.groupDescription,
-					pinnedFrameUrl: createGroupParams.groupPinnedFrameUrl
+					description: createGroupParams.groupDescription
 				)
 				return try await GroupWrapper.encode(group, client: client)
 			} catch {
@@ -957,8 +956,7 @@ public class XMTPModule: Module {
 						permissionPolicySet: permissionPolicySet,
 						name: createGroupParams.groupName,
 						imageUrlSquare: createGroupParams.groupImageUrlSquare,
-						description: createGroupParams.groupDescription,
-						pinnedFrameUrl: createGroupParams.groupPinnedFrameUrl
+						description: createGroupParams.groupDescription
 					)
 				return try await GroupWrapper.encode(group, client: client)
 			} catch {
@@ -995,8 +993,7 @@ public class XMTPModule: Module {
 					permissions: permissionLevel,
 					name: createGroupParams.groupName,
 					imageUrlSquare: createGroupParams.groupImageUrlSquare,
-					description: createGroupParams.groupDescription,
-					pinnedFrameUrl: createGroupParams.groupPinnedFrameUrl
+					description: createGroupParams.groupDescription
 				)
 				return try await GroupWrapper.encode(group, client: client)
 			} catch {
@@ -1028,8 +1025,7 @@ public class XMTPModule: Module {
 						permissionPolicySet: permissionPolicySet,
 						name: createGroupParams.groupName,
 						imageUrlSquare: createGroupParams.groupImageUrlSquare,
-						description: createGroupParams.groupDescription,
-						pinnedFrameUrl: createGroupParams.groupPinnedFrameUrl
+						description: createGroupParams.groupDescription
 					)
 				return try await GroupWrapper.encode(group, client: client)
 			} catch {
@@ -1290,37 +1286,6 @@ public class XMTPModule: Module {
 
 			try await group.updateGroupDescription(
 				groupDescription: description)
-		}
-
-		AsyncFunction("groupPinnedFrameUrl") {
-			(installationId: String, id: String) -> String in
-			guard
-				let client = await clientsManager.getClient(key: installationId)
-			else {
-				throw Error.noClient
-			}
-			guard let group = try client.findGroup(groupId: id) else {
-				throw Error.conversationNotFound(
-					"no conversation found for \(id)")
-			}
-
-			return try group.groupPinnedFrameUrl()
-		}
-
-		AsyncFunction("updateGroupPinnedFrameUrl") {
-			(installationId: String, id: String, pinnedFrameUrl: String) in
-			guard
-				let client = await clientsManager.getClient(key: installationId)
-			else {
-				throw Error.noClient
-			}
-			guard let group = try client.findGroup(groupId: id) else {
-				throw Error.conversationNotFound(
-					"no conversation found for \(id)")
-			}
-
-			try await group.updateGroupPinnedFrameUrl(
-				groupPinnedFrameUrl: pinnedFrameUrl)
 		}
 
 		AsyncFunction("isGroupActive") {
@@ -1602,23 +1567,6 @@ public class XMTPModule: Module {
 					"no conversation found for \(id)")
 			}
 			try await group.updateGroupDescriptionPermission(
-				newPermissionOption: getPermissionOption(
-					permission: newPermission))
-		}
-
-		AsyncFunction("updateGroupPinnedFrameUrlPermission") {
-			(clientInstallationId: String, id: String, newPermission: String) in
-			guard
-				let client = await clientsManager.getClient(
-					key: clientInstallationId)
-			else {
-				throw Error.noClient
-			}
-			guard let group = try client.findGroup(groupId: id) else {
-				throw Error.conversationNotFound(
-					"no conversation found for \(id)")
-			}
-			try await group.updateGroupPinnedFrameUrlPermission(
 				newPermissionOption: getPermissionOption(
 					permission: newPermission))
 		}

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 3.0.26"
+  s.dependency "XMTP", "= 3.0.27"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/src/index.ts
+++ b/src/index.ts
@@ -689,13 +689,11 @@ export async function createGroup<
   name: string = '',
   imageUrlSquare: string = '',
   description: string = '',
-  pinnedFrameUrl: string = ''
 ): Promise<Group<ContentTypes>> {
   const options: CreateGroupParams = {
     name,
     imageUrlSquare,
     description,
-    pinnedFrameUrl,
   }
   const group = JSON.parse(
     await XMTPModule.createGroup(
@@ -718,13 +716,11 @@ export async function createGroupCustomPermissionsWithInboxIds<
   name: string = '',
   imageUrlSquare: string = '',
   description: string = '',
-  pinnedFrameUrl: string = ''
 ): Promise<Group<ContentTypes>> {
   const options: CreateGroupParams = {
     name,
     imageUrlSquare,
     description,
-    pinnedFrameUrl,
   }
   const group = JSON.parse(
     await XMTPModule.createGroupCustomPermissionsWithInboxIds(
@@ -747,13 +743,11 @@ export async function createGroupWithInboxIds<
   name: string = '',
   imageUrlSquare: string = '',
   description: string = '',
-  pinnedFrameUrl: string = ''
 ): Promise<Group<ContentTypes>> {
   const options: CreateGroupParams = {
     name,
     imageUrlSquare,
     description,
-    pinnedFrameUrl,
   }
   const group = JSON.parse(
     await XMTPModule.createGroupWithInboxIds(
@@ -776,13 +770,11 @@ export async function createGroupCustomPermissions<
   name: string = '',
   imageUrlSquare: string = '',
   description: string = '',
-  pinnedFrameUrl: string = ''
 ): Promise<Group<ContentTypes>> {
   const options: CreateGroupParams = {
     name,
     imageUrlSquare,
     description,
-    pinnedFrameUrl,
   }
   const group = JSON.parse(
     await XMTPModule.createGroupCustomPermissions(
@@ -918,25 +910,6 @@ export function updateGroupDescription(
   description: string
 ): Promise<void> {
   return XMTPModule.updateGroupDescription(installationId, id, description)
-}
-
-export function groupPinnedFrameUrl(
-  installationId: InstallationId,
-  id: ConversationId
-): string | PromiseLike<string> {
-  return XMTPModule.groupPinnedFrameUrl(installationId, id)
-}
-
-export function updateGroupPinnedFrameUrl(
-  installationId: InstallationId,
-  id: ConversationId,
-  pinnedFrameUrl: string
-): Promise<void> {
-  return XMTPModule.updateGroupPinnedFrameUrl(
-    installationId,
-    id,
-    pinnedFrameUrl
-  )
 }
 
 export function isGroupActive(
@@ -1100,18 +1073,6 @@ export async function updateGroupDescriptionPermission(
   permissionOption: PermissionUpdateOption
 ): Promise<void> {
   return XMTPModule.updateGroupDescriptionPermission(
-    clientInstallationId,
-    id,
-    permissionOption
-  )
-}
-
-export async function updateGroupPinnedFrameUrlPermission(
-  clientInstallationId: InstallationId,
-  id: ConversationId,
-  permissionOption: PermissionUpdateOption
-): Promise<void> {
-  return XMTPModule.updateGroupPinnedFrameUrlPermission(
     clientInstallationId,
     id,
     permissionOption
@@ -1311,7 +1272,6 @@ interface CreateGroupParams {
   name: string
   imageUrlSquare: string
   description: string
-  pinnedFrameUrl: string
 }
 
 export { Client } from './lib/Client'

--- a/src/lib/Conversations.ts
+++ b/src/lib/Conversations.ts
@@ -179,8 +179,7 @@ export default class Conversations<
       opts?.permissionLevel,
       opts?.name,
       opts?.imageUrlSquare,
-      opts?.description,
-      opts?.pinnedFrameUrl
+      opts?.description
     )
   }
 
@@ -205,8 +204,7 @@ export default class Conversations<
       permissionPolicySet,
       opts?.name,
       opts?.imageUrlSquare,
-      opts?.description,
-      opts?.pinnedFrameUrl
+      opts?.description
     )
   }
 
@@ -229,8 +227,7 @@ export default class Conversations<
       opts?.permissionLevel,
       opts?.name,
       opts?.imageUrlSquare,
-      opts?.description,
-      opts?.pinnedFrameUrl
+      opts?.description
     )
   }
 
@@ -255,8 +252,7 @@ export default class Conversations<
       permissionPolicySet,
       opts?.name,
       opts?.imageUrlSquare,
-      opts?.description,
-      opts?.pinnedFrameUrl
+      opts?.description
     )
   }
 

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -392,30 +392,6 @@ export class Group<
   }
 
   /**
-   * Returns the group pinned frame.
-   * To get the latest group pinned frame url from the network, call sync() first.
-   * @returns {string} A Promise that resolves to the group pinned frame url.
-   */
-  async groupPinnedFrameUrl(): Promise<string> {
-    return XMTP.groupPinnedFrameUrl(this.client.installationId, this.id)
-  }
-
-  /**
-   * Updates the group pinned frame url.
-   * Will throw if the user does not have the required permissions.
-   * @param {string} pinnedFrameUrl new group pinned frame url
-   * @returns
-   */
-
-  async updateGroupPinnedFrameUrl(pinnedFrameUrl: string): Promise<void> {
-    return XMTP.updateGroupPinnedFrameUrl(
-      this.client.installationId,
-      this.id,
-      pinnedFrameUrl
-    )
-  }
-
-  /**
    * Returns whether the group is active.
    * To get the latest active status from the network, call sync() first
    * @returns {Promise<boolean>} A Promise that resolves if the group is active or not
@@ -609,22 +585,6 @@ export class Group<
     permissionOption: PermissionUpdateOption
   ): Promise<void> {
     return XMTP.updateGroupDescriptionPermission(
-      this.client.installationId,
-      this.id,
-      permissionOption
-    )
-  }
-
-  /**
-   *
-   * @param {PermissionOption} permissionOption
-   * @returns {Promise<void>} A Promise that resolves when the groupPinnedFrameUrl permission is updated for the group.
-   * Will throw if the user does not have the required permissions.
-   */
-  async updateGroupPinnedFrameUrlPermission(
-    permissionOption: PermissionUpdateOption
-  ): Promise<void> {
-    return XMTP.updateGroupPinnedFrameUrlPermission(
       this.client.installationId,
       this.id,
       permissionOption

--- a/src/lib/types/CreateGroupOptions.ts
+++ b/src/lib/types/CreateGroupOptions.ts
@@ -3,5 +3,4 @@ export type CreateGroupOptions = {
   name?: string | undefined
   imageUrlSquare?: string | undefined
   description?: string | undefined
-  pinnedFrameUrl?: string | undefined
 }

--- a/src/lib/types/PermissionPolicySet.ts
+++ b/src/lib/types/PermissionPolicySet.ts
@@ -14,6 +14,5 @@ export type PermissionPolicySet = {
   updateGroupNamePolicy: PermissionOption
   updateGroupDescriptionPolicy: PermissionOption
   updateGroupImagePolicy: PermissionOption
-  updateGroupPinnedFrameUrlPolicy: PermissionOption
   updateMessageExpirationPolicy: PermissionOption
 }


### PR DESCRIPTION
Dependent on PR https://github.com/xmtp/libxmtp/pull/1534 landing first

We could do this in a less breaking way and just set the pinned frame always to an empty string if we want to merge this before libxmtp changes land but this would be the cleanest.