### PR TITLE
Release for query improvements

### DIFF
--- a/.changeset/great-birds-sort.md
+++ b/.changeset/great-birds-sort.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+- Improvements to syncAll

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.2.3"
+  implementation "org.xmtp:android:4.2.4"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -132,7 +132,7 @@ android {
     }
     buildTypes {
         debug {
-            testCoverageEnabled = true
+            testCoverageEnabled = false
             debuggable = true
             signingConfig signingConfigs.debug
         }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -60,7 +60,7 @@ PODS:
   - hermes-engine (0.76.9):
     - hermes-engine/Pre-built (= 0.76.9)
   - hermes-engine/Pre-built (0.76.9)
-  - LibXMTP (4.2.5)
+  - LibXMTP (4.2.6)
   - MessagePacker (0.4.7)
   - MMKV (2.2.2):
     - MMKVCore (~> 2.2.2)
@@ -1737,18 +1737,18 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.2.3):
+  - XMTP (4.2.4):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - CSecp256k1 (~> 0.2)
-    - LibXMTP (= 4.2.5)
+    - LibXMTP (= 4.2.6)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (4.2.4):
+  - XMTPReactNative (4.2.5):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.2.3)
+    - XMTP (= 4.2.4)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2080,7 +2080,7 @@ SPEC CHECKSUMS:
   fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 9e868dc7be781364296d6ee2f56d0c1a9ef0bb11
-  LibXMTP: 734254bcfc6cf3dd43ddb8f68747d0a8c3d36045
+  LibXMTP: 4e5a97c44008252e39471ea86a7ac95a9266cba0
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: b4802ebd5a7c68fc0c4a5ccb4926fbdfb62d68e0
   MMKVCore: a255341a3746955f50da2ad9121b18cb2b346e61
@@ -2160,8 +2160,8 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: 2acc47db5d350039ca4442fc765fa38b4c5ff720
-  XMTPReactNative: 497961b60f77a7391af66c0e1ee39e72e42e5d61
+  XMTP: 3c48bf0faee35f1d45aff558bbdeff4ed68b29ca
+  XMTPReactNative: 5f2b1c7346a99ca8bba8fb2389122306ba0cd61b
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 283c313cbc1ba9857a692b5901eb740dad922eca

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.2.3"
+  s.dependency "XMTP", "= 4.2.4"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end


### PR DESCRIPTION
### Update XMTP library dependencies from version 4.2.3 to 4.2.4 for query improvements in Android and iOS platforms
Updates XMTP library dependencies across Android and iOS platforms to incorporate query improvements. The changes include:

- Updates Android XMTP library dependency from version 4.2.3 to 4.2.4 in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/679/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a)
- Updates iOS XMTP library dependency from version 4.2.3 to 4.2.4 in [ios/XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/679/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3)
- Updates multiple iOS dependencies including LibXMTP from 4.2.5 to 4.2.6 and XMTP from 4.2.3 to 4.2.4 in [example/ios/Podfile.lock](https://github.com/xmtp/xmtp-react-native/pull/679/files#diff-b2790cc3d555682b207af1ca2fb897ebd2114c01149bf460fd85fc2b1503a687)
- Adds changeset documentation for patch update to `@xmtp/react-native-sdk` package in [.changeset/great-birds-sort.md](https://github.com/xmtp/xmtp-react-native/pull/679/files#diff-b4d15aa39db88b20ff6c4e831ab27605d8b8e74f667741a1c497c23e5e35acc4)
- Disables test coverage for debug builds in example Android app by setting `testCoverageEnabled` to false in [example/android/app/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/679/files#diff-39ab2ed24002fb8e39b9db8ebac35907f77395dbc3c2faf95e6e6b6805e0b9ce)

#### 📍Where to Start
Start with the dependency updates in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/679/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a) to understand the core library version changes being applied across the project.

----

_[Macroscope](https://app.macroscope.com) summarized f7db67e._