### PR TITLE
Should Push for Push Notifications

### DIFF
--- a/.changeset/four-cougars-juggle.md
+++ b/.changeset/four-cougars-juggle.md
@@ -1,0 +1,6 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+- adds `should_push` to messages for push notifications handling
+- fixes occasional rust panic crash in streams

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:3.0.28"
+  implementation "org.xmtp:android:3.0.29"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 3.0.32"
+  s.dependency "XMTP", "= 3.0.33"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end


### PR DESCRIPTION
Adds the should_push field to messages so that push notification servers can respect them accordingly.

Should also fix rust panic on streams