### PR TITLE
Upgrade to libxmtp 1.5.6

### DIFF
--- a/.changeset/six-pots-change.md
+++ b/.changeset/six-pots-change.md
@@ -1,0 +1,5 @@
+---
+'@xmtp/react-native-sdk': patch
+---
+
+Fix an issue where the creationSignatureKind was not being set in some cases

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.5.5"
+  implementation "org.xmtp:android:4.5.6"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.5.5"
+  s.dependency "XMTP", "= 4.5.6"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end


### PR DESCRIPTION
### TL;DR

Upgraded XMTP SDK dependencies to version 4.5.6 to fix a signature issue.

### What changed?

- Added a changeset file documenting the fix for an issue where `creationSignatureKind` was not being set in some cases
- Updated the Android dependency for XMTP from version 4.5.5 to 4.5.6 in `build.gradle`
- Updated the iOS dependency for XMTP from version 4.5.5 to 4.5.6 in `XMTPReactNative.podspec`

### How to test?

1. Install the updated dependencies
2. Test client creation flows to verify that the `creationSignatureKind` is properly set
3. Verify that authentication and message signing work correctly

### Why make this change?

This update fixes a bug where the `creationSignatureKind` parameter was not being properly set in certain scenarios, which could potentially cause authentication issues. The fix ensures consistent behavior during client creation and authentication processes.