### PR TITLE
Validating ethereum signing functions moved to libxmtp on iOS

### DIFF
--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -893,6 +893,7 @@ class XMTPModule : Module() {
             DecryptedLocalAttachment(
                 fileUri = file.toURI().toString(),
                 mimeType = attachment.mimeType,
+                
                 filename = attachment.filename
             ).toJson()
         }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -60,7 +60,7 @@ PODS:
   - hermes-engine (0.76.9):
     - hermes-engine/Pre-built (= 0.76.9)
   - hermes-engine/Pre-built (0.76.9)
-  - LibXMTP (4.4.0)
+  - LibXMTP (4.5.0-dev.c78b650)
   - MessagePacker (0.4.7)
   - MMKV (2.2.3):
     - MMKVCore (~> 2.2.3)
@@ -1737,18 +1737,17 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.4.0):
+  - XMTP (4.5.0-dev.a0bb8bd):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
-    - CSecp256k1 (~> 0.2)
-    - LibXMTP (= 4.4.0)
+    - LibXMTP (= 4.5.0-dev.c78b650)
     - SQLCipher (= 4.5.7)
   - XMTPReactNative (4.4.0):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.4.0)
+    - XMTP (= 4.5.0-dev.a0bb8bd)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2080,7 +2079,7 @@ SPEC CHECKSUMS:
   fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 9e868dc7be781364296d6ee2f56d0c1a9ef0bb11
-  LibXMTP: fe0ac6528cf59308dbecde4f39f241b06cfaf567
+  LibXMTP: fc69bdd4b732d146be1ef8111f06fd4b4f87edf8
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: 941e8774da0e6fdf12c6b3fcc833ca687ae5a42d
   MMKVCore: 6d5cc1bacce539f4c974985dfe646fb65a5d27d2
@@ -2160,8 +2159,8 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: 720c5d4726f869ea38668735da9777ecc851fd89
-  XMTPReactNative: c2b932b71ff9dccebe37e2c8edde38720e8cc270
+  XMTP: fb1d2a6b5f2d69d9f1b615212e6593636e4e12e8
+  XMTPReactNative: 5108b1c7275f494a154e2a277d414c3531a8d3d9
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 283c313cbc1ba9857a692b5901eb740dad922eca

--- a/ios/Wrappers/MessageWrapper.swift
+++ b/ios/Wrappers/MessageWrapper.swift
@@ -77,7 +77,7 @@ struct ContentJson {
 				schema: ReactionSchema(rawValue: reaction["schema"] as? String ?? "")
 			))
 		} else if let reaction = obj["reactionV2"] as? [String: Any] {
-            return ContentJson(type: ContentTypeReactionV2, content: FfiReaction(
+            return ContentJson(type: ContentTypeReactionV2, content: FfiReactionPayload(
 				reference: reaction["reference"] as? String ?? "",
 				// Update if we add referenceInboxId to ../src/lib/types/ContentCodec.ts#L19-L24
                 referenceInboxId: "",

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.4.0"
+  s.dependency "XMTP", "= 4.5.0-dev.a0bb8bd"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end


### PR DESCRIPTION
See passing client tests on RN iOS below:

<img width="403" height="899" alt="image" src="https://github.com/user-attachments/assets/a85f74f8-7e2a-4219-85bf-9f64cf1b401a" />
