### PR TITLE
Release 4.4.0

### DIFF
--- a/.changeset/funny-starfishes-hang.md
+++ b/.changeset/funny-starfishes-hang.md
@@ -1,0 +1,7 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+Release 4.4.0
+- Archive-based backups for conversation and message backup/restore
+- Improved fork detection for reliably flagging group state mismatches

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.4.0-rc2"
+  implementation "org.xmtp:android:4.4.0"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -60,11 +60,11 @@ PODS:
   - hermes-engine (0.76.9):
     - hermes-engine/Pre-built (= 0.76.9)
   - hermes-engine/Pre-built (0.76.9)
-  - LibXMTP (4.4.0-rc2)
+  - LibXMTP (4.4.0)
   - MessagePacker (0.4.7)
-  - MMKV (2.2.2):
-    - MMKVCore (~> 2.2.2)
-  - MMKVCore (2.2.2)
+  - MMKV (2.2.3):
+    - MMKVCore (~> 2.2.3)
+  - MMKVCore (2.2.3)
   - OpenSSL-Universal (1.1.2200)
   - RCT-Folly (2024.10.14.00):
     - boost
@@ -1737,18 +1737,18 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.4.0-rc2):
+  - XMTP (4.4.0):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - CSecp256k1 (~> 0.2)
-    - LibXMTP (= 4.4.0-rc2)
+    - LibXMTP (= 4.4.0)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (4.3.6):
+  - XMTPReactNative (4.4.0-rc2):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.4.0-rc2)
+    - XMTP (= 4.4.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2080,10 +2080,10 @@ SPEC CHECKSUMS:
   fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 9e868dc7be781364296d6ee2f56d0c1a9ef0bb11
-  LibXMTP: 8f8f5222638557b8de4508152bb3eed72b8cf22d
+  LibXMTP: fe0ac6528cf59308dbecde4f39f241b06cfaf567
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
-  MMKV: b4802ebd5a7c68fc0c4a5ccb4926fbdfb62d68e0
-  MMKVCore: a255341a3746955f50da2ad9121b18cb2b346e61
+  MMKV: 941e8774da0e6fdf12c6b3fcc833ca687ae5a42d
+  MMKVCore: 6d5cc1bacce539f4c974985dfe646fb65a5d27d2
   OpenSSL-Universal: 6e1ae0555546e604dbc632a2b9a24a9c46c41ef6
   RCT-Folly: ea9d9256ba7f9322ef911169a9f696e5857b9e17
   RCTDeprecation: ebe712bb05077934b16c6bf25228bdec34b64f83
@@ -2160,8 +2160,8 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: 8361aef38f0e363cd39a259362c5db5f320e4268
-  XMTPReactNative: ef2c8a8cabc0b75fe66c27ce8fa93da9baf36fae
+  XMTP: 720c5d4726f869ea38668735da9777ecc851fd89
+  XMTPReactNative: 2c11827d2b901f9865376bb1033b14b7eb3acbfb
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 283c313cbc1ba9857a692b5901eb740dad922eca

--- a/example/src/tests/conversationTests.ts
+++ b/example/src/tests/conversationTests.ts
@@ -1211,7 +1211,7 @@ test('test pausedForVersion', async () => {
   return true
 })
 
-test('messages dont disappear', async () => {
+test('messages dont disappear createGroup', async () => {
   const [alix, bo] = await createClients(2)
 
   const groupCreationOptions = {
@@ -1221,6 +1221,87 @@ test('messages dont disappear', async () => {
     [bo.inboxId],
     groupCreationOptions
   )
+  await alixGroup.sync()
+
+  const settings = await alixGroup.isDisappearingMessagesEnabled()
+  assert(settings === false, `Expected null, got ${settings}`)
+
+  await alix.conversations.syncAllConversations()
+
+  await alixGroup.send({ text: 'hello world' })
+
+  const alixMessages = await alixGroup.messages()
+  assert(
+    alixMessages.length === 2,
+    `Expected 2 messages for alix, got ${alixMessages.length}`
+  )
+
+  // Wait 1 second
+  await delayToPropogate(1000)
+
+  const messages2 = await alixGroup.messages()
+  assert(
+    messages2.length === 2,
+    `Expected 2 messages for alix after sync, got ${messages2.length}`
+  )
+
+  return true
+})
+
+test('messages dont disappear newGroupCustomPermissionsWithIdentities', async () => {
+  const [alix, bo] = await createClients(2)
+
+  const groupCreationOptions = {
+    disappearingMessageSettings: undefined,
+  }
+  const alixGroup =
+    await alix.conversations.newGroupCustomPermissionsWithIdentities(
+      [bo.publicIdentity],
+      {
+        addMemberPolicy: 'allow',
+        removeMemberPolicy: 'admin',
+        addAdminPolicy: 'admin',
+        removeAdminPolicy: 'admin',
+        updateGroupNamePolicy: 'allow',
+        updateGroupDescriptionPolicy: 'allow',
+        updateGroupImagePolicy: 'allow',
+        updateMessageDisappearingPolicy: 'admin',
+      },
+      groupCreationOptions
+    )
+  await alixGroup.sync()
+
+  const settings = await alixGroup.isDisappearingMessagesEnabled()
+  assert(settings === false, `Expected null, got ${settings}`)
+
+  await alix.conversations.syncAllConversations()
+
+  await alixGroup.send({ text: 'hello world' })
+
+  const alixMessages = await alixGroup.messages()
+  assert(
+    alixMessages.length === 2,
+    `Expected 2 messages for alix, got ${alixMessages.length}`
+  )
+
+  // Wait 1 second
+  await delayToPropogate(1000)
+
+  const messages2 = await alixGroup.messages()
+  assert(
+    messages2.length === 2,
+    `Expected 2 messages for alix after sync, got ${messages2.length}`
+  )
+
+  return true
+})
+
+test('messages dont disappear newGroupWithIdentities', async () => {
+  const [alix, bo] = await createClients(2)
+
+  const alixGroup = await alix.conversations.newGroupWithIdentities([
+    bo.publicIdentity,
+  ])
   await alixGroup.sync()
 
   const settings = await alixGroup.isDisappearingMessagesEnabled()

--- a/example/src/tests/conversationTests.ts
+++ b/example/src/tests/conversationTests.ts
@@ -971,7 +971,7 @@ test('can streamAll from multiple clients - swapped orderring', async () => {
 
   // Start Caro starts a new conversation.
   await caro.conversations.newConversation(alix.inboxId)
-  await delayToPropogate()
+  await delayToPropogate(500)
   if (allBoConversations.length !== 0) {
     throw Error(
       'Unexpected all conversations count for Bo ' +

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -1250,7 +1250,10 @@ test('can list groups', async () => {
     `Group 2 url for alix should be www.group2image.com but was ${alixGroup2?.imageUrl}`
   )
 
-  assert(boGroup1?.isActive === true, `Group 1 should be active for bo`)
+  assert(
+    (await boGroup1?.isActive()) ?? false,
+    `Group 1 should be active for bo`
+  )
 
   return true
 })

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.4.0-rc2"
+  s.dependency "XMTP", "= 4.4.0"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end


### PR DESCRIPTION
Update libxmtp ref to 1.4.0 for final release:
- Archive-based backups for conversation and message backup/restore
- Improved fork detection for reliably flagging group state mismatches