### PR TITLE
Updating package.json since xmtp rn-sdk has an unpublished 5.0.0 entry already

### DIFF
--- a/.changeset/loud-eels-help.md
+++ b/.changeset/loud-eels-help.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+Updating package.json since xmtp rn-sdk has an unpublished 5.0.0 entry already

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/react-native-sdk",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Wraps for native xmtp sdks for react native",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Looks like we accidentally published a 5.0.0 last May, that was unpublished, so this version needs to be released as 5.0.1 to npm. 

- see previous PR that published 5.0.0: https://github.com/xmtp/xmtp-react-native/pull/664/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R3
- see npm docs policy on unpublished versions: https://docs.npmjs.com/policies/unpublish?utm_source=chatgpt.com#considerations