### PR TITLE
Update to libxmtp 1.5.3

### DIFF
--- a/.changeset/two-moles-kneel.md
+++ b/.changeset/two-moles-kneel.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+Fix initial group membership validation

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.5.0"
+  implementation "org.xmtp:android:4.5.3"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1736,16 +1736,16 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.5.0):
+  - XMTP (4.5.3):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (4.4.0):
+  - XMTPReactNative (5.0.1):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.5.0)
+    - XMTP (= 4.5.3)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2155,8 +2155,8 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: cdb24ebd474cb65cce7b337f6960f028abfa7d60
-  XMTPReactNative: c4210319adaf30ee0ba9acbd29014efde27f33b4
+  XMTP: b45139ed47c6ac358dfff6d7faec212b6faa026a
+  XMTPReactNative: 940560ad83a0bd6b4a14458d475f734403678b03
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 283c313cbc1ba9857a692b5901eb740dad922eca

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.5.0"
+  s.dependency "XMTP", "= 4.5.3"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end


### PR DESCRIPTION
### Update Android and iOS XMTP client dependencies to version 4.5.3 to match the libxmtp 1.5.3 update
This change updates the mobile XMTP dependencies to version 4.5.3 across Android and iOS build configurations.

- Update the Gradle implementation dependency `org.xmtp:android` from `4.5.0` to `4.5.3` in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/723/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a)
- Update the CocoaPods dependency `XMTP` from `4.5.0` to `4.5.3` with an exact version in [ios/XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/723/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3)

#### 📍Where to Start
Start by verifying the dependency bump in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/723/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a), then review the podspec change in [ios/XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/723/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3).



#### Changes since #723 opened

- Updated XMTP library dependencies and regenerated iOS Podfile lockfile [3ebc2ed]
- Updated `libxmtp` dependency to version 1.5.3 and prepared patch release for `@xmtp/react-native-sdk` [5586719]
----

_[Macroscope](https://app.macroscope.com) summarized 5586719._