### PR TITLE
Try to release again

### DIFF
--- a/.changeset/gold-pears-share.md
+++ b/.changeset/gold-pears-share.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": minor
+---
+
+Release 4.2.0

--- a/.changeset/gold-pears-share.md
+++ b/.changeset/gold-pears-share.md
@@ -1,5 +1,0 @@
----
-"@xmtp/react-native-sdk": minor
----
-
-Release 4.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @xmtp/react-native-sdk
 
+## 4.2.0
+
+- Release 4.2.0
+- Adds KeyPackage status to debug information
+
 ## 4.2.0-rc5
 
 ### Pre Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @xmtp/react-native-sdk
 
-## 5.0.0
-
-### Major Changes
-
-- 2bec8fe: Release 4.2.0
-
 ## 4.2.0-rc5
 
 ### Pre Release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/react-native-sdk",
-  "version": "5.0.0",
+  "version": "4.2.0",
   "description": "Wraps for native xmtp sdks for react native",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
### Downgrade @xmtp/react-native-sdk package version from 5.0.0 to 4.2.0 to release again
The package version is downgraded from 5.0.0 to 4.2.0 in [package.json](https://github.com/xmtp/xmtp-react-native/pull/665/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519). The changelog removes the 5.0.0 version entry in [CHANGELOG.md](https://github.com/xmtp/xmtp-react-native/pull/665/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed). A new changeset file is added for the minor version update in [.changeset/gold-pears-share.md](https://github.com/xmtp/xmtp-react-native/pull/665/files#diff-5910fc1a480b565f7a7f3feb23f0e95a8622a09b59a41c137704c28fbf3de9f0).

#### 📍Where to Start
Start with the version change in [package.json](https://github.com/xmtp/xmtp-react-native/pull/665/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to understand the version downgrade from 5.0.0 to 4.2.0.



#### Changes since #665 opened

- Removed changeset file for `@xmtp/react-native-sdk` package release management [db81b30]
- Updated changelog documentation to reflect new release version [4738b04]
----

_[Macroscope](https://app.macroscope.com) summarized 4738b04._