### PR TITLE
Adds test for group updated msg  upon joining group/dm and fix initiatedBy parsing on android

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
@@ -260,8 +260,8 @@ class ContentJson(
             )
 
             ContentTypeGroupUpdated.id -> mapOf(
-                "initiatedByInboxId" to (content as GroupUpdated).initiatedByInboxId,
                 "groupUpdated" to mapOf(
+                    "initiatedByInboxId" to (content as GroupUpdated).initiatedByInboxId,
                     "membersAdded" to content.addedInboxesList.map {
                         mapOf(
                             "inboxId" to it.inboxId

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1743,7 +1743,7 @@ PODS:
     - CSecp256k1 (~> 0.2)
     - LibXMTP (= 4.4.0)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (4.4.0-rc2):
+  - XMTPReactNative (4.4.0):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
@@ -2161,7 +2161,7 @@ SPEC CHECKSUMS:
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
   XMTP: 720c5d4726f869ea38668735da9777ecc851fd89
-  XMTPReactNative: 2c11827d2b901f9865376bb1033b14b7eb3acbfb
+  XMTPReactNative: c2b932b71ff9dccebe37e2c8edde38720e8cc270
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 283c313cbc1ba9857a692b5901eb740dad922eca


### PR DESCRIPTION
### Fix `initiatedByInboxId` nesting for `ContentTypeGroupUpdated` in Android `expo.modules.xmtpreactnativesdk.wrappers.ContentJson` and add tests for the group-updated message upon joining a group or DM
- Move `initiatedByInboxId` under the `groupUpdated` object for `ContentTypeGroupUpdated` in [ContentJson.kt](https://github.com/xmtp/xmtp-react-native/pull/712/files#diff-6070928f30e220b67c437420d2508b3720969bce82ab5433b1b46bb674c54d9e).
- Add a test in [conversationTests.ts](https://github.com/xmtp/xmtp-react-native/pull/712/files#diff-e9f0366d154e29ec868561703b5ad3325cd0018af4f1d31c45a8aff9fe4c4313) that registers `GroupUpdatedCodec`, creates a group and a DM, and asserts the first message is `xmtp.org/group_updated:1.0` with the expected `initiatedByInboxId` using `GroupUpdatedContent`.
- Update [Podfile.lock](https://github.com/xmtp/xmtp-react-native/pull/712/files#diff-b2790cc3d555682b207af1ca2fb897ebd2114c01149bf460fd85fc2b1503a687) to reference XMTPReactNative 4.4.0.

#### 📍Where to Start
Start with the `ContentTypeGroupUpdated` mapping in [ContentJson.kt](https://github.com/xmtp/xmtp-react-native/pull/712/files#diff-6070928f30e220b67c437420d2508b3720969bce82ab5433b1b46bb674c54d9e), then review the new test in [conversationTests.ts](https://github.com/xmtp/xmtp-react-native/pull/712/files#diff-e9f0366d154e29ec868561703b5ad3325cd0018af4f1d31c45a8aff9fe4c4313).

----

_[Macroscope](https://app.macroscope.com) summarized ab5b96b._