### PR TITLE
Fix legacy db paths

### DIFF
--- a/.changeset/real-seahorses-provide.md
+++ b/.changeset/real-seahorses-provide.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+- Fixes legacy db paths

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -448,18 +448,18 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.0.4):
+  - XMTP (4.0.5):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - CSecp256k1 (~> 0.2)
     - LibXMTP (= 4.0.3)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (4.0.1):
+  - XMTPReactNative (4.0.2):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.0.4)
+    - XMTP (= 4.0.5)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -762,8 +762,8 @@ SPEC CHECKSUMS:
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: 8336ee33cc121976532f64576619f35b6da68f29
-  XMTPReactNative: 8be869e824a9f469a26e3e45bc97961ecbe90438
+  XMTP: 070d4af15cd46ef7243621f1c44a4f5f8ec1e894
+  XMTPReactNative: a13ef70582f590a735fdeb40b93eb22197e2dbe8
   Yoga: e71803b4c1fff832ccf9b92541e00f9b873119b9
 
 PODFILE CHECKSUM: 2d04c11c2661aeaad852cd3ada0b0f1b06e0cf24

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.0.4"
+  s.dependency "XMTP", "= 4.0.5"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end


### PR DESCRIPTION
Allow legacy db paths to work as well.
Introduced in https://github.com/xmtp/xmtp-ios/pull/491
Previously we appended the port to the db path now we do not.