### PR TITLE
remove drop db connection on background on ios

### DIFF
--- a/.changeset/honest-camels-watch.md
+++ b/.changeset/honest-camels-watch.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+remove drop db connection on background on ios

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -2319,18 +2319,6 @@ public class XMTPModule: Module {
 
 			return logOutput
 		}
-
-		OnAppBecomesActive {
-			Task {
-				try await clientsManager.reconnectAllLocalDatabaseConnections()
-			}
-		}
-
-		OnAppEntersBackground {
-			Task {
-				try await clientsManager.dropAllLocalDatabaseConnections()
-			}
-		}
 	}
 
 	//


### PR DESCRIPTION
Reversing this change from https://github.com/xmtp/xmtp-react-native/pull/467

Was initially implemented as a workaround for db locks, which are now largely resolved in libxmtp with a single db write connection. 