### PR TITLE
Add the ability to set batched consent states

### DIFF
--- a/.changeset/blue-items-kneel.md
+++ b/.changeset/blue-items-kneel.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+- Add the ability to set array of consent states

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ConsentWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ConsentWrapper.kt
@@ -1,8 +1,11 @@
 package expo.modules.xmtpreactnativesdk.wrappers
 
 import com.google.gson.GsonBuilder
+import com.google.gson.JsonParser
 import org.xmtp.android.library.ConsentRecord
 import org.xmtp.android.library.ConsentState
+import org.xmtp.android.library.EntryType
+import org.xmtp.android.library.XMTPException
 
 class ConsentWrapper {
 
@@ -25,6 +28,37 @@ class ConsentWrapper {
                 ConsentState.DENIED -> "denied"
                 ConsentState.UNKNOWN -> "unknown"
             }
+        }
+
+        fun getConsentState(stateString: String): ConsentState {
+            return when (stateString) {
+                "allowed" -> ConsentState.ALLOWED
+                "denied" -> ConsentState.DENIED
+                else -> ConsentState.UNKNOWN
+            }
+        }
+
+        fun getConsentStates(stateStrings: List<String>): List<ConsentState> {
+            return stateStrings.map { stateString ->
+                getConsentState(stateString)
+            }
+        }
+
+        fun getEntryType(entryString: String): EntryType {
+            return when (entryString) {
+                "conversation_id" -> EntryType.CONVERSATION_ID
+                "inbox_id" -> EntryType.INBOX_ID
+                else -> throw XMTPException("Invalid entry type: $entryString")
+            }
+        }
+
+        fun consentRecordFromJson(params: String): ConsentRecord {
+            val jsonOptions = JsonParser.parseString(params).asJsonObject
+            return ConsentRecord(
+                jsonOptions.get("value").asString,
+                getEntryType(jsonOptions.get("entryType").asString),
+                getConsentState(jsonOptions.get("consentType").asString)
+            )
         }
     }
 }

--- a/ios/Wrappers/ConsentWrapper.swift
+++ b/ios/Wrappers/ConsentWrapper.swift
@@ -26,5 +26,4 @@ struct ConsentWrapper {
             case .unknown: return "unknown"
         }
     }
-
 }

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -640,16 +640,20 @@ public class XMTPModule: Module {
 				inboxIds: inboxIds, api: createApiClient(env: environment))
 			return try inboxStates.map { try InboxStateWrapper.encode($0) }
 		}
-		
+
 		AsyncFunction("staticKeyPackageStatuses") {
-			(environment: String, installationIds: [String]) -> [String: String] in
-			
-			let keyPackageStatus = try await XMTP.Client.keyPackageStatusesForInstallationIds(
-				installationIds: installationIds,
-				api: createApiClient(env: environment)
-			)
-			
-			return try keyPackageStatus.mapValues { try KeyPackageStatusWrapper.encode(keyPackageStatus: $0) }
+			(environment: String, installationIds: [String]) -> [String: String]
+			in
+
+			let keyPackageStatus = try await XMTP.Client
+				.keyPackageStatusesForInstallationIds(
+					installationIds: installationIds,
+					api: createApiClient(env: environment)
+				)
+
+			return try keyPackageStatus.mapValues {
+				try KeyPackageStatusWrapper.encode(keyPackageStatus: $0)
+			}
 		}
 
 		Function("staticActivatePersistentLibXMTPLogWriter") {
@@ -2295,6 +2299,24 @@ public class XMTPModule: Module {
 			)
 		}
 
+		AsyncFunction("setConsentStates") {
+			(
+				installationId: String, consentRecords: [String]
+			) in
+			guard
+				let client = await clientsManager.getClient(key: installationId)
+			else {
+				throw Error.noClient
+			}
+
+			let states =
+				try consentRecords.map {
+					try consentRecordFromJson($0)
+				}
+
+			try await client.preferences.setConsentState(entries: [states])
+		}
+
 		AsyncFunction("consentInboxIdState") {
 			(installationId: String, peerInboxId: String) -> String in
 			guard
@@ -2740,6 +2762,25 @@ public class XMTPModule: Module {
 		default:
 			throw Error.invalidPermissionOption
 		}
+	}
+
+	private func consentRecordFromJson(_ params: String) throws -> ConsentRecord
+	{
+		guard let data = params.data(using: .utf8),
+			let jsonObject = try? JSONSerialization.jsonObject(
+				with: data, options: []) as? [String: Any],
+			let value = jsonObject["value"] as? String,
+			let entry = jsonObject["entryType"] as? String,
+			let consent = jsonObject["consentType"] as? String
+		else {
+			throw Error.invalidPermissionOption
+		}
+
+		return ConsentRecord(
+			value: value,
+			entryType: try getEntryType(type: entry),
+			consentType: try getConsentState(state: consent)
+		)
 	}
 
 	private func getSortDirection(direction: String) throws -> SortDirection {

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -2314,7 +2314,7 @@ public class XMTPModule: Module {
 					try consentRecordFromJson($0)
 				}
 
-			try await client.preferences.setConsentState(entries: [states])
+			try await client.preferences.setConsentState(entries: states)
 		}
 
 		AsyncFunction("consentInboxIdState") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,10 @@ import { InboxState } from './lib/InboxState'
 import { Member, MembershipResult } from './lib/Member'
 import { PublicIdentity } from './lib/PublicIdentity'
 import { SignerType } from './lib/Signer'
-import { KeyPackageStatuses, NetworkDebugInfo } from './lib/XMTPDebugInformation'
+import {
+  KeyPackageStatuses,
+  NetworkDebugInfo,
+} from './lib/XMTPDebugInformation'
 import {
   ConversationOptions,
   ConversationFilterType,
@@ -1449,6 +1452,13 @@ export async function setConsentState(
     entryType,
     consentType
   )
+}
+
+export async function setConsentStates(
+  installationId: InstallationId,
+  records: string[]
+): Promise<void> {
+  return await XMTPModule.setConsentStates(installationId, records)
 }
 
 export async function consentInboxIdState(

--- a/src/lib/PrivatePreferences.ts
+++ b/src/lib/PrivatePreferences.ts
@@ -39,6 +39,14 @@ export default class PrivatePreferences {
     )
   }
 
+  async setConsentStates(consentRecords: ConsentRecord[]): Promise<void> {
+    const recordStrings = consentRecords.map((record) => JSON.stringify(record))
+    return await XMTPModule.setConsentStates(
+      this.client.installationId,
+      recordStrings
+    )
+  }
+
   /**
    * Syncs the local database between installations
    */


### PR DESCRIPTION
Closes: https://github.com/xmtp/xmtp-react-native/issues/667

Exposes out the ability from Android and iOS to set an array of consent states.

| iOS | Android |
|--------|--------|
| <img width="407" alt="Screenshot 2025-06-05 at 10 42 29 PM" src="https://github.com/user-attachments/assets/b05508e9-5485-474a-b1b5-683fe21236d0" />  |  <img width="439" alt="Screenshot 2025-06-05 at 10 35 35 PM" src="https://github.com/user-attachments/assets/fd2397c2-a559-45c9-8367-83eb103441d8" />  | 