### PR TITLE
Patch fix from libxmtp 1.1.1 for welcome message error

### DIFF
--- a/.changeset/fuzzy-readers-protect.md
+++ b/.changeset/fuzzy-readers-protect.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+Refactored welcome message processing to prevent key package deletion on failure

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.0.0"
+  implementation "org.xmtp:android:4.0.1"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -55,7 +55,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.71.14)
   - hermes-engine/Pre-built (0.71.14)
   - libevent (2.1.12)
-  - LibXMTP (4.0.0)
+  - LibXMTP (4.0.1)
   - MessagePacker (0.4.7)
   - MMKV (2.1.0):
     - MMKVCore (~> 2.1.0)
@@ -448,18 +448,18 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.0.0):
+  - XMTP (4.0.1):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - CSecp256k1 (~> 0.2)
-    - LibXMTP (= 4.0.0)
+    - LibXMTP (= 4.0.1)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (4.0.0-rc2):
+  - XMTPReactNative (4.0.0):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.0.0)
+    - XMTP (= 4.0.1)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -711,7 +711,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: d7cc127932c89c53374452d6f93473f1970d8e88
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  LibXMTP: d4ab1b29d090a215e7452a8c0fdc5ba889e8742d
+  LibXMTP: 368241361f468a84c6b7e02e2d63561bcd964ecd
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: ce484c1ac40bf76d5f09a0195d2ec5b3d3840d55
   MMKVCore: 1eb661c6c498ab88e3df9ce5d8ff94d05fcc0567
@@ -762,8 +762,8 @@ SPEC CHECKSUMS:
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: 23e6425f056dc52c712f17584a4ebb3256fb34d7
-  XMTPReactNative: 9b8d5d3dea565526caa5774b198c8decbc83843f
+  XMTP: e638e4924d18f5a362de982d8d80a9694c10e0c7
+  XMTPReactNative: d249f8a8525556e604f831b6e0981805e8e9943d
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
 PODFILE CHECKSUM: 2d04c11c2661aeaad852cd3ada0b0f1b06e0cf24

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.0.0"
+  s.dependency "XMTP", "= 4.0.1"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end


### PR DESCRIPTION
## Update XMTP dependencies to version 4.0.1
Updated XMTP package dependencies from version 4.0.0 to 4.0.1 in both Android and iOS build configurations

### 📍Where to Start
- The Android Gradle configuration in [build.gradle](https://github.com/xmtp/xmtp-react-native/pull/627/files#diff-f0881d3540b346da5e7541e8450ad0faed5c74c1857cd76c4465c287bab972d9R0) and iOS podspec in [XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/627/files#diff-66acc2b5704a51ed416756a77088c6b58103ff4c7b9fe0b992188c4f322c3679R0)

----

_[Macroscope](https://app.macroscope.com) summarized 8988cce._