### PR TITLE
Fix invalid key packages 

### DIFF
--- a/.changeset/olive-cougars-bow.md
+++ b/.changeset/olive-cougars-bow.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+- Fix invalid key packages 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.0.2"
+  implementation "org.xmtp:android:4.0.3"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.0.1"
+  implementation "org.xmtp:android:4.0.2"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -55,7 +55,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.71.14)
   - hermes-engine/Pre-built (0.71.14)
   - libevent (2.1.12)
-  - LibXMTP (4.0.1)
+  - LibXMTP (4.0.2)
   - MessagePacker (0.4.7)
   - MMKV (2.1.0):
     - MMKVCore (~> 2.1.0)
@@ -448,18 +448,18 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.0.2):
+  - XMTP (4.0.3):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - CSecp256k1 (~> 0.2)
-    - LibXMTP (= 4.0.1)
+    - LibXMTP (= 4.0.2)
     - SQLCipher (= 4.5.7)
   - XMTPReactNative (4.0.1):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.0.2)
+    - XMTP (= 4.0.3)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -711,7 +711,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: d7cc127932c89c53374452d6f93473f1970d8e88
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  LibXMTP: 368241361f468a84c6b7e02e2d63561bcd964ecd
+  LibXMTP: 35fc4ed23e8d048ae4fc96c7e0c750cfd9984e43
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: ce484c1ac40bf76d5f09a0195d2ec5b3d3840d55
   MMKVCore: 1eb661c6c498ab88e3df9ce5d8ff94d05fcc0567
@@ -762,10 +762,10 @@ SPEC CHECKSUMS:
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: 1fc757ccff6d66065a214d03187064d78559a4b1
-  XMTPReactNative: b8afaab064a90258b40343d735280432ec92a1a7
+  XMTP: a143a9c53da99c24bf8198821e4d124a40dbd6b0
+  XMTPReactNative: 626970e18dab53bc753e981de61e2c875899e39e
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
 PODFILE CHECKSUM: 2d04c11c2661aeaad852cd3ada0b0f1b06e0cf24
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -55,7 +55,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.71.14)
   - hermes-engine/Pre-built (0.71.14)
   - libevent (2.1.12)
-  - LibXMTP (4.0.2)
+  - LibXMTP (4.0.3)
   - MessagePacker (0.4.7)
   - MMKV (2.1.0):
     - MMKVCore (~> 2.1.0)
@@ -448,18 +448,18 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.0.3):
+  - XMTP (4.0.4):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - CSecp256k1 (~> 0.2)
-    - LibXMTP (= 4.0.2)
+    - LibXMTP (= 4.0.3)
     - SQLCipher (= 4.5.7)
   - XMTPReactNative (4.0.1):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.0.3)
+    - XMTP (= 4.0.4)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -711,7 +711,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: d7cc127932c89c53374452d6f93473f1970d8e88
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  LibXMTP: 35fc4ed23e8d048ae4fc96c7e0c750cfd9984e43
+  LibXMTP: 8afe9d029d10d2067d24b98c0d4cb9531d30c32f
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: ce484c1ac40bf76d5f09a0195d2ec5b3d3840d55
   MMKVCore: 1eb661c6c498ab88e3df9ce5d8ff94d05fcc0567
@@ -762,8 +762,8 @@ SPEC CHECKSUMS:
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: a143a9c53da99c24bf8198821e4d124a40dbd6b0
-  XMTPReactNative: 626970e18dab53bc753e981de61e2c875899e39e
+  XMTP: 8336ee33cc121976532f64576619f35b6da68f29
+  XMTPReactNative: 8be869e824a9f469a26e3e45bc97961ecbe90438
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
 PODFILE CHECKSUM: 2d04c11c2661aeaad852cd3ada0b0f1b06e0cf24

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.0.2"
+  s.dependency "XMTP", "= 4.0.3"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.0.3"
+  s.dependency "XMTP", "= 4.0.4"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end


### PR DESCRIPTION
### Update XMTP SDK dependencies to fix invalid key packages in React Native SDK for both Android and iOS platforms
* Updates `org.xmtp:android` dependency from version `4.0.1` to `4.0.3` in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/633/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a)
* Updates iOS dependencies in [ios/XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/633/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3) and [example/ios/Podfile.lock](https://github.com/xmtp/xmtp-react-native/pull/633/files#diff-b2790cc3d555682b207af1ca2fb897ebd2114c01149bf460fd85fc2b1503a687):
  - `LibXMTP` from `4.0.1` to `4.0.2`
  - `XMTP` from `4.0.2` to `4.0.4`
  - `XMTPReactNative` to use `XMTP 4.0.3`
* Adds changeset documentation in [.changeset/olive-cougars-bow.md](https://github.com/xmtp/xmtp-react-native/pull/633/files#diff-f415d292055f9700227df91d1cd05e567d9287f6502aa14d139e4b69eae75fd4) for `@xmtp/react-native-sdk` package

#### 📍Where to Start
Start with the dependency configuration in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/633/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a) and [ios/XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/633/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3) to review the version updates for both platforms.

----

_[Macroscope](https://app.macroscope.com) summarized 0dc9c6c._