### PR TITLE
Update README to point to sdk-specific doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Or better yet, open a PR and we'll get it reviewed and merged as soon as possibl
 
 ## Documentation
 
-To learn how to use the XMTP React Native SDK and get answers to frequently asked questions, see the [XMTP documentation](https://docs.xmtp.org/).
+To learn how to use the XMTP React Native SDK, see [Get started with the XMTP React Native SDK](https://docs.xmtp.org/sdks/react-native).
 
 ## SDK reference
 


### PR DESCRIPTION
### Update README documentation link to point to React Native SDK getting started guide
The documentation link in [README.md](https://github.com/xmtp/xmtp-react-native/pull/691/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) is updated from a generic XMTP documentation link to a specific React Native SDK getting started guide. The accompanying text is modified to reflect this change, removing the reference to frequently asked questions and focusing on the getting started content.

#### 📍Where to Start
Start with the documentation section in [README.md](https://github.com/xmtp/xmtp-react-native/pull/691/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) where the link and text have been updated.

----

_[Macroscope](https://app.macroscope.com) summarized 967d408._