### PR TITLE
Add creationSignatureKind

### DIFF
--- a/.changeset/thin-terms-dance.md
+++ b/.changeset/thin-terms-dance.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-native-sdk": patch
+---
+
+Add creationSignatureKind field to InboxState 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.5.3"
+  implementation "org.xmtp:android:4.5.5"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/InboxStateWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/InboxStateWrapper.kt
@@ -3,23 +3,39 @@ package expo.modules.xmtpreactnativesdk.wrappers
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import org.xmtp.android.library.libxmtp.InboxState
+import org.xmtp.android.library.libxmtp.SignatureKind
 
 class InboxStateWrapper {
     companion object {
         val gson: Gson = GsonBuilder().create()
+
+        private fun signatureKindToString(kind: SignatureKind?): String {
+            return when (kind) {
+                SignatureKind.ERC191 -> "ERC191"
+                SignatureKind.ERC1271 -> "ERC1271"
+                SignatureKind.INSTALLATION_KEY -> "INSTALLATION_KEY"
+                SignatureKind.LEGACY_DELEGATED -> "LEGACY_DELEGATED"
+                SignatureKind.P256 -> "P256"
+                null -> ""
+            }
+        }
         private fun encodeToObj(inboxState: InboxState): Map<String, Any> {
             return mapOf(
-                "inboxId" to inboxState.inboxId,
-                "identities" to inboxState.identities.map { PublicIdentityWrapper.encode(it) },
-                "installations" to inboxState.installations.map {
-                    gson.toJson(
-                        mapOf(
-                            "id" to it.installationId,
-                            "createdAt" to it.createdAt?.time
-                        )
-                    )
-                },
-                "recoveryIdentity" to PublicIdentityWrapper.encode(inboxState.recoveryPublicIdentity)
+                    "inboxId" to inboxState.inboxId,
+                    "identities" to inboxState.identities.map { PublicIdentityWrapper.encode(it) },
+                    "installations" to
+                            inboxState.installations.map {
+                                gson.toJson(
+                                        mapOf(
+                                                "id" to it.installationId,
+                                                "createdAt" to it.createdAt?.time
+                                        )
+                                )
+                            },
+                    "recoveryIdentity" to
+                            PublicIdentityWrapper.encode(inboxState.recoveryPublicIdentity),
+                    "creationSignatureKind" to
+                            signatureKindToString(inboxState.creationSignatureKind)
             )
         }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1736,16 +1736,16 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.5.3):
+  - XMTP (4.5.5):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (5.0.1):
+  - XMTPReactNative (5.0.3):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.5.3)
+    - XMTP (= 4.5.5)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2155,8 +2155,8 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: b45139ed47c6ac358dfff6d7faec212b6faa026a
-  XMTPReactNative: 940560ad83a0bd6b4a14458d475f734403678b03
+  XMTP: dc1eede674b3a4bd05d5ceee19ee002c95961f0f
+  XMTPReactNative: 421dfe638ba0c587a03fb5dd420512242b93ac1f
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 283c313cbc1ba9857a692b5901eb740dad922eca

--- a/ios/Wrappers/InboxStateWrapper.swift
+++ b/ios/Wrappers/InboxStateWrapper.swift
@@ -10,45 +10,63 @@ import XMTP
 
 // Wrapper around XMTP.InboxState to allow passing these objects back into react native.
 struct InboxStateWrapper {
-	static func encodeToObj(_ inboxState: XMTP.InboxState) throws -> [String:
-		Any]
-	{
-		return [
-			"inboxId": inboxState.inboxId,
-			"identities": try inboxState.identities.map {
-				try PublicIdentityWrapper.encode(publicIdentity: $0)
-			},
-			"installations": try inboxState.installations.map {
-				try Installation.encodeInstallation(installation: $0)
-			},
-			"recoveryIdentity": try PublicIdentityWrapper.encode(
-				publicIdentity: inboxState.recoveryIdentity),
-		]
-	}
+    static func signatureKindToString(_ kind: FfiSignatureKind?) -> String {
+        guard let kind = kind else { return "" }
+        switch kind {
+        case .erc191:
+            return "ERC191"
+        case .erc1271:
+            return "ERC1271"
+        case .installationKey:
+            return "INSTALLATION_KEY"
+        case .legacyDelegated:
+            return "LEGACY_DELEGATED"
+        case .p256:
+            return "P256"
+        }
+    }
 
-	static func encode(_ inboxState: XMTP.InboxState) throws -> String {
-		let obj = try encodeToObj(inboxState)
-		let data = try JSONSerialization.data(withJSONObject: obj)
-		guard let result = String(data: data, encoding: .utf8) else {
-			throw WrapperError.encodeError("could not encode inboxState")
-		}
-		return result
-	}
+    static func encodeToObj(_ inboxState: XMTP.InboxState) throws -> [String:
+        Any]
+    {
+        return [
+            "inboxId": inboxState.inboxId,
+            "identities": try inboxState.identities.map {
+                try PublicIdentityWrapper.encode(publicIdentity: $0)
+            },
+            "installations": try inboxState.installations.map {
+                try Installation.encodeInstallation(installation: $0)
+            },
+            "recoveryIdentity": try PublicIdentityWrapper.encode(
+                publicIdentity: inboxState.recoveryIdentity),
+            "creationSignatureKind": signatureKindToString(
+                inboxState.creationSignatureKind),
+        ]
+    }
+
+    static func encode(_ inboxState: XMTP.InboxState) throws -> String {
+        let obj = try encodeToObj(inboxState)
+        let data = try JSONSerialization.data(withJSONObject: obj)
+        guard let result = String(data: data, encoding: .utf8) else {
+            throw WrapperError.encodeError("could not encode inboxState")
+        }
+        return result
+    }
 }
 
 struct Installation {
-	static func encodeInstallation(installation: XMTP.Installation) throws
-		-> String
-	{
-		let obj: [String: Any] = [
-			"id": installation.id,
-			"createdAt": installation.createdAt?.timeIntervalSince1970
-				?? NSNull(),
-		]
-		let data = try JSONSerialization.data(withJSONObject: obj)
-		guard let result = String(data: data, encoding: .utf8) else {
-			throw WrapperError.encodeError("could not encode inboxState")
-		}
-		return result
-	}
+    static func encodeInstallation(installation: XMTP.Installation) throws
+        -> String
+    {
+        let obj: [String: Any] = [
+            "id": installation.id,
+            "createdAt": installation.createdAt?.timeIntervalSince1970
+                ?? NSNull(),
+        ]
+        let data = try JSONSerialization.data(withJSONObject: obj)
+        guard let result = String(data: data, encoding: .utf8) else {
+            throw WrapperError.encodeError("could not encode inboxState")
+        }
+        return result
+    }
 }

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.5.3"
+  s.dependency "XMTP", "= 4.5.5"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/react-native-sdk",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Wraps for native xmtp sdks for react native",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/lib/InboxState.ts
+++ b/src/lib/InboxState.ts
@@ -1,22 +1,32 @@
 import { InboxId } from './Client'
 import { PublicIdentity } from './PublicIdentity'
 
+type SignatureKind =
+  | 'ERC191'
+  | 'ERC1271'
+  | 'INSTALLATION_KEY'
+  | 'LEGACY_DELEGATED'
+  | 'P256'
+
 export class InboxState {
   inboxId: InboxId
   identities: PublicIdentity[]
   installations: Installation[]
   recoveryIdentity: PublicIdentity
+  creationSignatureKind?: SignatureKind
 
   constructor(
     inboxId: InboxId,
     identities: PublicIdentity[],
     installations: Installation[],
-    recoveryIdentity: PublicIdentity
+    recoveryIdentity: PublicIdentity,
+    creationSignatureKind?: SignatureKind
   ) {
     this.inboxId = inboxId
     this.identities = identities
     this.installations = installations
     this.recoveryIdentity = recoveryIdentity
+    this.creationSignatureKind = creationSignatureKind
   }
 
   static from(json: string): InboxState {
@@ -29,7 +39,10 @@ export class InboxState {
       entry.installations.map((inst: string) => {
         return Installation.from(inst)
       }),
-      PublicIdentity.from(entry.recoveryIdentity)
+      PublicIdentity.from(entry.recoveryIdentity),
+      entry.creationSignatureKind?.length
+        ? entry.creationSignatureKind
+        : undefined
     )
   }
 }


### PR DESCRIPTION
### TL;DR

Upgraded XMTP SDK to version 4.5.5 and added support for signature kind information in InboxState.

### What changed?

- Updated XMTP SDK from version 4.5.3 to 4.5.5 in both Android and iOS
- Added `creationSignatureKind` property to the `InboxState` class
- Implemented helper functions to convert signature kinds to strings in both platforms
- Bumped package version from 5.0.2 to 5.0.3

### How to test?

1. Install the updated package
2. Verify that the `creationSignatureKind` property is available on `InboxState` objects
3. Ensure that existing functionality continues to work with the updated XMTP SDK

### Why make this change?

This update exposes the signature kind information from the XMTP SDK, which provides additional context about how an inbox was created. This information can be useful for applications that need to understand the authentication method used for inbox creation. The SDK upgrade also includes any bug fixes or improvements from the XMTP native SDKs.