### PR TITLE
Release 4.3.7

### DIFF
--- a/.changeset/four-panthers-lick.md
+++ b/.changeset/four-panthers-lick.md
@@ -1,5 +1,0 @@
----
-"@xmtp/react-native-sdk": patch
----
-
-Release 4.3.7 with critical bug fix for disappearing message settings.

--- a/.changeset/four-panthers-lick.md
+++ b/.changeset/four-panthers-lick.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+Release 4.3.7 with critical bug fix for disappearing message settings.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.3.5"
+  implementation "org.xmtp:android:4.3.6"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -60,11 +60,11 @@ PODS:
   - hermes-engine (0.76.9):
     - hermes-engine/Pre-built (= 0.76.9)
   - hermes-engine/Pre-built (0.76.9)
-  - LibXMTP (4.3.6)
+  - LibXMTP (4.3.7)
   - MessagePacker (0.4.7)
-  - MMKV (2.2.2):
-    - MMKVCore (~> 2.2.2)
-  - MMKVCore (2.2.2)
+  - MMKV (2.2.3):
+    - MMKVCore (~> 2.2.3)
+  - MMKVCore (2.2.3)
   - OpenSSL-Universal (1.1.2200)
   - RCT-Folly (2024.10.14.00):
     - boost
@@ -1737,18 +1737,18 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.3.6):
+  - XMTP (4.3.7):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - CSecp256k1 (~> 0.2)
-    - LibXMTP (= 4.3.6)
+    - LibXMTP (= 4.3.7)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (4.3.5):
+  - XMTPReactNative (4.3.7):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.3.6)
+    - XMTP (= 4.3.7)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2080,10 +2080,10 @@ SPEC CHECKSUMS:
   fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 9e868dc7be781364296d6ee2f56d0c1a9ef0bb11
-  LibXMTP: 9f1fbdfb5f72ca9f188104103e64fa758b0185c2
+  LibXMTP: 98ddeba06bd48c957166b8657600121205000670
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
-  MMKV: b4802ebd5a7c68fc0c4a5ccb4926fbdfb62d68e0
-  MMKVCore: a255341a3746955f50da2ad9121b18cb2b346e61
+  MMKV: 941e8774da0e6fdf12c6b3fcc833ca687ae5a42d
+  MMKVCore: 6d5cc1bacce539f4c974985dfe646fb65a5d27d2
   OpenSSL-Universal: 6e1ae0555546e604dbc632a2b9a24a9c46c41ef6
   RCT-Folly: ea9d9256ba7f9322ef911169a9f696e5857b9e17
   RCTDeprecation: ebe712bb05077934b16c6bf25228bdec34b64f83
@@ -2160,10 +2160,10 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: 245e8309335ec29ccea4b7c5edfefd27360a7b82
-  XMTPReactNative: 6a21de8c0a54dc644a263d7f3677209ad73bd986
+  XMTP: 9ea13dcee1502cd775669fff7b02813486d109f2
+  XMTPReactNative: 2ca6976e19657c933bc23c9bc60b133e98d2bd2b
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
-PODFILE CHECKSUM: 445234b5e9cf4fcba62da9f7d5f6b62e89502f20
+PODFILE CHECKSUM: 283c313cbc1ba9857a692b5901eb740dad922eca
 
 COCOAPODS: 1.16.2

--- a/example/src/tests/conversationTests.ts
+++ b/example/src/tests/conversationTests.ts
@@ -1211,7 +1211,7 @@ test('test pausedForVersion', async () => {
   return true
 })
 
-test('messages dont disappear', async () => {
+test('messages dont disappear createGroup', async () => {
   const [alix, bo] = await createClients(2)
 
   const groupCreationOptions = {
@@ -1221,6 +1221,87 @@ test('messages dont disappear', async () => {
     [bo.inboxId],
     groupCreationOptions
   )
+  await alixGroup.sync()
+
+  const settings = await alixGroup.isDisappearingMessagesEnabled()
+  assert(settings === false, `Expected null, got ${settings}`)
+
+  await alix.conversations.syncAllConversations()
+
+  await alixGroup.send({ text: 'hello world' })
+
+  const alixMessages = await alixGroup.messages()
+  assert(
+    alixMessages.length === 2,
+    `Expected 2 messages for alix, got ${alixMessages.length}`
+  )
+
+  // Wait 1 second
+  await delayToPropogate(1000)
+
+  const messages2 = await alixGroup.messages()
+  assert(
+    messages2.length === 2,
+    `Expected 2 messages for alix after sync, got ${messages2.length}`
+  )
+
+  return true
+})
+
+test('messages dont disappear newGroupCustomPermissionsWithIdentities', async () => {
+  const [alix, bo] = await createClients(2)
+
+  const groupCreationOptions = {
+    disappearingMessageSettings: undefined,
+  }
+  const alixGroup =
+    await alix.conversations.newGroupCustomPermissionsWithIdentities(
+      [bo.publicIdentity],
+      {
+        addMemberPolicy: 'allow',
+        removeMemberPolicy: 'admin',
+        addAdminPolicy: 'admin',
+        removeAdminPolicy: 'admin',
+        updateGroupNamePolicy: 'allow',
+        updateGroupDescriptionPolicy: 'allow',
+        updateGroupImagePolicy: 'allow',
+        updateMessageDisappearingPolicy: 'admin',
+      },
+      groupCreationOptions
+    )
+  await alixGroup.sync()
+
+  const settings = await alixGroup.isDisappearingMessagesEnabled()
+  assert(settings === false, `Expected null, got ${settings}`)
+
+  await alix.conversations.syncAllConversations()
+
+  await alixGroup.send({ text: 'hello world' })
+
+  const alixMessages = await alixGroup.messages()
+  assert(
+    alixMessages.length === 2,
+    `Expected 2 messages for alix, got ${alixMessages.length}`
+  )
+
+  // Wait 1 second
+  await delayToPropogate(1000)
+
+  const messages2 = await alixGroup.messages()
+  assert(
+    messages2.length === 2,
+    `Expected 2 messages for alix after sync, got ${messages2.length}`
+  )
+
+  return true
+})
+
+test('messages dont disappear newGroupWithIdentities', async () => {
+  const [alix, bo] = await createClients(2)
+
+  const alixGroup = await alix.conversations.newGroupWithIdentities([
+    bo.publicIdentity,
+  ])
   await alixGroup.sync()
 
   const settings = await alixGroup.isDisappearingMessagesEnabled()

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.3.6"
+  s.dependency "XMTP", "= 4.3.7"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/react-native-sdk",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "description": "Wraps for native xmtp sdks for react native",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
### Release 4.3.7 by upgrading Android to `org.xmtp:android` 4.3.6, setting iOS `XMTP` CocoaPod to 4.3.7, bumping `package.json` to 4.3.7, and adding tests asserting disabled disappearing messages for new groups
- Update Android dependency in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/708/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a) from `org.xmtp:android` 4.3.5 to 4.3.6.
- Bump iOS podspec in [ios/XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/708/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3) to `XMTP` 4.3.7.
- Adjust example iOS lockfile in [example/ios/Podfile.lock](https://github.com/xmtp/xmtp-react-native/pull/708/files#diff-b2790cc3d555682b207af1ca2fb897ebd2114c01149bf460fd85fc2b1503a687) to `LibXMTP` 4.3.7, `XMTP` 4.3.7, `XMTPReactNative` 4.3.7, and `MMKV/MMKVCore` 2.2.3 with updated checksums.
- Increment package version in [package.json](https://github.com/xmtp/xmtp-react-native/pull/708/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to 4.3.7.
- Rename and add conversation tests in [example/src/tests/conversationTests.ts](https://github.com/xmtp/xmtp-react-native/pull/708/files#diff-e9f0366d154e29ec868561703b5ad3325cd0018af4f1d31c45a8aff9fe4c4313) to verify non-disappearing behavior for `newGroupWithIdentities` and `newGroupCustomPermissionsWithIdentities` when `disappearingMessageSettings` is `undefined`.

#### 📍Where to Start
Start with the new and renamed tests in [example/src/tests/conversationTests.ts](https://github.com/xmtp/xmtp-react-native/pull/708/files#diff-e9f0366d154e29ec868561703b5ad3325cd0018af4f1d31c45a8aff9fe4c4313), focusing on `messages dont disappear newGroupCustomPermissionsWithIdentities`, `messages dont disappear newGroupWithIdentities`, and `messages dont disappear createGroup`.

----

_[Macroscope](https://app.macroscope.com) summarized 980cb28._