### PR TITLE
Key package patch 2

### DIFF
--- a/.changeset/nice-onions-vanish.md
+++ b/.changeset/nice-onions-vanish.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+A hot fix release for keyPackages, fixes remove member with invalid key package

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:3.1.0"
+  implementation "org.xmtp:android:3.1.1"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -55,7 +55,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.71.14)
   - hermes-engine/Pre-built (0.71.14)
   - libevent (2.1.12)
-  - LibXMTP (3.1.0)
+  - LibXMTP (3.1.1)
   - MessagePacker (0.4.7)
   - MMKV (2.1.0):
     - MMKVCore (~> 2.1.0)
@@ -448,18 +448,18 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (3.1.0):
+  - XMTP (3.1.1):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - CSecp256k1 (~> 0.2)
-    - LibXMTP (= 3.1.0)
+    - LibXMTP (= 3.1.1)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (3.1.17):
+  - XMTPReactNative (3.2.0):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 3.1.0)
+    - XMTP (= 3.1.1)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -711,7 +711,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: d7cc127932c89c53374452d6f93473f1970d8e88
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  LibXMTP: 91a1663c23fd77bd7de99c3a61921d7363a2585f
+  LibXMTP: 5ae3361cbbe7a02a0168d33e0b5e001846db2e42
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: ce484c1ac40bf76d5f09a0195d2ec5b3d3840d55
   MMKVCore: 1eb661c6c498ab88e3df9ce5d8ff94d05fcc0567
@@ -762,8 +762,8 @@ SPEC CHECKSUMS:
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: dda9e161e40888846c666189518b92a47e4020b1
-  XMTPReactNative: f8218aad550bf4aecfb1aa9d0183a429f0bdf0e6
+  XMTP: 862f6b2fd22dc5e90ca00a90ba8f357614af8682
+  XMTPReactNative: 3abf27496e33cbd97f8c80f2700c914565173dcf
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
 PODFILE CHECKSUM: 2d04c11c2661aeaad852cd3ada0b0f1b06e0cf24

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 3.1.0"
+  s.dependency "XMTP", "= 3.1.1"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end


### PR DESCRIPTION
### Update XMTP library dependencies from version 3.1.0 to 3.1.1 for Android and iOS platforms
Updates the XMTP library dependency versions in both platform-specific build configuration files:

* Android: Updated XMTP library from `3.1.0` to `3.1.1` in [build.gradle](https://github.com/xmtp/xmtp-react-native/pull/635/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a)
* iOS: Updated XMTP library from `3.1.0` to `3.1.1` in [XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/635/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3)

#### 📍Where to Start
Begin by reviewing the version update in [build.gradle](https://github.com/xmtp/xmtp-react-native/pull/635/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a) for Android, followed by the iOS dependency update in [XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/635/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3).

----

_[Macroscope](https://app.macroscope.com) summarized c908f39._ (Automatic summaries will resume when PR exits draft mode or review begins).