### PR TITLE
Update upstream references to libxmtp 1.5.0-rc2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.5.0-rc1"
+  implementation "org.xmtp:android:4.5.0-rc2"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.4.0"
+  implementation "org.xmtp:android:4.5.0-rc1"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
@@ -42,8 +42,8 @@ import org.xmtp.android.library.codecs.getReactionAction
 import org.xmtp.android.library.codecs.getReactionSchema
 import org.xmtp.android.library.codecs.id
 import uniffi.xmtpv3.FfiMultiRemoteAttachment
-import uniffi.xmtpv3.FfiReaction
 import uniffi.xmtpv3.FfiReactionAction
+import uniffi.xmtpv3.FfiReactionPayload
 import uniffi.xmtpv3.FfiReactionSchema
 import uniffi.xmtpv3.decodeMultiRemoteAttachment
 import uniffi.xmtpv3.decodeReaction
@@ -137,7 +137,7 @@ class ContentJson(
             } else if (obj.has("reactionV2")) {
                 val reaction = obj.get("reactionV2").asJsonObject
                 return ContentJson(
-                    ContentTypeReactionV2, FfiReaction(
+                    ContentTypeReactionV2, FfiReactionPayload(
                         reference = reaction.get("reference").asString,
                         action = getReactionV2Action(reaction.get("action").asString.lowercase()),
                         schema = getReactionV2Schema(reaction.get("schema").asString.lowercase()),
@@ -232,7 +232,7 @@ class ContentJson(
             )
 
             ContentTypeReactionV2.id ->  {
-                val reaction: FfiReaction = decodeReaction(encodedContent!!.toByteArray())
+                val reaction: FfiReactionPayload = decodeReaction(encodedContent!!.toByteArray())
                 mapOf(
                     "reaction" to mapOf(
                         "reference" to reaction.reference,

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1736,17 +1736,16 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.5.0-rc1):
+  - XMTP (4.5.0-rc2):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
-    - CSecp256k1 (~> 0.2)
     - SQLCipher (= 4.5.7)
   - XMTPReactNative (4.4.0):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.5.0-rc1)
+    - XMTP (= 4.5.0-rc2)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2156,8 +2155,8 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: f538cad8b8a7e6a1c41d723293507b85afdcd9e3
-  XMTPReactNative: 6e0ac5055f25214d9cf58d506adb188da8ccc181
+  XMTP: 3b928fe6b176783670aaa3c77af1f909c5a6b1c3
+  XMTPReactNative: 6d754e03b452c7090c8d1d3167da30d83b93ae98
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 283c313cbc1ba9857a692b5901eb740dad922eca

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -60,7 +60,6 @@ PODS:
   - hermes-engine (0.76.9):
     - hermes-engine/Pre-built (= 0.76.9)
   - hermes-engine/Pre-built (0.76.9)
-  - LibXMTP (4.4.0)
   - MessagePacker (0.4.7)
   - MMKV (2.2.3):
     - MMKVCore (~> 2.2.3)
@@ -1737,18 +1736,17 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.4.0):
+  - XMTP (4.5.0-rc1):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - CSecp256k1 (~> 0.2)
-    - LibXMTP (= 4.4.0)
     - SQLCipher (= 4.5.7)
   - XMTPReactNative (4.4.0):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.4.0)
+    - XMTP (= 4.5.0-rc1)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1855,7 +1853,6 @@ SPEC REPOS:
     - Connect-Swift
     - CryptoSwift
     - CSecp256k1
-    - LibXMTP
     - MessagePacker
     - MMKV
     - MMKVCore
@@ -2080,7 +2077,6 @@ SPEC CHECKSUMS:
   fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 9e868dc7be781364296d6ee2f56d0c1a9ef0bb11
-  LibXMTP: fe0ac6528cf59308dbecde4f39f241b06cfaf567
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: 941e8774da0e6fdf12c6b3fcc833ca687ae5a42d
   MMKVCore: 6d5cc1bacce539f4c974985dfe646fb65a5d27d2
@@ -2160,8 +2156,8 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: 720c5d4726f869ea38668735da9777ecc851fd89
-  XMTPReactNative: c2b932b71ff9dccebe37e2c8edde38720e8cc270
+  XMTP: f538cad8b8a7e6a1c41d723293507b85afdcd9e3
+  XMTPReactNative: 6e0ac5055f25214d9cf58d506adb188da8ccc181
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 283c313cbc1ba9857a692b5901eb740dad922eca

--- a/ios/Wrappers/KeyPackageStatusWrapper.swift
+++ b/ios/Wrappers/KeyPackageStatusWrapper.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import XMTP
-import LibXMTP
 
 struct KeyPackageStatusWrapper {
 	static func encodeToObj(keyPackageStatus: FfiKeyPackageStatus) throws -> [String: Any] {

--- a/ios/Wrappers/MessageWrapper.swift
+++ b/ios/Wrappers/MessageWrapper.swift
@@ -1,6 +1,5 @@
 import Foundation
 import XMTP
-import LibXMTP
 
 // Wrapper around XMTP.DecodedMessage to allow passing these objects back
 // into react native.
@@ -77,7 +76,7 @@ struct ContentJson {
 				schema: ReactionSchema(rawValue: reaction["schema"] as? String ?? "")
 			))
 		} else if let reaction = obj["reactionV2"] as? [String: Any] {
-            return ContentJson(type: ContentTypeReactionV2, content: FfiReaction(
+            return ContentJson(type: ContentTypeReactionV2, content: FfiReactionPayload(
 				reference: reaction["reference"] as? String ?? "",
 				// Update if we add referenceInboxId to ../src/lib/types/ContentCodec.ts#L19-L24
                 referenceInboxId: "",

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -1,5 +1,4 @@
 import ExpoModulesCore
-import LibXMTP
 import OSLog
 import XMTP
 

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.5.0-rc1"
+  s.dependency "XMTP", "= 4.5.0-rc2"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.4.0"
+  s.dependency "XMTP", "= 4.5.0-rc1"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,17 +72,17 @@ export async function findInboxIdFromIdentity(
 }
 
 export async function deleteLocalDatabase(installationId: InstallationId) {
-  return XMTPModule.deleteLocalDatabase(installationId)
+  return await XMTPModule.deleteLocalDatabase(installationId)
 }
 
 export async function dropLocalDatabaseConnection(
   installationId: InstallationId
 ) {
-  return XMTPModule.dropLocalDatabaseConnection(installationId)
+  return await XMTPModule.dropLocalDatabaseConnection(installationId)
 }
 
 export async function reconnectLocalDatabase(installationId: InstallationId) {
-  return XMTPModule.reconnectLocalDatabase(installationId)
+  return await XMTPModule.reconnectLocalDatabase(installationId)
 }
 
 export async function getInboxState(
@@ -1653,11 +1653,11 @@ export function registerPushToken(pushServer: string, token: string) {
   return XMTPModule.registerPushToken(pushServer, token)
 }
 
-export function subscribePushTopics(
+export async function subscribePushTopics(
   installationId: InstallationId,
   topics: ConversationTopic[]
 ) {
-  return XMTPModule.subscribePushTopics(installationId, topics)
+  return await XMTPModule.subscribePushTopics(installationId, topics)
 }
 
 export async function exportNativeLogs() {

--- a/src/lib/XMTPPush.ts
+++ b/src/lib/XMTPPush.ts
@@ -12,7 +12,7 @@ export class XMTPPush {
     XMTPModule.registerPushToken(server, token)
   }
 
-  subscribe(topics: ConversationTopic[]) {
-    XMTPModule.subscribePushTopics(this.client.installationId, topics)
+  async subscribe(topics: ConversationTopic[]) {
+    return await XMTPModule.subscribePushTopics(this.client.installationId, topics)
   }
 }


### PR DESCRIPTION
### Update Android and iOS XMTP dependencies to 4.5.0-rc2 and convert push and database APIs to asynchronous coroutines and Promises across `XMTPModule` and JS wrappers
- Update Android Gradle dependency to `org.xmtp:android:4.5.0-rc2` in [build.gradle](https://github.com/xmtp/xmtp-react-native/pull/717/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a) and iOS pod to 4.5.0-rc2 in [XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/717/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3) and [Podfile.lock](https://github.com/xmtp/xmtp-react-native/pull/717/files#diff-b2790cc3d555682b207af1ca2fb897ebd2114c01149bf460fd85fc2b1503a687), removing `LibXMTP` imports where unused.
- Convert `expo.modules.xmtpreactnativesdk.XMTPModule` functions `deleteLocalDatabase`, `dropLocalDatabaseConnection`, `getHmacKeys`, `getAllPushTopics`, and `subscribePushTopics` to `AsyncFunction` coroutines and run their bodies in `withContext(Dispatchers.IO)` in [XMTPModule.kt](https://github.com/xmtp/xmtp-react-native/pull/717/files#diff-3d1b8496c4f066a0a1d2f776063d85d49f70545d6a94a57fe91eb6efecd50a48).
- Update Reaction V2 content types from `FfiReaction` to `FfiReactionPayload` in [ContentJson.kt](https://github.com/xmtp/xmtp-react-native/pull/717/files#diff-6070928f30e220b67c437420d2508b3720969bce82ab5433b1b46bb674c54d9e) and [MessageWrapper.swift](https://github.com/xmtp/xmtp-react-native/pull/717/files#diff-438ca0b2f3d9791083caea0ac7d81fc3bae8ab970b69a3053b6c19fd23adfa54).
- Make JS utilities and push API asynchronous: `deleteLocalDatabase`, `dropLocalDatabaseConnection`, `reconnectLocalDatabase`, and `subscribePushTopics` in [src/index.ts](https://github.com/xmtp/xmtp-react-native/pull/717/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80), and `XMTPPush.subscribe` in [src/lib/XMTPPush.ts](https://github.com/xmtp/xmtp-react-native/pull/717/files#diff-1229ced3d54aeae232bd5eeac395b469686ed87683939d413c6705b5f803c258).

#### 📍Where to Start
Start with the coroutine conversions in `expo.modules.xmtpreactnativesdk.XMTPModule` in [XMTPModule.kt](https://github.com/xmtp/xmtp-react-native/pull/717/files#diff-3d1b8496c4f066a0a1d2f776063d85d49f70545d6a94a57fe91eb6efecd50a48), then follow the async surface changes in [src/index.ts](https://github.com/xmtp/xmtp-react-native/pull/717/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) and [src/lib/XMTPPush.ts](https://github.com/xmtp/xmtp-react-native/pull/717/files#diff-1229ced3d54aeae232bd5eeac395b469686ed87683939d413c6705b5f803c258).

----

_[Macroscope](https://app.macroscope.com) summarized f7f3500._