### PR TITLE
Adds fork detection fields to conversation and conversationDebugInfo and example app UI for testing

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.4.0-rc1"
+  implementation "org.xmtp:android:4.4.0-rc2"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ConversationDebugInfoWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ConversationDebugInfoWrapper.kt
@@ -12,7 +12,18 @@ class ConversationDebugInfoWrapper {
                 "epoch" to info.epoch,
                 "maybeForked" to info.maybeForked,
                 "forkDetails" to info.forkDetails,
+                "localCommitLog" to info.localCommitLog,
+               "remoteCommitLog" to info.remoteCommitLog,
+                "commitLogForkStatus" to commitLogForkStatusToString(info.commitLogForkStatus)
             )
+        }
+        
+        fun commitLogForkStatusToString(status: ConversationDebugInfo.CommitLogForkStatus): String {
+            return when (status) {
+                ConversationDebugInfo.CommitLogForkStatus.FORKED -> "forked"
+                ConversationDebugInfo.CommitLogForkStatus.NOT_FORKED -> "notForked"
+                else -> "unknown"
+            }
         }
 
         fun encode(info: ConversationDebugInfo): String {

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DmWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DmWrapper.kt
@@ -18,6 +18,7 @@ class DmWrapper {
                 put("version", "DM")
                 put("topic", dm.topic)
                 put("peerInboxId", dm.peerInboxId)
+                put("commitLogForkStatus", ConversationDebugInfoWrapper.commitLogForkStatusToString(dm.commitLogForkStatus()))
                 if (dmParams.consentState) {
                     put("consentState", consentStateToString(dm.consentState()))
                 }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt
@@ -21,6 +21,7 @@ class GroupWrapper {
                 put("createdAt", group.createdAt.time)
                 put("version", "GROUP")
                 put("topic", group.topic)
+                put("commitLogForkStatus", ConversationDebugInfoWrapper.commitLogForkStatusToString(group.commitLogForkStatus()))
                 if (groupParams.isActive) put("isActive", group.isActive())
                 if (groupParams.addedByInboxId) put("addedByInboxId", group.addedByInboxId())
                 if (groupParams.name) put("name", group.name)
@@ -79,7 +80,8 @@ class ConversationParamsWrapper(
                 if (jsonOptions.has("description")) jsonOptions.get("description").asBoolean else true,
                 if (jsonOptions.has("consentState")) jsonOptions.get("consentState").asBoolean else true,
                 if (jsonOptions.has("lastMessage")) jsonOptions.get("lastMessage").asBoolean else false,
-            )
+
+                )
         }
     }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -60,7 +60,7 @@ PODS:
   - hermes-engine (0.76.9):
     - hermes-engine/Pre-built (= 0.76.9)
   - hermes-engine/Pre-built (0.76.9)
-  - LibXMTP (4.4.0-rc1)
+  - LibXMTP (4.4.0-rc2)
   - MessagePacker (0.4.7)
   - MMKV (2.2.2):
     - MMKVCore (~> 2.2.2)
@@ -1737,18 +1737,18 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.4.0-rc1):
+  - XMTP (4.4.0-rc2):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - CSecp256k1 (~> 0.2)
-    - LibXMTP (= 4.4.0-rc1)
+    - LibXMTP (= 4.4.0-rc2)
     - SQLCipher (= 4.5.7)
   - XMTPReactNative (4.3.6):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.4.0-rc1)
+    - XMTP (= 4.4.0-rc2)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2080,7 +2080,7 @@ SPEC CHECKSUMS:
   fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 9e868dc7be781364296d6ee2f56d0c1a9ef0bb11
-  LibXMTP: 46fbff8eeb4532bfcd91e7fbc7d9de342179191a
+  LibXMTP: 8f8f5222638557b8de4508152bb3eed72b8cf22d
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: b4802ebd5a7c68fc0c4a5ccb4926fbdfb62d68e0
   MMKVCore: a255341a3746955f50da2ad9121b18cb2b346e61
@@ -2160,8 +2160,8 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: 081759dce2071b83e35828b351718fbd54a28a22
-  XMTPReactNative: 72bf3206a76ee618579339c8e5f9a6d3c662a9ef
+  XMTP: 8361aef38f0e363cd39a259362c5db5f320e4268
+  XMTPReactNative: ef2c8a8cabc0b75fe66c27ce8fa93da9baf36fae
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 283c313cbc1ba9857a692b5901eb740dad922eca

--- a/example/src/ConversationScreen.tsx
+++ b/example/src/ConversationScreen.tsx
@@ -1954,112 +1954,122 @@ function AddMemberModal({
   onAddMember: () => void
   isLoading?: boolean
 }) {
+  if (!visible) return null
+
   return (
-    <Modal transparent visible={visible} onRequestClose={onRequestClose}>
+    <View
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 1000,
+      }}
+    >
       <TouchableWithoutFeedback onPress={onRequestClose}>
         <View
           style={{
-            flex: 1,
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
             backgroundColor: 'rgba(0,0,0,0.5)',
           }}
         />
       </TouchableWithoutFeedback>
       <View
         style={{
-          flex: 1,
-          justifyContent: 'center',
-          margin: '5%',
+          position: 'absolute',
+          top: '30%',
+          left: 20,
+          right: 20,
+          backgroundColor: 'white',
+          borderRadius: 8,
+          padding: 24,
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.25,
+          shadowRadius: 4,
+          elevation: 5,
         }}
       >
         <View
           style={{
-            margin: 20,
-            backgroundColor: 'white',
-            borderRadius: 8,
-            padding: 24,
-            shadowColor: '#000',
-            shadowOffset: { width: 0, height: 2 },
-            shadowOpacity: 0.25,
-            shadowRadius: 4,
-            elevation: 5,
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: 20,
           }}
         >
-          <View
-            style={{
-              flexDirection: 'row',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              marginBottom: 20,
-            }}
-          >
-            <Text style={{ fontSize: 18, fontWeight: 'bold' }}>Add Member</Text>
-            <TouchableOpacity onPress={onRequestClose}>
-              <FontAwesome name="close" size={24} color="#666" />
-            </TouchableOpacity>
-          </View>
+          <Text style={{ fontSize: 18, fontWeight: 'bold' }}>Add Member</Text>
+          <TouchableOpacity onPress={onRequestClose}>
+            <FontAwesome name="close" size={24} color="#666" />
+          </TouchableOpacity>
+        </View>
 
-          <Text style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
-            Enter the wallet address of the person you want to add to this
-            group:
-          </Text>
+        <Text style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
+          Enter the wallet address of the person you want to add to this
+          group:
+        </Text>
 
-          <TextInput
+        <TextInput
+          style={{
+            borderWidth: 1,
+            borderColor: '#ddd',
+            borderRadius: 6,
+            padding: 12,
+            fontSize: 16,
+            marginBottom: 20,
+            backgroundColor: '#f9f9f9',
+          }}
+          placeholder="0x1234567890abcdef..."
+          value={memberAddress}
+          onChangeText={onChangeAddress}
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!isLoading}
+        />
+
+        <View style={{ flexDirection: 'row', gap: 10 }}>
+          <TouchableOpacity
             style={{
-              borderWidth: 1,
-              borderColor: '#ddd',
+              flex: 1,
+              backgroundColor: '#f0f0f0',
+              paddingVertical: 12,
+              paddingHorizontal: 16,
               borderRadius: 6,
-              padding: 12,
-              fontSize: 16,
-              marginBottom: 20,
-              backgroundColor: '#f9f9f9',
+              alignItems: 'center',
             }}
-            placeholder="0x1234567890abcdef..."
-            value={memberAddress}
-            onChangeText={onChangeAddress}
-            autoCapitalize="none"
-            autoCorrect={false}
-            editable={!isLoading}
-          />
+            onPress={onRequestClose}
+            disabled={isLoading}
+          >
+            <Text style={{ fontSize: 16, color: '#666' }}>Cancel</Text>
+          </TouchableOpacity>
 
-          <View style={{ flexDirection: 'row', gap: 10 }}>
-            <TouchableOpacity
-              style={{
-                flex: 1,
-                backgroundColor: '#f0f0f0',
-                paddingVertical: 12,
-                paddingHorizontal: 16,
-                borderRadius: 6,
-                alignItems: 'center',
-              }}
-              onPress={onRequestClose}
-              disabled={isLoading}
+          <TouchableOpacity
+            style={{
+              flex: 1,
+              backgroundColor:
+                memberAddress.trim() && !isLoading ? '#007AFF' : '#ccc',
+              paddingVertical: 12,
+              paddingHorizontal: 16,
+              borderRadius: 6,
+              alignItems: 'center',
+            }}
+            onPress={onAddMember}
+            disabled={!memberAddress.trim() || isLoading}
+          >
+            <Text
+              style={{ fontSize: 16, color: 'white', fontWeight: 'bold' }}
             >
-              <Text style={{ fontSize: 16, color: '#666' }}>Cancel</Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={{
-                flex: 1,
-                backgroundColor:
-                  memberAddress.trim() && !isLoading ? '#007AFF' : '#ccc',
-                paddingVertical: 12,
-                paddingHorizontal: 16,
-                borderRadius: 6,
-                alignItems: 'center',
-              }}
-              onPress={onAddMember}
-              disabled={!memberAddress.trim() || isLoading}
-            >
-              <Text
-                style={{ fontSize: 16, color: 'white', fontWeight: 'bold' }}
-              >
-                {isLoading ? 'Adding...' : 'Add Member'}
-              </Text>
-            </TouchableOpacity>
-          </View>
+              {isLoading ? 'Adding...' : 'Add Member'}
+            </Text>
+          </TouchableOpacity>
         </View>
       </View>
-    </Modal>
+    </View>
   )
 }
 

--- a/example/src/ConversationScreen.tsx
+++ b/example/src/ConversationScreen.tsx
@@ -2010,8 +2010,7 @@ function AddMemberModal({
         </View>
 
         <Text style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
-          Enter the wallet address of the person you want to add to this
-          group:
+          Enter the wallet address of the person you want to add to this group:
         </Text>
 
         <TextInput
@@ -2061,9 +2060,7 @@ function AddMemberModal({
             onPress={onAddMember}
             disabled={!memberAddress.trim() || isLoading}
           >
-            <Text
-              style={{ fontSize: 16, color: 'white', fontWeight: 'bold' }}
-            >
+            <Text style={{ fontSize: 16, color: 'white', fontWeight: 'bold' }}>
               {isLoading ? 'Adding...' : 'Add Member'}
             </Text>
           </TouchableOpacity>

--- a/example/src/ConversationScreen.tsx
+++ b/example/src/ConversationScreen.tsx
@@ -8,7 +8,13 @@ import * as ImagePicker from 'expo-image-picker'
 import type { ImagePickerAsset } from 'expo-image-picker'
 import { PermissionStatus } from 'expo-modules-core'
 import moment from 'moment'
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  useLayoutEffect,
+} from 'react'
 import {
   Button,
   FlatList,
@@ -25,6 +31,8 @@ import {
   TouchableWithoutFeedback,
   View,
   ScrollView,
+  Clipboard,
+  Alert,
 } from 'react-native'
 import {
   MultiRemoteAttachmentContent,
@@ -34,6 +42,8 @@ import {
   ReplyContent,
   useClient,
   Client,
+  ConversationVersion,
+  PublicIdentity,
 } from 'xmtp-react-native-sdk'
 import { ConversationSendPayload } from 'xmtp-react-native-sdk/lib/types'
 
@@ -59,6 +69,7 @@ const hiddenMessageTypes = ['xmtp.org/reaction:1.0']
 /// Show the messages in a conversation.
 export default function ConversationScreen({
   route,
+  navigation, // Make sure to destructure navigation
 }: NativeStackScreenProps<NavigationParamList, 'conversation'>) {
   const { topic } = route.params
   const messageListRef = useRef<FlatList>(null)
@@ -189,8 +200,153 @@ export default function ConversationScreen({
     [filteredMessages]
   )
 
+  // Add the header configuration
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: () => (
+        <TouchableOpacity
+          onPress={() => setShowingOptionsModal(true)}
+          style={{ marginRight: 15 }}
+        >
+          <FontAwesome name="ellipsis-v" size={20} color="#000" />
+        </TouchableOpacity>
+      ),
+    })
+  }, [navigation])
+
+  // Add state for the options modal
+  const [isShowingOptionsModal, setShowingOptionsModal] = useState(false)
+  const [isShowingDebugModal, setShowingDebugModal] = useState(false)
+  const [debugInfo, setDebugInfo] = useState<any>(null)
+  const [isLoadingDebugInfo, setIsLoadingDebugInfo] = useState(false)
+  const [debugInfoTimestamp, setDebugInfoTimestamp] = useState<string>('')
+  const [isShowingAddMemberModal, setShowingAddMemberModal] = useState(false)
+  const [memberAddress, setMemberAddress] = useState('')
+  const [isAddingMember, setIsAddingMember] = useState(false)
+
+  // Add handlers for menu options
+  const handleSyncConversation = async () => {
+    setShowingOptionsModal(false)
+    try {
+      await conversation?.sync()
+      await refreshMessages()
+      console.log('Conversation synced successfully')
+    } catch (error) {
+      console.error('Error syncing conversation:', error)
+    }
+  }
+
+  const refreshDebugInfo = async () => {
+    // Clear previous debug info and show loading state
+    console.log('🔄 refreshDebugInfo called - clearing previous data')
+    setDebugInfo(null)
+    setIsLoadingDebugInfo(true)
+
+    try {
+      const timestamp = new Date().toLocaleTimeString()
+      console.log(`🔄 [${timestamp}] Fetching fresh debug information...`)
+      const freshDebugInfo = await conversation?.getDebugInformation()
+      console.log(
+        `✅ [${timestamp}] Fresh Debug Info received:`,
+        freshDebugInfo
+      )
+      setDebugInfo(freshDebugInfo)
+      setDebugInfoTimestamp(timestamp)
+    } catch (error: any) {
+      console.error('❌ Error getting debug info:', error)
+      setDebugInfo({
+        error: error?.message || 'Failed to fetch debug information',
+      })
+    } finally {
+      setIsLoadingDebugInfo(false)
+    }
+  }
+
+  const handleDebugInfo = async () => {
+    console.log('🔄 handleDebugInfo called')
+    setShowingOptionsModal(false)
+    console.log('🔄 Setting debug modal to true')
+    setShowingDebugModal(true)
+    await refreshDebugInfo()
+  }
+
+  const handleAddMember = () => {
+    setShowingOptionsModal(false)
+    setMemberAddress('')
+    setShowingAddMemberModal(true)
+  }
+
+  const addMemberToGroup = async () => {
+    if (!memberAddress.trim() || !conversation) return
+
+    setIsAddingMember(true)
+    try {
+      console.log('🔄 Adding member to group:', memberAddress)
+
+      // Create a PublicIdentity object for the address
+      const identity: PublicIdentity = {
+        identifier: memberAddress,
+        kind: 'ETHEREUM',
+      }
+
+      // Type guard to ensure conversation is a Group
+      if (conversation.version === ConversationVersion.GROUP) {
+        const result = await (conversation as any).addMembersByIdentity([
+          identity,
+        ])
+        console.log('✅ Member added successfully:', result)
+
+        // Clear the input and close modal
+        setMemberAddress('')
+        setShowingAddMemberModal(false)
+
+        // Sync the conversation to see updated member list
+        await conversation.sync()
+      } else {
+        throw new Error('This conversation is not a group')
+      }
+    } catch (error: any) {
+      console.error('❌ Error adding member:', error)
+      Alert.alert(
+        'Error',
+        `Failed to add member: ${error?.message || 'Unknown error'}`
+      )
+    } finally {
+      setIsAddingMember(false)
+    }
+  }
+
   return (
     <SafeAreaView style={{ flex: 1 }}>
+      {/* Add the options modal */}
+      <OptionsModal
+        visible={isShowingOptionsModal}
+        onRequestClose={() => setShowingOptionsModal(false)}
+        onSyncConversation={handleSyncConversation}
+        onDebugInfo={handleDebugInfo}
+        onAddMember={handleAddMember}
+        isGroup={conversation?.version === ConversationVersion.GROUP}
+      />
+
+      {/* Add Member Modal */}
+      <AddMemberModal
+        visible={isShowingAddMemberModal}
+        onRequestClose={() => setShowingAddMemberModal(false)}
+        memberAddress={memberAddress}
+        onChangeAddress={setMemberAddress}
+        onAddMember={addMemberToGroup}
+        isLoading={isAddingMember}
+      />
+
+      {/* Add the new debug info modal */}
+      <DebugInfoModal
+        visible={isShowingDebugModal}
+        onRequestClose={() => setShowingDebugModal(false)}
+        debugInfo={debugInfo}
+        isLoading={isLoadingDebugInfo}
+        onRefresh={refreshDebugInfo}
+        timestamp={debugInfoTimestamp}
+      />
       <KeyboardAvoidingView
         behavior="padding"
         keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
@@ -1330,4 +1486,691 @@ function MessageContents({
       </Text>
     </>
   )
+}
+
+function OptionsModal({
+  visible,
+  onRequestClose,
+  onDebugInfo,
+  onSyncConversation,
+  onAddMember,
+  isGroup = false,
+}: {
+  visible: boolean
+  onRequestClose: () => void
+  onDebugInfo: () => void
+  onSyncConversation: () => void
+  onAddMember?: () => void
+  isGroup?: boolean
+}) {
+  return (
+    <Modal transparent visible={visible} onRequestClose={onRequestClose}>
+      <TouchableWithoutFeedback onPress={onRequestClose}>
+        <View
+          style={{
+            flex: 1,
+            backgroundColor: 'rgba(0,0,0,0.5)',
+          }}
+        />
+      </TouchableWithoutFeedback>
+      <View
+        style={{
+          position: 'absolute',
+          top: 100,
+          right: 20,
+          backgroundColor: 'white',
+          borderRadius: 8,
+          paddingVertical: 8,
+          minWidth: 200,
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.25,
+          shadowRadius: 4,
+          elevation: 5,
+        }}
+      >
+        <TouchableOpacity
+          style={{ paddingVertical: 12, paddingHorizontal: 16 }}
+          onPress={onSyncConversation}
+        >
+          <Text style={{ fontSize: 16 }}>Sync Conversation</Text>
+        </TouchableOpacity>
+        {isGroup && onAddMember && (
+          <TouchableOpacity
+            style={{ paddingVertical: 12, paddingHorizontal: 16 }}
+            onPress={onAddMember}
+          >
+            <Text style={{ fontSize: 16 }}>Add Member</Text>
+          </TouchableOpacity>
+        )}
+        <TouchableOpacity
+          style={{ paddingVertical: 12, paddingHorizontal: 16 }}
+          onPress={onDebugInfo}
+        >
+          <Text style={{ fontSize: 16 }}>Debug Info</Text>
+        </TouchableOpacity>
+      </View>
+    </Modal>
+  )
+}
+
+function DebugInfoModal({
+  visible,
+  onRequestClose,
+  debugInfo,
+  isLoading = false,
+  onRefresh,
+  timestamp,
+}: {
+  visible: boolean
+  onRequestClose: () => void
+  debugInfo: any
+  isLoading?: boolean
+  onRefresh: () => Promise<void>
+  timestamp?: string
+}) {
+  console.log(
+    '🔄 DebugInfoModal render - visible:',
+    visible,
+    'debugInfo:',
+    !!debugInfo
+  )
+
+  if (!visible) return null
+
+  return (
+    <View
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 1000,
+      }}
+    >
+      <TouchableWithoutFeedback onPress={onRequestClose}>
+        <View
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: 'rgba(0,0,0,0.5)',
+          }}
+        />
+      </TouchableWithoutFeedback>
+      <View
+        style={{
+          position: 'absolute',
+          top: 60,
+          left: 20,
+          right: 20,
+          bottom: 60,
+          backgroundColor: 'white',
+          borderRadius: 8,
+          padding: 20,
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.25,
+          shadowRadius: 4,
+          elevation: 5,
+        }}
+      >
+        <View
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: 20,
+          }}
+        >
+          <View>
+            <Text style={{ fontSize: 18, fontWeight: 'bold' }}>
+              Debug Information
+            </Text>
+            {timestamp && (
+              <Text style={{ fontSize: 12, color: '#666', marginTop: 2 }}>
+                Last updated: {timestamp}
+              </Text>
+            )}
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 15 }}>
+            <TouchableOpacity
+              onPress={onRefresh}
+              disabled={isLoading}
+              style={{
+                opacity: isLoading ? 0.5 : 1,
+                backgroundColor: '#007AFF',
+                paddingHorizontal: 12,
+                paddingVertical: 6,
+                borderRadius: 6,
+                flexDirection: 'row',
+                alignItems: 'center',
+              }}
+            >
+              <FontAwesome
+                name="refresh"
+                size={16}
+                color="white"
+                style={{ marginRight: 6 }}
+              />
+              <Text
+                style={{ color: 'white', fontSize: 14, fontWeight: 'bold' }}
+              >
+                {isLoading ? 'Loading...' : 'Refresh'}
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={onRequestClose}>
+              <FontAwesome name="close" size={24} color="#666" />
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        <ScrollView style={{ flex: 1 }}>
+          {isLoading ? (
+            <View
+              style={{
+                flex: 1,
+                justifyContent: 'center',
+                alignItems: 'center',
+                paddingTop: 100,
+              }}
+            >
+              <Text style={{ fontSize: 16, color: '#666', marginBottom: 20 }}>
+                Loading debug information...
+              </Text>
+              <View
+                style={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: 20,
+                  borderWidth: 3,
+                  borderColor: '#e0e0e0',
+                  borderTopColor: '#007AFF',
+                  transform: [{ rotate: '0deg' }],
+                }}
+              />
+            </View>
+          ) : debugInfo ? (
+            <View>
+              {debugInfo.conversationId && (
+                <DebugInfoSection
+                  title="Conversation ID"
+                  value={debugInfo.conversationId}
+                />
+              )}
+              {debugInfo.createdAtNs && (
+                <DebugInfoSection
+                  title="Created At"
+                  value={new Date(
+                    debugInfo.createdAtNs / 1000000
+                  ).toLocaleString()}
+                />
+              )}
+              <DebugInfoSection
+                title="Epoch"
+                value={debugInfo.epoch?.toString()}
+              />
+              <DebugInfoSection
+                title="Maybe Forked"
+                value={debugInfo.maybeForked?.toString()}
+              />
+              <DebugInfoSection
+                title="Fork Details"
+                value={debugInfo.forkDetails}
+              />
+              <DebugInfoSection
+                title="Local Commit Log"
+                value={debugInfo.localCommitLog}
+                multiline
+                showCopyButton
+              />
+              <DebugInfoSection
+                title="Remote Commit Log"
+                value={debugInfo.remoteCommitLog}
+                multiline
+                showCopyButton
+              />
+              <DebugInfoSection
+                title="Commit Log Fork Status"
+                value={debugInfo.commitLogForkStatus}
+              />
+
+              {/* Network Debug Info */}
+              {debugInfo.networkDebugInfo && (
+                <>
+                  <Text
+                    style={{
+                      fontSize: 16,
+                      fontWeight: 'bold',
+                      marginTop: 20,
+                      marginBottom: 10,
+                    }}
+                  >
+                    Network Information
+                  </Text>
+                  <DebugInfoSection
+                    title="Total Request Count"
+                    value={debugInfo.networkDebugInfo.totalRequestCount?.toString()}
+                  />
+                  <DebugInfoSection
+                    title="Total Request Time"
+                    value={`${debugInfo.networkDebugInfo.totalRequestTimeMs}ms`}
+                  />
+                  <DebugInfoSection
+                    title="Average Request Time"
+                    value={`${debugInfo.networkDebugInfo.averageRequestTimeMs}ms`}
+                  />
+                  <DebugInfoSection
+                    title="Longest Request Time"
+                    value={`${debugInfo.networkDebugInfo.longestRequestTimeMs}ms`}
+                  />
+                  <DebugInfoSection
+                    title="Error Count"
+                    value={debugInfo.networkDebugInfo.errorCount?.toString()}
+                  />
+                </>
+              )}
+            </View>
+          ) : (
+            <Text style={{ textAlign: 'center', color: '#666', marginTop: 50 }}>
+              No debug information available
+            </Text>
+          )}
+        </ScrollView>
+      </View>
+    </View>
+  )
+}
+
+function DebugInfoSection({
+  title,
+  value,
+  multiline = false,
+  showCopyButton = false,
+}: {
+  title: string
+  value?: string
+  multiline?: boolean
+  showCopyButton?: boolean
+}) {
+  if (!value) return null
+
+  const handleCopy = () => {
+    Clipboard.setString(value)
+    Alert.alert('Copied!', `${title} has been copied to clipboard`)
+  }
+
+  // Check if this is a commit log (local or remote) and format it
+  const isLocalCommitLog = title === 'Local Commit Log'
+  const isRemoteCommitLog = title === 'Remote Commit Log'
+  const isCommitLog = isLocalCommitLog || isRemoteCommitLog
+  const isEnum = title === 'Commit Log Fork Status'
+
+  let formattedValue = value
+  if (isCommitLog) {
+    formattedValue = formatCommitLog(value)
+  } else if (isEnum) {
+    formattedValue = safeEnumToString(value)
+  }
+
+  return (
+    <View style={{ marginBottom: 15 }}>
+      <View
+        style={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 5,
+        }}
+      >
+        <Text style={{ fontSize: 14, fontWeight: 'bold', color: '#333' }}>
+          {title}
+        </Text>
+        {showCopyButton && (
+          <TouchableOpacity
+            onPress={handleCopy}
+            style={{
+              backgroundColor: '#007AFF',
+              paddingHorizontal: 8,
+              paddingVertical: 4,
+              borderRadius: 4,
+              flexDirection: 'row',
+              alignItems: 'center',
+            }}
+          >
+            <FontAwesome
+              name="copy"
+              size={12}
+              color="white"
+              style={{ marginRight: 4 }}
+            />
+            <Text style={{ color: 'white', fontSize: 12, fontWeight: 'bold' }}>
+              Copy
+            </Text>
+          </TouchableOpacity>
+        )}
+      </View>
+      <View
+        style={{
+          backgroundColor: '#f9f9f9',
+          padding: 10,
+          borderRadius: 4,
+          borderWidth: 1,
+          borderColor: '#e0e0e0',
+          // Removed maxHeight and ScrollView for better UX - let main modal handle scrolling
+        }}
+      >
+        <Text
+          style={{
+            fontSize: 13,
+            color: '#666',
+            fontFamily: multiline ? 'monospace' : 'System',
+            lineHeight: 18,
+          }}
+          selectable // Make text selectable
+        >
+          {formattedValue}
+        </Text>
+      </View>
+    </View>
+  )
+}
+
+// Helper function to safely convert enum values to strings
+function safeEnumToString(enumValue: any): string {
+  if (enumValue === null || enumValue === undefined) {
+    return 'undefined'
+  }
+
+  // If it's already a string, return it
+  if (typeof enumValue === 'string') {
+    return enumValue
+  }
+
+  // If it's a number (enum index), convert to string
+  if (typeof enumValue === 'number') {
+    // Map common enum indices to meaningful strings
+    switch (enumValue) {
+      case 0:
+        return 'forked'
+      case 1:
+        return 'notForked'
+      case 2:
+        return 'unknown'
+      default:
+        return `enumValue(${enumValue})`
+    }
+  }
+
+  // If it's an object (Swift enum), try to extract meaningful info
+  if (typeof enumValue === 'object') {
+    // Common patterns for Swift enums
+    if (enumValue.rawValue !== undefined) {
+      return String(enumValue.rawValue)
+    }
+    if (enumValue.description !== undefined) {
+      return String(enumValue.description)
+    }
+    if (enumValue.toString && typeof enumValue.toString === 'function') {
+      try {
+        return enumValue.toString()
+      } catch {
+        // Fall through to generic handling
+      }
+    }
+
+    // Try to extract any string-like properties
+    const keys = Object.keys(enumValue)
+    if (keys.length > 0) {
+      return `SwiftEnum(${keys.join(', ')})`
+    }
+
+    return '[SwiftEnum: unknown]'
+  }
+
+  // Fallback: convert to string safely
+  try {
+    return String(enumValue)
+  } catch {
+    return '[Error: Cannot convert enum to string]'
+  }
+}
+
+function AddMemberModal({
+  visible,
+  onRequestClose,
+  memberAddress,
+  onChangeAddress,
+  onAddMember,
+  isLoading = false,
+}: {
+  visible: boolean
+  onRequestClose: () => void
+  memberAddress: string
+  onChangeAddress: (address: string) => void
+  onAddMember: () => void
+  isLoading?: boolean
+}) {
+  return (
+    <Modal transparent visible={visible} onRequestClose={onRequestClose}>
+      <TouchableWithoutFeedback onPress={onRequestClose}>
+        <View
+          style={{
+            flex: 1,
+            backgroundColor: 'rgba(0,0,0,0.5)',
+          }}
+        />
+      </TouchableWithoutFeedback>
+      <View
+        style={{
+          flex: 1,
+          justifyContent: 'center',
+          margin: '5%',
+        }}
+      >
+        <View
+          style={{
+            margin: 20,
+            backgroundColor: 'white',
+            borderRadius: 8,
+            padding: 24,
+            shadowColor: '#000',
+            shadowOffset: { width: 0, height: 2 },
+            shadowOpacity: 0.25,
+            shadowRadius: 4,
+            elevation: 5,
+          }}
+        >
+          <View
+            style={{
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: 20,
+            }}
+          >
+            <Text style={{ fontSize: 18, fontWeight: 'bold' }}>Add Member</Text>
+            <TouchableOpacity onPress={onRequestClose}>
+              <FontAwesome name="close" size={24} color="#666" />
+            </TouchableOpacity>
+          </View>
+
+          <Text style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
+            Enter the wallet address of the person you want to add to this
+            group:
+          </Text>
+
+          <TextInput
+            style={{
+              borderWidth: 1,
+              borderColor: '#ddd',
+              borderRadius: 6,
+              padding: 12,
+              fontSize: 16,
+              marginBottom: 20,
+              backgroundColor: '#f9f9f9',
+            }}
+            placeholder="0x1234567890abcdef..."
+            value={memberAddress}
+            onChangeText={onChangeAddress}
+            autoCapitalize="none"
+            autoCorrect={false}
+            editable={!isLoading}
+          />
+
+          <View style={{ flexDirection: 'row', gap: 10 }}>
+            <TouchableOpacity
+              style={{
+                flex: 1,
+                backgroundColor: '#f0f0f0',
+                paddingVertical: 12,
+                paddingHorizontal: 16,
+                borderRadius: 6,
+                alignItems: 'center',
+              }}
+              onPress={onRequestClose}
+              disabled={isLoading}
+            >
+              <Text style={{ fontSize: 16, color: '#666' }}>Cancel</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={{
+                flex: 1,
+                backgroundColor:
+                  memberAddress.trim() && !isLoading ? '#007AFF' : '#ccc',
+                paddingVertical: 12,
+                paddingHorizontal: 16,
+                borderRadius: 6,
+                alignItems: 'center',
+              }}
+              onPress={onAddMember}
+              disabled={!memberAddress.trim() || isLoading}
+            >
+              <Text
+                style={{ fontSize: 16, color: 'white', fontWeight: 'bold' }}
+              >
+                {isLoading ? 'Adding...' : 'Add Member'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  )
+}
+
+// Helper function to format commit log entries
+function formatCommitLog(rawLog: string): string {
+  if (!rawLog || typeof rawLog !== 'string') return rawLog
+
+  console.log('🔍 Raw commit log for parsing:', rawLog)
+
+  try {
+    // More sophisticated parsing that handles nested structures like Some("value") and None
+    const entries = []
+    let currentPos = 0
+
+    while (true) {
+      // Find the start of the next LocalCommitLog entry
+      const startMatch = rawLog.indexOf('LocalCommitLog {', currentPos)
+      if (startMatch === -1) break
+
+      // Find the matching closing brace
+      let braceCount = 0
+      let pos = startMatch + 'LocalCommitLog {'.length
+      let entryEnd = -1
+
+      while (pos < rawLog.length) {
+        if (rawLog[pos] === '{') {
+          braceCount++
+        } else if (rawLog[pos] === '}') {
+          if (braceCount === 0) {
+            entryEnd = pos
+            break
+          }
+          braceCount--
+        }
+        pos++
+      }
+
+      if (entryEnd !== -1) {
+        // Extract the content between the braces
+        const entryContent = rawLog
+          .substring(startMatch + 'LocalCommitLog {'.length, entryEnd)
+          .trim()
+        entries.push(entryContent)
+        currentPos = entryEnd + 1
+      } else {
+        break
+      }
+    }
+
+    console.log('🔍 Found entries:', entries.length)
+
+    if (entries.length === 0) {
+      return rawLog // Return original if no entries found
+    }
+
+    // Format each entry
+    return entries
+      .map((entryContent, index) => {
+        // Split by commas but be careful about commas inside quotes
+        const parts = []
+        let current = ''
+        let inQuotes = false
+        let depth = 0
+
+        for (let i = 0; i < entryContent.length; i++) {
+          const char = entryContent[i]
+
+          if (char === '"' && entryContent[i - 1] !== '\\') {
+            inQuotes = !inQuotes
+          } else if (!inQuotes) {
+            if (char === '(' || char === '{') {
+              depth++
+            } else if (char === ')' || char === '}') {
+              depth--
+            } else if (char === ',' && depth === 0) {
+              parts.push(current.trim())
+              current = ''
+              continue
+            }
+          }
+
+          current += char
+        }
+
+        if (current.trim()) {
+          parts.push(current.trim())
+        }
+
+        // Format each part as key: value
+        const formatted = parts
+          .map((part) => {
+            const colonIndex = part.indexOf(':')
+            if (colonIndex !== -1) {
+              const key = part.substring(0, colonIndex).trim()
+              const value = part.substring(colonIndex + 1).trim()
+              return `  ${key}: ${value}`
+            }
+            return `  ${part}`
+          })
+          .filter((line) => line.trim())
+          .join('\n')
+
+        return `Entry ${index + 1}:\n${formatted}\n`
+      })
+      .join('\n' + '─'.repeat(50) + '\n\n')
+  } catch (error) {
+    console.error('🔍 Error parsing commit log:', error)
+    // If parsing fails, return the original with some basic formatting
+    return rawLog
+      .replace(/LocalCommitLog\s*\{/g, '\n\nLocalCommitLog {\n  ')
+      .replace(/,\s+/g, ',\n  ')
+      .replace(/\s*\}/g, '\n}')
+  }
 }

--- a/example/src/HomeScreen.tsx
+++ b/example/src/HomeScreen.tsx
@@ -30,12 +30,155 @@ export default function HomeScreen() {
     isFetching,
     isRefetching,
   } = useConversationList()
+
+  const [forkStatusCounts, setForkStatusCounts] = useState({
+    notForked: 0,
+    forked: 0,
+    unknown: 0,
+  })
+
+  // Stream all messages when screen loads
+  useEffect(() => {
+    if (!client) return
+
+    console.log('🏠 Setting up streamAllMessages on HomeScreen')
+
+    const setupStreamAllMessages = async () => {
+      try {
+        await client.conversations.streamAllMessages(
+          async (message) => {
+            console.log(
+              '🏠 Received message in HomeScreen stream:',
+              message.id,
+              message.content()
+            )
+            // You can add additional logic here to handle incoming messages
+            // For example, updating a global state, showing notifications, etc.
+          },
+          'all', // Stream from both groups and DMs
+          undefined, // Use default consent states (allowed and unknown)
+          () => {
+            console.log('🏠 StreamAllMessages closed on HomeScreen')
+          }
+        )
+        console.log('🏠 StreamAllMessages setup complete on HomeScreen')
+      } catch (error) {
+        console.error(
+          '🏠 Error setting up streamAllMessages on HomeScreen:',
+          error
+        )
+      }
+    }
+
+    setupStreamAllMessages().catch(console.error)
+
+    return () => {
+      console.log('🏠 Cleaning up streamAllMessages on HomeScreen')
+      try {
+        client.conversations.cancelStreamAllMessages()
+      } catch (error) {
+        console.error(
+          '🏠 Error canceling streamAllMessages on HomeScreen:',
+          error
+        )
+      }
+    }
+  }, [client])
+
+  // Update fork status counts when conversations change
+  useEffect(() => {
+    if (!conversations) return
+
+    const updateCounts = async () => {
+      const counts = { notForked: 0, forked: 0, unknown: 0 }
+
+      await Promise.all(
+        conversations.map(async (conversation) => {
+          try {
+            const status = conversation.commitLogForkStatus
+
+            switch (status) {
+              case 'notForked':
+                counts.notForked++
+                break
+              case 'forked':
+                counts.forked++
+                break
+              default:
+                counts.unknown++
+                break
+            }
+          } catch (error) {
+            console.error('Error getting debug info for conversation:', error)
+            counts.unknown++
+          }
+        })
+      )
+
+      setForkStatusCounts(counts)
+    }
+
+    updateCounts().catch(console.error)
+  }, [conversations])
+
   return (
     <>
       <View>
         <Text style={{ fontSize: 24, fontWeight: 'bold', textAlign: 'center' }}>
           Inbox
         </Text>
+
+        {/* Fork Status Summary */}
+        <View
+          style={{
+            backgroundColor: '#f0f0f0',
+            padding: 12,
+            marginHorizontal: 16,
+            marginVertical: 8,
+            borderRadius: 8,
+            borderWidth: 1,
+            borderColor: '#ddd',
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 16,
+              fontWeight: 'bold',
+              marginBottom: 8,
+              textAlign: 'center',
+            }}
+          >
+            Fork Status Summary
+          </Text>
+          <View
+            style={{ flexDirection: 'row', justifyContent: 'space-around' }}
+          >
+            <View style={{ alignItems: 'center' }}>
+              <Text
+                style={{ fontSize: 18, fontWeight: 'bold', color: '#28a745' }}
+              >
+                {forkStatusCounts.notForked}
+              </Text>
+              <Text style={{ fontSize: 12, color: '#666' }}>Not Forked</Text>
+            </View>
+            <View style={{ alignItems: 'center' }}>
+              <Text
+                style={{ fontSize: 18, fontWeight: 'bold', color: '#dc3545' }}
+              >
+                {forkStatusCounts.forked}
+              </Text>
+              <Text style={{ fontSize: 12, color: '#666' }}>Forked</Text>
+            </View>
+            <View style={{ alignItems: 'center' }}>
+              <Text
+                style={{ fontSize: 18, fontWeight: 'bold', color: '#6c757d' }}
+              >
+                {forkStatusCounts.unknown}
+              </Text>
+              <Text style={{ fontSize: 12, color: '#666' }}>Unknown</Text>
+            </View>
+          </View>
+        </View>
         <FlatList
           refreshing={isFetching || isRefetching}
           onRefresh={refetch}

--- a/example/src/tests/clientTests.ts
+++ b/example/src/tests/clientTests.ts
@@ -1,9 +1,6 @@
 import { ethers, Wallet } from 'ethers'
 import RNFS from 'react-native-fs'
-import {
-  ArchiveMetadata,
-  ArchiveOptions,
-} from 'xmtp-react-native-sdk/lib/ArchiveOptions'
+import { ArchiveOptions } from 'xmtp-react-native-sdk/lib/ArchiveOptions'
 import { InstallationId } from 'xmtp-react-native-sdk/lib/Client'
 
 import {

--- a/ios/Wrappers/ConversationDebugInfoWrapper.swift
+++ b/ios/Wrappers/ConversationDebugInfoWrapper.swift
@@ -8,7 +8,21 @@ struct ConversationDebugInfoWrapper {
             "epoch": info.epoch,
             "maybeForked": info.maybeForked,
             "forkDetails": info.forkDetails,
+            "localCommitLog": info.localCommitLog,
+            "remoteCommitLog": info.remoteCommitLog,
+            "commitLogForkStatus": commitLogForkStatusToString(info.commitLogForkStatus)
         ]
+    }
+    
+    static func commitLogForkStatusToString(_ status: CommitLogForkStatus) -> String {
+        switch status {
+        case .forked:
+            return "forked"
+        case .notForked:
+            return "notForked"
+        default:
+            return "unknown"
+        }
     }
     
     static func encode(_ info: XMTP.ConversationDebugInfo) throws -> String {

--- a/ios/Wrappers/DmWrapper.swift
+++ b/ios/Wrappers/DmWrapper.swift
@@ -17,7 +17,8 @@ struct DmWrapper {
 			"createdAt": UInt64(dm.createdAt.timeIntervalSince1970 * 1000),
 			"version": "DM",
 			"topic": dm.topic,
-			"peerInboxId": try dm.peerInboxId
+			"peerInboxId": try dm.peerInboxId,
+			"commitLogForkStatus": ConversationDebugInfoWrapper.commitLogForkStatusToString(dm.commitLogForkStatus())
 		]
 
 		if conversationParams.consentState {

--- a/ios/Wrappers/GroupWrapper.swift
+++ b/ios/Wrappers/GroupWrapper.swift
@@ -17,7 +17,8 @@ struct GroupWrapper {
 			"id": group.id,
 			"createdAt": UInt64(group.createdAt.timeIntervalSince1970 * 1000),
 			"version": "GROUP",
-			"topic": group.topic
+			"topic": group.topic,
+			"commitLogForkStatus": ConversationDebugInfoWrapper.commitLogForkStatusToString(group.commitLogForkStatus())
 		]
 
 		if conversationParams.isActive {

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.4.0-rc1"
+  s.dependency "XMTP", "= 4.4.0-rc2"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/react-native-sdk",
-  "version": "4.3.6",
+  "version": "4.4.0-rc2",
   "description": "Wraps for native xmtp sdks for react native",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1020,8 +1020,8 @@ export async function createGroupCustomPermissionsWithIdentities<
   name: string = '',
   imageUrl: string = '',
   description: string = '',
-  disappearStartingAtNs: number = 0,
-  retentionDurationInNs: number = 0
+  disappearStartingAtNs: number | undefined = undefined,
+  retentionDurationInNs: number | undefined = undefined
 ): Promise<Group<ContentTypes>> {
   const options: CreateGroupParams = {
     name,
@@ -1052,8 +1052,8 @@ export async function createGroupWithIdentities<
   name: string = '',
   imageUrl: string = '',
   description: string = '',
-  disappearStartingAtNs: number = 0,
-  retentionDurationInNs: number = 0
+  disappearStartingAtNs: number | undefined = undefined,
+  retentionDurationInNs: number | undefined = undefined
 ): Promise<Group<ContentTypes>> {
   const options: CreateGroupParams = {
     name,
@@ -1084,8 +1084,8 @@ export async function createGroupCustomPermissions<
   name: string = '',
   imageUrl: string = '',
   description: string = '',
-  disappearStartingAtNs: number = 0,
-  retentionDurationInNs: number = 0
+  disappearStartingAtNs: number | undefined = undefined,
+  retentionDurationInNs: number | undefined = undefined
 ): Promise<Group<ContentTypes>> {
   const options: CreateGroupParams = {
     name,
@@ -1114,8 +1114,8 @@ export async function createGroupOptimistic<
   name: string = '',
   imageUrl: string = '',
   description: string = '',
-  disappearStartingAtNs: number = 0,
-  retentionDurationInNs: number = 0
+  disappearStartingAtNs: number | undefined = undefined,
+  retentionDurationInNs: number | undefined = undefined
 ): Promise<Group<ContentTypes>> {
   const options: CreateGroupParams = {
     name,
@@ -1695,6 +1695,7 @@ export async function getDebugInformation(
   id: ConversationId
 ): Promise<ConversationDebugInfo> {
   const info = await XMTPModule.getDebugInformation(installationId, id)
+  console.log(info)
   return ConversationDebugInfo.from(info)
 }
 

--- a/src/lib/Conversation.ts
+++ b/src/lib/Conversation.ts
@@ -17,6 +17,7 @@ import {
   DisappearingMessageSettings,
   ConversationDebugInfo,
 } from '../index'
+import { CommitLogForkStatus } from './ConversationDebugInfo'
 import { DecodedMessageUnion } from './types/DecodedMessageUnion'
 import { DefaultContentTypes } from './types/DefaultContentType'
 
@@ -33,6 +34,7 @@ export interface ConversationBase<ContentTypes extends DefaultContentTypes> {
   id: string
   state: ConsentState
   lastMessage?: DecodedMessage<ContentTypes[number]>
+  commitLogForkStatus?: CommitLogForkStatus
 
   send<SendContentTypes extends DefaultContentTypes = ContentTypes>(
     content: ConversationSendPayload<SendContentTypes>,

--- a/src/lib/ConversationDebugInfo.ts
+++ b/src/lib/ConversationDebugInfo.ts
@@ -1,12 +1,31 @@
+export enum CommitLogForkStatus {
+  FORKED = 'forked',
+  NOT_FORKED = 'notForked',
+  UNKNOWN = 'unknown',
+}
+
 export class ConversationDebugInfo {
   epoch: number
   maybeForked: boolean
   forkDetails: string
+  localCommitLog: string
+  remoteCommitLog: string
+  commitLogForkStatus: CommitLogForkStatus
 
-  constructor(epoch: number, maybeForked: boolean, forkDetails: string) {
+  constructor(
+    epoch: number,
+    maybeForked: boolean,
+    forkDetails: string,
+    localCommitLog: string,
+    remoteCommitLog: string,
+    commitLogForkStatus: CommitLogForkStatus
+  ) {
     this.epoch = epoch
     this.maybeForked = maybeForked
     this.forkDetails = forkDetails
+    this.localCommitLog = localCommitLog
+    this.remoteCommitLog = remoteCommitLog
+    this.commitLogForkStatus = commitLogForkStatus
   }
 
   static from(json: string): ConversationDebugInfo {
@@ -14,7 +33,10 @@ export class ConversationDebugInfo {
     return new ConversationDebugInfo(
       entry.epoch,
       entry.maybeForked,
-      entry.forkDetails
+      entry.forkDetails,
+      entry.localCommitLog,
+      entry.remoteCommitLog,
+      entry.commitLogForkStatus
     )
   }
 }

--- a/src/lib/Dm.ts
+++ b/src/lib/Dm.ts
@@ -13,6 +13,7 @@ import {
   ConversationTopic,
   DisappearingMessageSettings,
 } from '../index'
+import { CommitLogForkStatus } from './ConversationDebugInfo'
 import { ConversationSendPayload } from './types/ConversationCodecs'
 import { DecodedMessageUnion } from './types/DecodedMessageUnion'
 import { DefaultContentTypes } from './types/DefaultContentType'
@@ -26,6 +27,7 @@ export interface DmParams {
   topic: ConversationTopic
   consentState: ConsentState
   lastMessage?: DecodedMessage
+  commitLogForkStatus?: CommitLogForkStatus
 }
 
 export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
@@ -38,6 +40,7 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
   topic: ConversationTopic
   state: ConsentState
   lastMessage?: DecodedMessageUnion<ContentTypes>
+  commitLogForkStatus?: CommitLogForkStatus
 
   constructor(
     client: Client<ContentTypes>,
@@ -50,6 +53,7 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
     this.topic = params.topic
     this.state = params.consentState
     this.lastMessage = lastMessage
+    this.commitLogForkStatus = params.commitLogForkStatus
   }
 
   /**

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -4,6 +4,7 @@ import { Subscription } from 'expo-modules-core'
 import { Client, InboxId } from './Client'
 import { ConsentState } from './ConsentRecord'
 import { ConversationBase, ConversationVersion } from './Conversation'
+import { CommitLogForkStatus } from './ConversationDebugInfo'
 import { DecodedMessage } from './DecodedMessage'
 import { Member, MembershipResult } from './Member'
 import * as XMTP from '../index'
@@ -35,6 +36,7 @@ export interface GroupParams {
   description: string
   consentState: ConsentState
   lastMessage?: DecodedMessage
+  commitLogForkStatus?: CommitLogForkStatus
 }
 
 export class Group<
@@ -53,6 +55,7 @@ export class Group<
   groupDescription: string
   state: ConsentState
   lastMessage?: DecodedMessageUnion<ContentTypes>
+  commitLogForkStatus?: CommitLogForkStatus
 
   constructor(
     client: Client<ContentTypes>,
@@ -70,6 +73,7 @@ export class Group<
     this.groupDescription = params.description
     this.state = params.consentState
     this.lastMessage = lastMessage
+    this.commitLogForkStatus = params.commitLogForkStatus
   }
 
   /**


### PR DESCRIPTION
See Example App UI updates for verifying fork detection commit log

<img width="600"  alt="image" src="https://github.com/user-attachments/assets/6e9437d4-2779-4bee-b4dd-2bb7d139196f" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/5ace4442-c96f-4848-b391-6ecacbf8be53" />




### Expose commit log fork detection and commit logs across React Native conversation models and debug info, and add example app UI for testing fork status
- Add `localCommitLog`, `remoteCommitLog`, and stringified `commitLogForkStatus` to native encoders for conversations and debug info via helpers in [android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ConversationDebugInfoWrapper.kt](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-4cec2b82cf578322ac13f4a1f750ba9fd6fb67d146033a1b758f70ded9763912), [android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/DmWrapper.kt](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-bf34e3090a6883b4f5b36ebfbf7a90b96a18f6e669541b47691938bffccc87a3), [android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/GroupWrapper.kt](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-9e3b852c5d1be33bce2601d617ee6db527c162d251d34098cdaa4725a0197b5d), [ios/Wrappers/ConversationDebugInfoWrapper.swift](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-09d41fe0577083c6fc381cf7a4c8f064b5b23472d0b8e4d55ac6c77c0d8e0bec), [ios/Wrappers/DmWrapper.swift](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-d809907680d077730500d551d47eeb2cee881002695d365cb1a5b72e52a8596a), and [ios/Wrappers/GroupWrapper.swift](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-60f969744f966e275332171530b0c816c6b0404dd389f201a92ac478c6d15a00).
- Extend TypeScript models to surface `commitLogForkStatus` and commit logs: introduce `CommitLogForkStatus`, add fields to `ConversationDebugInfo`, and plumb optional `commitLogForkStatus` through `Dm`, `Group`, and `ConversationBase` in [src/lib/ConversationDebugInfo.ts](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-dc00f89a3d6a24761d5a32d07f67b5ea4782aac10403a92521f8d3060dd8152d), [src/lib/Dm.ts](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-91229175a5640a00261c07e8aa8ac1e4d60a6dc2b82a158315f73cb95629e885), [src/lib/Group.ts](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-f2fe49ba305551e805d90b6c87407658327c9f6fb204800c14d2cb26331300c5), and [src/lib/Conversation.ts](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-04b01cc7b95bf292a4c00f53eee21842ef6cd6f48720112849487d718d9858bb).
- Update example app UI with an options menu, debug information modal (including commit logs and fork status with refresh/copy), and group add-member flow in [example/src/ConversationScreen.tsx](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-f03729d30c0c3074b8938c566b209fa82edf82755dc7a53bc0896c3e3fd602e9); add a fork status summary panel and message stream setup in [example/src/HomeScreen.tsx](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-5f8e549a7b3c61c7fa9b6a886703a57d0655322892e1fcc32eff8cbe47ba4a9c).
- Adjust group creation functions to serialize `disappearStartingAtNs` and `retentionDurationInNs` as `undefined` when omitted and log raw debug info in `getDebugInformation` in [src/index.ts](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).
- Bump XMTP dependencies to 4.4.0-rc2 in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a), [ios/XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3), and [example/ios/Podfile.lock](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-b2790cc3d555682b207af1ca2fb897ebd2114c01149bf460fd85fc2b1503a687); remove an unused import in [example/src/tests/clientTests.ts](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-a9fbaf6d0f12a74e139cb6d1ac663e952984ff42ed4a835b9243f1ebc3a6b236).

#### 📍Where to Start
Start with the native encoding in `ConversationDebugInfoWrapper.encodeToObj` at [android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ConversationDebugInfoWrapper.kt](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-4cec2b82cf578322ac13f4a1f750ba9fd6fb67d146033a1b758f70ded9763912) (and parity in [ios/Wrappers/ConversationDebugInfoWrapper.swift](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-09d41fe0577083c6fc381cf7a4c8f064b5b23472d0b8e4d55ac6c77c0d8e0bec)), then follow the parsing in `ConversationDebugInfo.from` in [src/lib/ConversationDebugInfo.ts](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-dc00f89a3d6a24761d5a32d07f67b5ea4782aac10403a92521f8d3060dd8152d), and finally review the UI consumption in [example/src/ConversationScreen.tsx](https://github.com/xmtp/xmtp-react-native/pull/707/files#diff-f03729d30c0c3074b8938c566b209fa82edf82755dc7a53bc0896c3e3fd602e9).

----

_[Macroscope](https://app.macroscope.com) summarized 0dbcce6._