### PR TITLE
Update upstream referernces to libxmtp 1.5.0-rc3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.5.0-rc2"
+  implementation "org.xmtp:android:4.5.0-rc3"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -61,9 +61,9 @@ PODS:
     - hermes-engine/Pre-built (= 0.76.9)
   - hermes-engine/Pre-built (0.76.9)
   - MessagePacker (0.4.7)
-  - MMKV (2.2.3):
-    - MMKVCore (~> 2.2.3)
-  - MMKVCore (2.2.3)
+  - MMKV (2.2.4):
+    - MMKVCore (~> 2.2.4)
+  - MMKVCore (2.2.4)
   - OpenSSL-Universal (1.1.2200)
   - RCT-Folly (2024.10.14.00):
     - boost
@@ -1736,7 +1736,7 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.5.0-rc2):
+  - XMTP (4.5.0-rc3):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - SQLCipher (= 4.5.7)
@@ -1745,7 +1745,7 @@ PODS:
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.5.0-rc2)
+    - XMTP (= 4.5.0-rc3)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2077,8 +2077,8 @@ SPEC CHECKSUMS:
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 9e868dc7be781364296d6ee2f56d0c1a9ef0bb11
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
-  MMKV: 941e8774da0e6fdf12c6b3fcc833ca687ae5a42d
-  MMKVCore: 6d5cc1bacce539f4c974985dfe646fb65a5d27d2
+  MMKV: 1a8e7dbce7f9cad02c52e1b1091d07bd843aefaf
+  MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
   OpenSSL-Universal: 6e1ae0555546e604dbc632a2b9a24a9c46c41ef6
   RCT-Folly: ea9d9256ba7f9322ef911169a9f696e5857b9e17
   RCTDeprecation: ebe712bb05077934b16c6bf25228bdec34b64f83
@@ -2155,8 +2155,8 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: 3b928fe6b176783670aaa3c77af1f909c5a6b1c3
-  XMTPReactNative: 6d754e03b452c7090c8d1d3167da30d83b93ae98
+  XMTP: a1a9ff553a2af81a5f10ba75f0ac7424c17c1813
+  XMTPReactNative: 8ebb40f3f6caf92bb3250d20090794b94fc03c58
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 283c313cbc1ba9857a692b5901eb740dad922eca

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.5.0-rc2"
+  s.dependency "XMTP", "= 4.5.0-rc3"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/react-native-sdk",
-  "version": "4.4.0",
+  "version": "4.5.0-rc3",
   "description": "Wraps for native xmtp sdks for react native",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
### Update Android and iOS build dependencies to XMTP 4.5.0-rc3 to align upstream references with libxmtp 1.5.0-rc3
This change updates mobile dependency pins and the package version to reference XMTP 4.5.0-rc3 across Android, iOS, and JavaScript packaging.

- Update Android dependency `org.xmtp:android` to `4.5.0-rc3` in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/718/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a)
- Pin CocoaPods `XMTP` to `= 4.5.0-rc3` in [ios/XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/718/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3)
- Refresh lockfile with `XMTP 4.5.0-rc3` and `MMKV/MMKVCore 2.2.4` in [example/ios/Podfile.lock](https://github.com/xmtp/xmtp-react-native/pull/718/files#diff-b2790cc3d555682b207af1ca2fb897ebd2114c01149bf460fd85fc2b1503a687)
- Bump package version to `4.5.0-rc3` in [package.json](https://github.com/xmtp/xmtp-react-native/pull/718/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)

#### 📍Where to Start
Start with the dependency version change in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/718/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a), then verify the CocoaPods pin in [ios/XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/718/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3) and the corresponding lockfile updates in [example/ios/Podfile.lock](https://github.com/xmtp/xmtp-react-native/pull/718/files#diff-b2790cc3d555682b207af1ca2fb897ebd2114c01149bf460fd85fc2b1503a687).

----

_[Macroscope](https://app.macroscope.com) summarized 46e8b33._