### PR TITLE
chore: added a link to the badge lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # xmtp-react-native
  
-![Lint](https://github.com/xmtp/xmtp-android/actions/workflows/lint.yml/badge.svg) ![Status](https://img.shields.io/badge/Project_Status-Production-brightgreen)
+[![Lint](https://github.com/xmtp/xmtp-android/actions/workflows/lint.yml/badge.svg)](https://github.com/xmtp/xmtp-react-native/actions/workflows/lint.yml) 
+![Status](https://img.shields.io/badge/Project_Status-Production-brightgreen)
 
 This repo provides a package you can use to build with XMTP in a React Native or Expo app.
 


### PR DESCRIPTION
## docs: Add clickable link to Lint status badge
Added hyperlink to the Lint status badge in README.md that points to the GitHub Actions workflow for the xmtp-react-native repository

### 📍Where to Start
The modified badge link in [README.md](https://github.com/xmtp/xmtp-react-native/pull/625/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)

----

_[Macroscope](https://app.macroscope.com) summarized 65c41b1._