### PR TITLE
Release 4.3

### DIFF
--- a/.changeset/odd-apes-act.md
+++ b/.changeset/odd-apes-act.md
@@ -1,0 +1,9 @@
+---
+"@xmtp/react-native-sdk": minor
+---
+
+- Quantum Encryption
+- Always send group update codec on membership add
+- Keep consent across installations & don’t transfer denied conversations
+- Give order to identities
+- Callback for stream disconnection

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.3.0-rc2"
+  implementation "org.xmtp:android:4.3.0"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -60,7 +60,7 @@ PODS:
   - hermes-engine (0.76.9):
     - hermes-engine/Pre-built (= 0.76.9)
   - hermes-engine/Pre-built (0.76.9)
-  - LibXMTP (4.3.0-rc2)
+  - LibXMTP (4.3.0)
   - MessagePacker (0.4.7)
   - MMKV (2.2.2):
     - MMKVCore (~> 2.2.2)
@@ -1737,18 +1737,18 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.3.0-rc2):
+  - XMTP (4.3.0):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - CSecp256k1 (~> 0.2)
-    - LibXMTP (= 4.3.0-rc2)
+    - LibXMTP (= 4.3.0)
     - SQLCipher (= 4.5.7)
   - XMTPReactNative (4.3.0-rc2):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.3.0-rc2)
+    - XMTP (= 4.3.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2080,7 +2080,7 @@ SPEC CHECKSUMS:
   fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 9e868dc7be781364296d6ee2f56d0c1a9ef0bb11
-  LibXMTP: 127699920a1753bbca781de7fb403add1f533055
+  LibXMTP: 65a54249d73b30576ec1665bfa4425a8bf30adb8
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: b4802ebd5a7c68fc0c4a5ccb4926fbdfb62d68e0
   MMKVCore: a255341a3746955f50da2ad9121b18cb2b346e61
@@ -2160,8 +2160,8 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: 34f3de5aa397a881094e8b396911738b811aef5a
-  XMTPReactNative: 736267d8a45a0dd2d81e7c957b08d2ff6a26748b
+  XMTP: 4b3b4621cab3f848a06153f691949843b82a029e
+  XMTPReactNative: 604f4ba30be2a324c2c9d77d73baea9e3060ccd9
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 283c313cbc1ba9857a692b5901eb740dad922eca

--- a/example/src/tests/conversationTests.ts
+++ b/example/src/tests/conversationTests.ts
@@ -292,7 +292,7 @@ test('register and use custom content types', async () => {
   const alixConvo = await alix.conversations.findConversation(boConvo.id)
 
   const messages = await alixConvo!.messages()
-  assert(messages.length === 1, 'did not get messages')
+  assert(messages.length === 2, 'did not get messages')
 
   const message = messages[0]
   const messageContent = message.content()
@@ -339,7 +339,7 @@ test('register and use custom content types with prepare', async () => {
   const alixConvo = await alix.conversations.findConversation(boConvo.id)
 
   const messages = await alixConvo!.messages()
-  assert(messages.length === 1, 'did not get messages')
+  assert(messages.length === 2, 'did not get messages')
 
   const message = messages[0]
   const messageContent = message.content()
@@ -387,7 +387,7 @@ test('handle fallback types appropriately', async () => {
   const aliceConvo = await alix.conversations.findConversation(bobConvo.id)
 
   const messages = await aliceConvo!.messages()
-  assert(messages.length === 2, 'did not get messages')
+  assert(messages.length === 3, 'did not get messages')
 
   const messageUndefinedFallback = messages[0]
   const messageWithDefinedFallback = messages[1]

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.3.0-rc2"
+  s.dependency "XMTP", "= 4.3.0"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end


### PR DESCRIPTION
### Release version 4.3 by updating XMTP library dependencies from 4.3.0-rc2 to 4.3.0 in Android and iOS platforms
This release updates the XMTP library dependencies from release candidate version 4.3.0-rc2 to stable version 4.3.0 across both platforms and includes a changeset documenting new features:

- Updates `LibXMTP` dependency version in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/688/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a) from 4.3.0-rc2 to 4.3.0
- Updates `LibXMTP-Swift` dependency version in [ios/XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/688/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3) from 4.3.0-rc2 to 4.3.0
- Adds changeset in [.changeset/odd-apes-act.md](https://github.com/xmtp/xmtp-react-native/pull/688/files#diff-01c5ebf810af8050408654ab43fe63f813a1a090075447d7373c2862a0704f0b) documenting quantum encryption, group update codec improvements, consent management across installations, identity ordering, and stream disconnection callbacks

#### 📍Where to Start
Start with the dependency version updates in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/688/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a) to understand the library version changes being released.



#### Changes since #688 opened

- Updated XMTP dependencies from release candidate to final release versions [022a5a6]
- Updated conversation test assertions to expect additional messages [479040b]
----

_[Macroscope](https://app.macroscope.com) summarized 479040b._