### PR TITLE
Welcome processing fix patch release

### DIFF
--- a/.changeset/tricky-toys-agree.md
+++ b/.changeset/tricky-toys-agree.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+Welcome processing fix patch release

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.0.4"
+  implementation "org.xmtp:android:4.0.5"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -60,7 +60,7 @@ PODS:
   - hermes-engine (0.76.9):
     - hermes-engine/Pre-built (= 0.76.9)
   - hermes-engine/Pre-built (0.76.9)
-  - LibXMTP (4.0.4)
+  - LibXMTP (4.0.5)
   - MessagePacker (0.4.7)
   - MMKV (2.1.0):
     - MMKVCore (~> 2.1.0)
@@ -1737,18 +1737,18 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.0.6):
+  - XMTP (4.0.7):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - CSecp256k1 (~> 0.2)
-    - LibXMTP (= 4.0.4)
+    - LibXMTP (= 4.0.5)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (4.0.3):
+  - XMTPReactNative (4.0.4):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.0.6)
+    - XMTP (= 4.0.7)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2080,7 +2080,7 @@ SPEC CHECKSUMS:
   fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 9e868dc7be781364296d6ee2f56d0c1a9ef0bb11
-  LibXMTP: f483261aa52ed115a2fa937990121391d549c0f6
+  LibXMTP: dc2146c42a94861fe1f1c64d9b592a94dc0a8a06
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: ce484c1ac40bf76d5f09a0195d2ec5b3d3840d55
   MMKVCore: 1eb661c6c498ab88e3df9ce5d8ff94d05fcc0567
@@ -2160,8 +2160,8 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: a9ae4752dea8f94ffd8ac8a80aa7fb87113d49d5
-  XMTPReactNative: 8b15c7a5134cbbc2b751b88a110a00199f5a11ee
+  XMTP: cca2b0975730b1c4f44f568af070aa677a97c0de
+  XMTPReactNative: 8811a8d8679bbe5b6d8f8e71a67854aba9237b26
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 283c313cbc1ba9857a692b5901eb740dad922eca

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.0.6"
+  s.dependency "XMTP", "= 4.0.7"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end


### PR DESCRIPTION
### Update XMTP library dependencies to fix welcome processing in React Native SDK
* Updates Android XMTP library from `4.0.4` to `4.0.5` in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/653/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a)
* Updates iOS XMTP library from `4.0.6` to `4.0.7` in [ios/XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/653/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3)
* Adds changeset entry in [.changeset/tricky-toys-agree.md](https://github.com/xmtp/xmtp-react-native/pull/653/files#diff-eacbcef8f9028b54025b3911ecbfc896c2351ec65cf0ad199eca5705e53ca515) for patch release

#### 📍Where to Start
Start with the version updates in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/653/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a) and [ios/XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/653/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3) to verify the dependency changes.

----

_[Macroscope](https://app.macroscope.com) summarized 4db4449._