### PR TITLE
1.6 Release Candidate 1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,10 @@ jobs:
         if: steps.release-type.outputs.type == 'dev'
         run: |
           CURRENT_VERSION="${{ steps.current-version.outputs.current_version }}"
-          if [[ ! $CURRENT_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+-dev$ ]]; then
-            echo "Error: For dev releases, package version must be in format MAJOR.MINOR.PATCH-dev"
+          if [[ ! $CURRENT_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+-(dev|rc[0-9]+)$ ]]; then
+            echo "Error: For dev releases, package version must be in format MAJOR.MINOR.PATCH-dev or MAJOR.MINOR.PATCH-rc{number}"
             echo "Current version is $CURRENT_VERSION"
-            echo "Please update package.json version to follow the dev format (e.g., 1.0.0-dev)"
+            echo "Please update package.json version to follow the dev format (e.g., 1.0.0-dev or 1.0.0-rc1)"
             exit 1
           fi
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.6.0-dev.606cdda"
+  implementation "org.xmtp:android:4.6.1-rc1"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"
@@ -107,7 +107,7 @@ dependencies {
   // implementation 'io.grpc:grpc-protobuf-lite:1.62.2'
   // implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0'
   // implementation 'org.web3j:crypto:4.9.4'
-  // implementation "net.java.dev.jna:jna:5.14.0@aar"
+  // implementation "net.java.dev.jna:jna:5.17.0@aar"
   // api 'com.google.protobuf:protobuf-kotlin-lite:3.22.3'
   // api 'org.xmtp:proto-kotlin:3.72.4'
 }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/AuthParamsWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/AuthParamsWrapper.kt
@@ -1,7 +1,11 @@
 package expo.modules.xmtpreactnativesdk.wrappers
 
+import com.google.gson.JsonArray
 import com.google.gson.JsonParser
+import org.xmtp.android.library.ForkRecoveryOptions
+import org.xmtp.android.library.ForkRecoveryPolicy
 import org.xmtp.android.library.SignerType
+import java.math.BigInteger
 
 class AuthParamsWrapper(
     val environment: String,
@@ -11,10 +15,71 @@ class AuthParamsWrapper(
     val deviceSyncEnabled: Boolean,
     val debugEventsEnabled: Boolean,
     val appVersion: String?,
+    val gatewayHost: String?,
+    val forkRecoveryOptions: ForkRecoveryOptions?
 ) {
     companion object {
+        private fun createForkRecoveryOptions(
+            enableRecoveryRequestsString: String?,
+            groupsToRequestRecovery: JsonArray?,
+            disableRecoveryResponse: Boolean?,
+            workerIntervalNs: BigInteger?
+        ): ForkRecoveryOptions? {
+            // If none of the fork recovery options are provided, return null
+            if (enableRecoveryRequestsString == null && 
+                groupsToRequestRecovery == null && 
+                disableRecoveryResponse == null && 
+                workerIntervalNs == null) {
+                return null
+            }
+
+            // Convert groupsToRequestRecovery JsonArray to List<String>
+            val groupsList = groupsToRequestRecovery?.map { it.asString } ?: emptyList()
+
+            //convert BigInt to ULong safely
+            val workerIntervalNsLong = workerIntervalNs?.let { bigInt ->
+                try {
+                    if (bigInt <= BigInteger.valueOf(Long.MAX_VALUE)) {
+                        bigInt.toLong().toULong()
+                    } else {
+                        ULong.MAX_VALUE // Clamp to max value if too large
+                    }
+                } catch (e: Exception) {
+                    null
+                }
+            }
+
+            return ForkRecoveryOptions(
+                enableRecoveryRequests = convertToForkRecoveryPolicy(enableRecoveryRequestsString),
+                groupsToRequestRecovery = groupsList,
+                disableRecoveryResponses = disableRecoveryResponse,
+                workerIntervalNs = workerIntervalNsLong
+            )
+        }
+
+        private fun convertToForkRecoveryPolicy(enableRecoveryRequestsString: String?): ForkRecoveryPolicy {
+            return when (enableRecoveryRequestsString) {
+                "none" -> ForkRecoveryPolicy.None
+                "all" -> ForkRecoveryPolicy.All
+                "groups" -> ForkRecoveryPolicy.AllowlistedGroups
+                else -> ForkRecoveryPolicy.None
+            }
+        }
+
         fun authParamsFromJson(authParams: String): AuthParamsWrapper {
             val jsonOptions = JsonParser.parseString(authParams).asJsonObject
+            val enableRecoveryRequestsString = if (jsonOptions.has("enableRecoveryRequests")) jsonOptions.get("enableRecoveryRequests").asString else null
+            val groupsToRequestRecovery = if (jsonOptions.has("groupsToRequestRecovery")) jsonOptions.get("groupsToRequestRecovery").asJsonArray else null
+            val disableRecoveryResponse = if (jsonOptions.has("disableRecoveryResponses")) jsonOptions.get("disableRecoveryResponses").asBoolean else null
+            val workerIntervalNs = if (jsonOptions.has("workerIntervalNs")) jsonOptions.get("workerIntervalNs").asBigInteger else null
+
+            val forkRecoveryOptions = createForkRecoveryOptions(
+                enableRecoveryRequestsString,
+                groupsToRequestRecovery,
+                disableRecoveryResponse,
+                workerIntervalNs
+            )
+
             return AuthParamsWrapper(
                 jsonOptions.get("environment").asString,
                 if (jsonOptions.has("dbDirectory")) jsonOptions.get("dbDirectory").asString else null,
@@ -23,7 +88,9 @@ class AuthParamsWrapper(
                 if (jsonOptions.has("deviceSyncEnabled")) jsonOptions.get("deviceSyncEnabled").asBoolean else true,
                 if (jsonOptions.has("debugEventsEnabled")) jsonOptions.get("debugEventsEnabled").asBoolean else false,
                 if (jsonOptions.has("appVersion")) jsonOptions.get("appVersion").asString else null,
-                )
+                if (jsonOptions.has("gatewayHost")) jsonOptions.get("gatewayHost").asString else null,
+                forkRecoveryOptions
+            )
         }
     }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
   - EXImageLoader (5.0.0):
     - ExpoModulesCore
     - React-Core
-  - Expo (52.0.44):
+  - Expo (52.0.47):
     - ExpoModulesCore
   - ExpoAsset (11.0.5):
     - ExpoModulesCore
@@ -51,7 +51,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ExpoSplashScreen (0.29.22):
+  - ExpoSplashScreen (0.29.24):
+    - ExpoModulesCore
+  - ExpoSystemUI (4.0.9):
     - ExpoModulesCore
   - fast_float (6.1.4)
   - FBLazyVector (0.76.9)
@@ -64,7 +66,7 @@ PODS:
   - MMKV (2.2.4):
     - MMKVCore (~> 2.2.4)
   - MMKVCore (2.2.4)
-  - OpenSSL-Universal (1.1.2200)
+  - OpenSSL-Universal (3.3.3001)
   - RCT-Folly (2024.10.14.00):
     - boost
     - DoubleConversion
@@ -1375,7 +1377,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-netinfo (9.3.7):
+  - react-native-netinfo (11.4.1):
     - React-Core
   - react-native-quick-base64 (2.1.2):
     - DoubleConversion
@@ -1423,12 +1425,31 @@ PODS:
     - Yoga
   - react-native-randombytes (3.6.1):
     - React-Core
-  - react-native-safe-area-context (5.3.0):
+  - react-native-safe-area-context (4.12.0):
     - React-Core
   - react-native-sqlite-storage (6.0.1):
     - React-Core
-  - react-native-webview (11.26.0):
+  - react-native-webview (13.12.5):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.10.14.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - React-nativeconfig (0.76.9)
   - React-NativeModulesApple (0.76.9):
     - glog
@@ -1701,11 +1722,11 @@ PODS:
     - React-logger
     - React-perflogger
     - React-utils (= 0.76.9)
-  - RNCAsyncStorage (1.17.11):
+  - RNCAsyncStorage (1.23.1):
     - React-Core
   - RNFS (2.20.0):
     - React-Core
-  - RNScreens (4.10.0):
+  - RNScreens (4.4.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1727,7 +1748,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSVG (15.11.2):
+  - RNSVG (15.8.0):
     - React-Core
   - SocketRocket (0.7.1)
   - SQLCipher (4.5.7):
@@ -1736,16 +1757,16 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.6.0-dev.fcce662):
+  - XMTP (4.6.1-rc3):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (5.0.5):
+  - XMTPReactNative (5.0.6):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.6.0-dev.fcce662)
+    - XMTP (= 4.6.1-rc3)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1764,12 +1785,12 @@ DEPENDENCIES:
   - ExpoKeepAwake (from `../node_modules/expo-keep-awake/ios`)
   - ExpoModulesCore (from `../node_modules/expo-modules-core`)
   - ExpoSplashScreen (from `../node_modules/expo-splash-screen/ios`)
+  - ExpoSystemUI (from `../node_modules/expo-system-ui/ios`)
   - fast_float (from `../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
-  - OpenSSL-Universal (= 1.1.2200)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
@@ -1892,6 +1913,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-modules-core"
   ExpoSplashScreen:
     :path: "../node_modules/expo-splash-screen/ios"
+  ExpoSystemUI:
+    :path: "../node_modules/expo-system-ui/ios"
   fast_float:
     :podspec: "../node_modules/react-native/third-party-podspecs/fast_float.podspec"
   FBLazyVector:
@@ -2060,7 +2083,7 @@ SPEC CHECKSUMS:
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   EXConstants: fcfc75800824ac2d5c592b5bc74130bad17b146b
   EXImageLoader: e5da974e25b13585c196b658a440720c075482d5
-  Expo: 75e002fc29a18a72aa3db967b41b29c2b206875d
+  Expo: 1687edb10c76b0c0f135306d6ae245379f50ed54
   ExpoAsset: 48386d40d53a8c1738929b3ed509bcad595b5516
   ExpoClipboard: 44fd1c8959ee8f6175d059dc011b154c9709a969
   ExpoCrypto: e97e864c8d7b9ce4a000bca45dddb93544a1b2b4
@@ -2070,7 +2093,8 @@ SPEC CHECKSUMS:
   ExpoImagePicker: 24e5ba8da111f74519b1e6dc556e0b438b2b8464
   ExpoKeepAwake: b0171a73665bfcefcfcc311742a72a956e6aa680
   ExpoModulesCore: 725faec070d590810d2ea5983d9f78f7cf6a38ec
-  ExpoSplashScreen: cb4e3d3ee646ed59810f7776cca0ae5c03ab4285
+  ExpoSplashScreen: 399ee9f85b6c8a61b965e13a1ecff8384db591c2
+  ExpoSystemUI: b82a45cf0f6a4fa18d07c46deba8725dd27688b4
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 7605ea4810e0e10ae4815292433c09bf4324ba45
   fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
@@ -2079,7 +2103,7 @@ SPEC CHECKSUMS:
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: 1a8e7dbce7f9cad02c52e1b1091d07bd843aefaf
   MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
-  OpenSSL-Universal: 6e1ae0555546e604dbc632a2b9a24a9c46c41ef6
+  OpenSSL-Universal: 6082b0bf950e5636fe0d78def171184e2b3899c2
   RCT-Folly: ea9d9256ba7f9322ef911169a9f696e5857b9e17
   RCTDeprecation: ebe712bb05077934b16c6bf25228bdec34b64f83
   RCTRequired: ca91e5dd26b64f577b528044c962baf171c6b716
@@ -2114,13 +2138,13 @@ SPEC CHECKSUMS:
   react-native-encrypted-storage: 569d114e329b1c2c2d9f8c84bcdbe4478dda2258
   react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
   react-native-mmkv: f0574e88f254d13d1a87cf6d38c36bc5d3910d49
-  react-native-netinfo: be701059f57093572e5ba08cba14483d334b425d
+  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-quick-base64: 5565249122493bef017004646d73f918e8c2dfb0
   react-native-quick-crypto: c168ffba24470d8edfd03961d9492638431b9869
   react-native-randombytes: 3c8f3e89d12487fd03a2f966c288d495415fc116
-  react-native-safe-area-context: fdb0a66feac038cb6eb1edafcf2ccee2b5cf0284
+  react-native-safe-area-context: 8b8404e70b0cbf2a56428a17017c14c1dcc16448
   react-native-sqlite-storage: 0c84826214baaa498796c7e46a5ccc9a82e114ed
-  react-native-webview: 5bb1454f1eb43e0bad229bb428a378d6b865a0ad
+  react-native-webview: 69a5462ca94921ff695e1b52b12fffe62af7d312
   React-nativeconfig: 8efdb1ef1e9158c77098a93085438f7e7b463678
   React-NativeModulesApple: cebca2e5320a3d66e123cade23bd90a167ffce5e
   React-perflogger: 72e653eb3aba9122f9e57cf012d22d2486f33358
@@ -2148,17 +2172,17 @@ SPEC CHECKSUMS:
   React-utils: ed818f19ab445000d6b5c4efa9d462449326cc9f
   ReactCodegen: f853a20cc9125c5521c8766b4b49375fec20648b
   ReactCommon: 300d8d9c5cb1a6cd79a67cf5d8f91e4d477195f9
-  RNCAsyncStorage: 357676e1dc19095208c80d4271066c407cd02ed1
+  RNCAsyncStorage: aa75595c1aefa18f868452091fa0c411a516ce11
   RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
-  RNScreens: 5cac36d8f7b3d92fb4304abcb44c5de336413df8
-  RNSVG: a07e14363aa208062c6483bad24a438d5986d490
+  RNScreens: 295d9c0aaeb7f680d03d7e9b476569a4959aae89
+  RNSVG: 8542aa11770b27563714bbd8494a8436385fc85f
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: 7c3440c4cc70b2bb8d8e581ece48db6b863ea514
-  XMTPReactNative: c433215e0fc1b03f688992ffbbeaed5ddf8051ee
+  XMTP: d9e99e75df20472dd4845f5b9f0476e4748d1fd6
+  XMTPReactNative: ae7fe2223f35aae19235a1c792f3035f8ff70cb9
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
-PODFILE CHECKSUM: 283c313cbc1ba9857a692b5901eb740dad922eca
+PODFILE CHECKSUM: 5b1b93f724b9cde6043d1824960f7bfd9a7973cd
 
 COCOAPODS: 1.16.2

--- a/example/src/HomeScreen.tsx
+++ b/example/src/HomeScreen.tsx
@@ -222,6 +222,27 @@ export default function HomeScreen() {
                   <Text>Copy</Text>
                 </TouchableOpacity>
               </View>
+              <Text style={{ fontSize: 14, marginTop: 8 }}>Inbox ID</Text>
+              <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                <Text style={{ fontSize: 12, fontWeight: 'bold', flex: 1 }}>
+                  {client?.inboxId}
+                </Text>
+                <TouchableOpacity
+                  onPress={async () => {
+                    if (client?.inboxId) {
+                      await Clipboard.setStringAsync(client.inboxId)
+                    }
+                  }}
+                  style={{
+                    padding: 8,
+                    backgroundColor: '#ddd',
+                    borderRadius: 4,
+                    marginLeft: 8,
+                  }}
+                >
+                  <Text>Copy</Text>
+                </TouchableOpacity>
+              </View>
             </View>
           }
         />

--- a/example/src/LaunchScreen.tsx
+++ b/example/src/LaunchScreen.tsx
@@ -264,6 +264,10 @@ export default function LaunchScreen(
                   codecs: supportedCodecs,
                   preAuthenticateToInboxCallback,
                   dbEncryptionKey,
+                  forkRecoveryOptions: {
+                    enableRecoveryRequests: 'all',
+                    workerIntervalNs: 10_000_000_000,
+                  },
                 })
               )
             })().catch(console.error) // Don't forget error handling

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.6.0-dev.fcce662"
+  s.dependency "XMTP", "= 4.6.1-rc3"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/react-native-sdk",
-  "version": "5.0.6",
+  "version": "5.1.0-rc1",
   "description": "Wraps for native xmtp sdks for react native",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { ArchiveMetadata } from './lib/ArchiveOptions'
 import {
   Address,
   Client,
+  ForkRecoveryOptions,
   InboxId,
   InstallationId,
   SignatureType,
@@ -128,7 +129,9 @@ export async function createRandom(
   customLocalHost?: string | undefined,
   deviceSyncEnabled?: boolean | undefined,
   debugEventsEnabled?: boolean | undefined,
-  appVersion?: string | undefined
+  appVersion?: string | undefined,
+  gatewayHost?: string | undefined,
+  forkRecoveryOptions?: ForkRecoveryOptions | undefined
 ): Promise<string> {
   const authParams: AuthParams = {
     environment,
@@ -138,6 +141,11 @@ export async function createRandom(
     deviceSyncEnabled,
     debugEventsEnabled,
     appVersion,
+    gatewayHost,
+    enableRecoveryRequests: forkRecoveryOptions?.enableRecoveryRequests,
+    groupsToRequestRecovery: forkRecoveryOptions?.groupsToRequestRecovery,
+    disableRecoveryResponses: forkRecoveryOptions?.disableRecoveryResponses,
+    workerIntervalNs: forkRecoveryOptions?.workerIntervalNs,
   }
   return await XMTPModule.createRandom(
     hasPreAuthenticateToInboxCallback,
@@ -159,7 +167,9 @@ export async function create(
   customLocalHost?: string | undefined,
   deviceSyncEnabled?: boolean | undefined,
   debugEventsEnabled?: boolean | undefined,
-  appVersion?: string | undefined
+  appVersion?: string | undefined,
+  gatewayHost?: string | undefined,
+  forkRecoveryOptions?: ForkRecoveryOptions | undefined
 ): Promise<string> {
   const authParams: AuthParams = {
     environment,
@@ -169,6 +179,11 @@ export async function create(
     deviceSyncEnabled,
     debugEventsEnabled,
     appVersion,
+    gatewayHost,
+    enableRecoveryRequests: forkRecoveryOptions?.enableRecoveryRequests,
+    groupsToRequestRecovery: forkRecoveryOptions?.groupsToRequestRecovery,
+    disableRecoveryResponses: forkRecoveryOptions?.disableRecoveryResponses,
+    workerIntervalNs: forkRecoveryOptions?.workerIntervalNs,
   }
   const signerParams: SignerParams = {
     signerType,
@@ -194,7 +209,9 @@ export async function build(
   customLocalHost?: string | undefined,
   deviceSyncEnabled?: boolean | undefined,
   debugEventsEnabled?: boolean | undefined,
-  appVersion?: string | undefined
+  appVersion?: string | undefined,
+  gatewayHost?: string | undefined,
+  forkRecoveryOptions?: ForkRecoveryOptions | undefined
 ): Promise<string> {
   const authParams: AuthParams = {
     environment,
@@ -204,6 +221,11 @@ export async function build(
     deviceSyncEnabled,
     debugEventsEnabled,
     appVersion,
+    gatewayHost,
+    enableRecoveryRequests: forkRecoveryOptions?.enableRecoveryRequests,
+    groupsToRequestRecovery: forkRecoveryOptions?.groupsToRequestRecovery,
+    disableRecoveryResponses: forkRecoveryOptions?.disableRecoveryResponses,
+    workerIntervalNs: forkRecoveryOptions?.workerIntervalNs,
   }
   return await XMTPModule.build(
     JSON.stringify(identity),
@@ -222,7 +244,9 @@ export async function ffiCreateClient(
   customLocalHost?: string | undefined,
   deviceSyncEnabled?: boolean | undefined,
   debugEventsEnabled?: boolean | undefined,
-  appVersion?: string | undefined
+  appVersion?: string | undefined,
+  gatewayHost?: string | undefined,
+  forkRecoveryOptions?: ForkRecoveryOptions | undefined
 ): Promise<string> {
   const authParams: AuthParams = {
     environment,
@@ -232,6 +256,11 @@ export async function ffiCreateClient(
     deviceSyncEnabled,
     debugEventsEnabled,
     appVersion,
+    gatewayHost,
+    enableRecoveryRequests: forkRecoveryOptions?.enableRecoveryRequests,
+    groupsToRequestRecovery: forkRecoveryOptions?.groupsToRequestRecovery,
+    disableRecoveryResponses: forkRecoveryOptions?.disableRecoveryResponses,
+    workerIntervalNs: forkRecoveryOptions?.workerIntervalNs,
   }
   return await XMTPModule.ffiCreateClient(
     JSON.stringify(identity),
@@ -918,7 +947,8 @@ export async function sendWithContentType<T>(
   installationId: InboxId,
   conversationId: ConversationId,
   content: T,
-  codec: ContentCodec<T>
+  codec: ContentCodec<T>,
+  shouldPush?: boolean
 ): Promise<MessageId> {
   if ('contentKey' in codec) {
     const contentJson = JSON.stringify(content)
@@ -936,7 +966,7 @@ export async function sendWithContentType<T>(
       installationId,
       conversationId,
       Array.from(encodedContentData),
-      codec.shouldPush(content)
+      shouldPush ?? codec.shouldPush(content)
     )
   }
 }
@@ -1817,6 +1847,13 @@ export async function archiveMetadata(
   return new ArchiveMetadata(metadata)
 }
 
+export async function leaveGroup(
+  installationId: InstallationId,
+  id: ConversationId
+): Promise<void> {
+  return await XMTPModule.leaveGroup(installationId, id)
+}
+
 export const emitter = new EventEmitter(XMTPModule ?? NativeModulesProxy.XMTP)
 
 interface AuthParams {
@@ -1827,6 +1864,11 @@ interface AuthParams {
   deviceSyncEnabled?: boolean
   debugEventsEnabled?: boolean
   appVersion?: string
+  gatewayHost?: string
+  enableRecoveryRequests?: string
+  groupsToRequestRecovery?: string[]
+  disableRecoveryResponses?: boolean
+  workerIntervalNs?: number
 }
 
 interface SignerParams {

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -107,7 +107,9 @@ export class Client<
       options.customLocalHost,
       options.deviceSyncEnabled,
       options.debugEventsEnabled,
-      options.appVersion
+      options.appVersion,
+      options.gatewayHost,
+      options.forkRecoveryOptions
     )
     this.removeSubscription(authInboxSubscription)
 
@@ -196,7 +198,9 @@ export class Client<
           options.customLocalHost,
           options.deviceSyncEnabled,
           options.debugEventsEnabled,
-          options.appVersion
+          options.appVersion,
+          options.gatewayHost,
+          options.forkRecoveryOptions
         )
       })().catch((error) => {
         this.removeAllSubscriptions(authInboxSubscription)
@@ -235,7 +239,9 @@ export class Client<
       options.customLocalHost,
       options.deviceSyncEnabled,
       options.debugEventsEnabled,
-      options.appVersion
+      options.appVersion,
+      options.gatewayHost,
+      options.forkRecoveryOptions
     )
 
     return new Client(
@@ -281,7 +287,9 @@ export class Client<
       options.customLocalHost,
       options.deviceSyncEnabled,
       options.debugEventsEnabled,
-      options.appVersion
+      options.appVersion,
+      options.gatewayHost,
+      options.forkRecoveryOptions
     )
 
     return new Client(
@@ -1174,6 +1182,30 @@ export class Client<
 export type XMTPEnvironment = 'local' | 'dev' | 'production'
 export type SignatureType = 'revokeInstallations'
 
+export type ForkRecoveryPolicy = 'none' | 'all' | 'groups'
+
+export type ForkRecoveryOptions = {
+  /**
+   * Policy for enabling recovery requests
+   * - 'none': No recovery requests
+   * - 'all': Recovery for all groups
+   * - 'groups': Recovery only for allowlisted groups
+   */
+  enableRecoveryRequests?: ForkRecoveryPolicy
+  /**
+   * List of group IDs to request recovery for (when enableRecoveryRequests is 'groups')
+   */
+  groupsToRequestRecovery?: string[]
+  /**
+   * Whether to disable recovery responses
+   */
+  disableRecoveryResponses?: boolean
+  /**
+   * Worker interval in nanoseconds (will be converted to ULong on Android, UInt64 on iOS)
+   */
+  workerIntervalNs?: number
+}
+
 export type ClientOptions = {
   /**
    * Specify which XMTP environment to connect to. (default: `dev`)
@@ -1211,4 +1243,12 @@ export type ClientOptions = {
    * OPTIONAL specify if debug events should be tracked defaults to false
    */
   debugEventsEnabled?: boolean
+  /**
+   * OPTIONAL specify the gateway host
+   */
+  gatewayHost?: string
+  /**
+   * OPTIONAL specify fork recovery options for handling group forks
+   */
+  forkRecoveryOptions?: ForkRecoveryOptions
 }

--- a/src/lib/Dm.ts
+++ b/src/lib/Dm.ts
@@ -76,7 +76,11 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
     opts?: SendOptions
   ): Promise<MessageId> {
     if (opts && opts.contentType) {
-      return await this._sendWithJSCodec(content, opts.contentType)
+      return await this._sendWithJSCodec(
+        content,
+        opts.contentType,
+        opts.shouldPush
+      )
     }
 
     try {
@@ -97,7 +101,8 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
 
   private async _sendWithJSCodec<T>(
     content: T,
-    contentType: XMTP.ContentTypeId
+    contentType: XMTP.ContentTypeId,
+    shouldPush?: boolean
   ): Promise<MessageId> {
     const codec =
       Client.codecRegistry[
@@ -112,7 +117,8 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
       this.client.installationId,
       this.id,
       content,
-      codec
+      codec,
+      shouldPush ?? codec.shouldPush(content) ?? true
     )
   }
 

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -126,7 +126,8 @@ export class Group<
 
   private async _sendWithJSCodec<T>(
     content: T,
-    contentType: XMTP.ContentTypeId
+    contentType: XMTP.ContentTypeId,
+    shouldPush?: boolean
   ): Promise<MessageId> {
     const codec =
       Client.codecRegistry[
@@ -141,7 +142,8 @@ export class Group<
       this.client.installationId,
       this.id,
       content,
-      codec
+      codec,
+      shouldPush ?? codec.shouldPush(content) ?? true
     )
   }
 
@@ -802,5 +804,12 @@ export class Group<
    */
   async getDebugInformation(): Promise<ConversationDebugInfo> {
     return await XMTP.getDebugInformation(this.client.installationId, this.id)
+  }
+
+  /**
+   * @returns {Promise<void>} A Promise that resolves when the group is left.
+   */
+  async leaveGroup(): Promise<void> {
+    return await XMTP.leaveGroup(this.client.installationId, this.id)
   }
 }

--- a/src/lib/types/SendOptions.ts
+++ b/src/lib/types/SendOptions.ts
@@ -2,4 +2,6 @@ import { ContentTypeId } from './ContentCodec'
 
 export type SendOptions = {
   contentType?: ContentTypeId
+  /** Whether to send a push notification. Defaults to the codec's shouldPush behavior if not specified. */
+  shouldPush?: boolean
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add gatewayHost and fork recovery options across JS, Android, and iOS client creation paths and expose group leave and push control for 1.6 RC1
Implement optional `gatewayHost` and fork recovery options in client creation/config on JS, Android, and iOS; add `leaveGroup` APIs; update sync to return `numSynced`; and accept `-rc{number}` versions in the release workflow.

#### 📍Where to Start
Start with the auth parameter flow at `authParamsFromJson` in [AuthParamsWrapper.kt](https://github.com/xmtp/xmtp-react-native/pull/752/files#diff-334f3bb3ee25959251f9986393c1cc889c45e44af054e0b58422240fe5879a8b), then follow propagation into `XMTPModule.createClientOptions` in [XMTPModule.kt](https://github.com/xmtp/xmtp-react-native/pull/752/files#diff-3d1b8496c4f066a0a1d2f776063d85d49f70545d6a94a57fe91eb6efecd50a48) and `XMTPModule.createClientConfig` in [XMTPModule.swift](https://github.com/xmtp/xmtp-react-native/pull/752/files#diff-6260b37315249e4d7814a7eed83d9c53d15c299d753edd037d00ddd617d5a2b9), and finally the JS entry points in [src/index.ts](https://github.com/xmtp/xmtp-react-native/pull/752/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized beda5b8. 10 files reviewed, 50 issues evaluated, 40 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt — 0 comments posted, 18 evaluated, 12 filtered</summary>

- [line 219](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L219): `dbEncryptionKey` elements are coerced to bytes with `toByte()` without validation. If any `Int` falls outside the range -128..127 (e.g., 128..255 or larger/negative), it will wrap modulo 256, potentially corrupting the database encryption key. Given the type allows any `Int`, add validation to enforce 0..255 (or -128..127, as appropriate) and fail fast with a clear error rather than silently altering the key material. <b>[ Low confidence ]</b>
- [line 497](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L497): Missing cleanup of global `signer` on exception in `revokeInstallations`. Wrap the call in try/finally to always clear `signer`. <b>[ Already posted ]</b>
- [line 518](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L518): Missing cleanup of global `signer` on exception in `revokeAllOtherInstallations`. Use try/finally to guarantee `signer` reset. <b>[ Already posted ]</b>
- [line 539](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L539): Missing cleanup of global `signer` on exception in `addAccount`. Use try/finally to ensure `signer` is cleared. <b>[ Already posted ]</b>
- [line 562](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L562): Missing cleanup of global `signer` on exception in `removeAccount`. Ensure `signer = null` runs in a finally block. <b>[ Already posted ]</b>
- [line 709](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L709): Missing cleanup of global `signer` on exception in `staticRevokeInstallations`. Use try/finally to clear `signer` regardless of success/failure. <b>[ Already posted ]</b>
- [line 874](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L874): Potential NullPointerException: `appContext.reactContext` is accessed with a non-null assertion through a safe-call chain ending with `!!` when opening the input stream in `encryptAttachment`. If `reactContext` is null or `contentResolver.openInputStream(uri)` returns null (e.g., missing permission or invalid URI), the `!!` will throw, crashing the app. Use the `context` accessor that throws a controlled exception or handle nulls gracefully. <b>[ Already posted ]</b>
- [line 899](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L899): Potential NullPointerException: Same pattern as in `encryptAttachment` occurs in `decryptAttachment` when opening the input stream: `appContext.reactContext?.contentResolver?.openInputStream(... )!!`. If `reactContext` is null or the stream cannot be opened, this crashes. Use the guarded `context` or handle nulls. <b>[ Already posted ]</b>
- [line 1923](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L1923): Duplicate function registration: `Function("unsubscribeFromConsent")` is declared twice in the module (first at lines 848–851 and again at 1923–1926). Depending on Expo Modules behavior, this may either override the first definition or cause an error during module registration. Either outcome is surprising; keep a single definition. <b>[ Low confidence ]</b>
- [line 1950](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L1950): Potential NullPointerException: `registerPushToken` uses `appContext.reactContext!!` to create `XMTPPush`. If the React context is unavailable when this function is called, this will crash. Use the guarded `context` property that throws a controlled `Exceptions.ReactContextLost()` or guard against null. <b>[ Already posted ]</b>
- [line 1995](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L1995): Resource leak in `exportNativeLogs`: The `BufferedReader` created to read `logcat` output isn’t closed in a `use {}` block, and the spawned `Process` isn’t waited on or destroyed. This can leak resources. Wrap the reader in `.use {}` and call `process.waitFor()` and/or `process.destroy()` in finally. <b>[ Code style ]</b>
- [line 2264](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L2264): Possible concurrent access to `subscriptions` map without synchronization. The map is mutated from multiple threads/coroutines (e.g., UI thread calling unsubscribe functions and background coroutines assigning within `subscribeTo*`), but it is a standard `MutableMap` (likely a `HashMap`) which is not thread-safe. This risks race conditions or ConcurrentModificationExceptions. Use a thread-safe map (e.g., `ConcurrentHashMap`) or ensure all accesses happen on a single dispatcher with proper synchronization. <b>[ Low confidence ]</b>
</details>

<details>
<summary>android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/AuthParamsWrapper.kt — 0 comments posted, 3 evaluated, 2 filtered</summary>

- [line 40](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/AuthParamsWrapper.kt#L40): Negative `workerIntervalNs` values are not handled. In `createForkRecoveryOptions`, a negative `BigInteger` passes the `<= Long.MAX_VALUE` check, is converted to `Long` and then to `ULong` via `toULong()`, producing a very large `ULong` due to two’s-complement wrapping. This likely results in an unintended enormous interval. Add explicit non-negativity validation, e.g., clamp to zero or reject negatives with an error. <b>[ Already posted ]</b>
- [line 70](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/AuthParamsWrapper.kt#L70): `AuthParamsWrapper.authParamsFromJson` assumes `authParams` parses to a JSON object and that key `environment` exists and is a string. If the string is invalid JSON, not an object, or `environment` is missing/non-string, `.asJsonObject` or `.get("environment").asString` will throw, leading to an unhandled exception in `clientOptions`. Consider validating the shape and providing clear error messages or defaults. <b>[ Low confidence ]</b>
</details>

<details>
<summary>example/src/HomeScreen.tsx — 0 comments posted, 8 evaluated, 7 filtered</summary>

- [line 50](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/example/src/HomeScreen.tsx#L50): Uncaught exceptions possible in streaming callback: Inside `streamAllMessages`, the callback calls `message.content()` inline within `console.log`. If `content()` throws (e.g., decoding error), the exception may propagate into the stream handler and tear down the stream or leave it in an inconsistent state. Wrap callback logic in `try/catch` to ensure the stream remains healthy and errors are surfaced without breaking the subscription. <b>[ Low confidence ]</b>
- [line 186](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/example/src/HomeScreen.tsx#L186): Potential React key collisions: `keyExtractor={(item) => item.topic}` assumes all `topic` values are unique. If there are duplicate topics (possible in certain datasets or bugs), React will reuse elements incorrectly, causing rendering inconsistencies. Add a uniqueness guarantee or incorporate a disambiguator (e.g., combine with participant or index as fallback) and/or validate for duplicates before rendering. <b>[ Low confidence ]</b>
- [line 205](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/example/src/HomeScreen.tsx#L205): Unsafe property access: `{client?.publicIdentity.identifier}` applies optional chaining only to `client`, not to `publicIdentity`. If `client` exists but `client.publicIdentity` is `undefined` (e.g., during initialization or a transient state), accessing `.identifier` will throw at runtime. Use `client?.publicIdentity?.identifier` or guard `publicIdentity` before rendering. <b>[ Low confidence ]</b>
- [line 209](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/example/src/HomeScreen.tsx#L209): Unsafe property access in the copy handler condition: `if (client?.publicIdentity.identifier) { ... }` applies optional chaining only to `client`. If `client.publicIdentity` is `undefined`, evaluating `.identifier` will throw before the `if` body. Use `client?.publicIdentity?.identifier` in the condition. <b>[ Already posted ]</b>
- [line 266](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/example/src/HomeScreen.tsx#L266): Unhandled errors in `denyGroup` can lead to unhandled promise rejections and no user feedback: `await conversation.updateConsent('denied'); const consent = await conversation.consentState();` lacks a `try/catch`. If either call throws (e.g., network error), the rejection will escape the `onPress` handler, potentially crashing the component or producing noisy logs, and `consentState` will not update. Wrap in `try/catch` and provide a failure path. <b>[ Low confidence ]</b>
- [line 291](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/example/src/HomeScreen.tsx#L291): Potential null/undefined dereference: `navigation!.navigate('conversation', { topic: conversation.topic })` uses a non-null assertion on `navigation`. If the component is rendered outside a `NavigationContainer` or context fails, `navigation` can be `null`/`undefined` and this will throw. Guard the context with `if (!navigation) return;` or use optional chaining and fallback. <b>[ Low confidence ]</b>
- [line 320](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/example/src/HomeScreen.tsx#L320): Incorrect time rendering when there is no `lastMessage`: `moment(lastMessage?.sentNs / 1000000).fromNow()` will evaluate `moment(undefined)` when `lastMessage` is `undefined`, which yields the current time or an invalid moment. This produces misleading output (e.g., "a few seconds ago") or "Invalid date" even when no message exists. Guard before rendering or conditionally render only when `lastMessage` and `sentNs` are defined. <b>[ Low confidence ]</b>
</details>

<details>
<summary>example/src/LaunchScreen.tsx — 0 comments posted, 5 evaluated, 5 filtered</summary>

- [line 146](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/example/src/LaunchScreen.tsx#L146): Potential resource leak: `setClient(client)` (line 146) overwrites any previously set client without disposing or closing it. If `XMTP.Client` holds network connections or background tasks (e.g., recovery worker via `forkRecoveryOptions`), replacing it without teardown can leak resources. Ensure the prior client is shut down before replacing it (e.g., an explicit `client.close()` or equivalent), and enforce at-most-once activation. <b>[ Low confidence ]</b>
- [line 147](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/example/src/LaunchScreen.tsx#L147): The `configureWallet` success path navigates away before saving keys, which can trigger React state updates on an unmounted component. Specifically, `navigation.navigate('home')` is called (line 147) and then `await savedKeys.save(...)` (line 149) calls `setSavedAddress`/`setSavedInboxId`. If `LaunchScreen` unmounts on navigation, these setState calls will run after unmount, causing warnings and potential memory leaks. Move persistence to a durable store (e.g., AsyncStorage) or ensure the component is still mounted before updating state. <b>[ Low confidence ]</b>
- [line 253](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/example/src/LaunchScreen.tsx#L253): No re-entrancy or in-flight guard exists on the wallet configuration actions. A user can press "Use Random Wallet" or "Use Saved Wallet" multiple times quickly, creating multiple concurrent `XMTP.Client` instances and invoking `configureWallet` multiple times. This can cause overlapping side effects (multiple `setClient` calls, multiple navigations, and repeated persistence) and potential resource leaks if previous clients are not torn down. Disable the buttons while an operation is in flight or add an idempotent guard. <b>[ Already posted ]</b>
- [line 256](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/example/src/LaunchScreen.tsx#L256): Contract parity mismatch between wallet paths: `getDbEncryptionKey(selectedNetwork, true)` is used for the "Random Wallet" path (lines 256–259), whereas the "Saved Wallet" path uses `getDbEncryptionKey(selectedNetwork)` without the second argument (lines 286–288). If the second parameter controls behavior like cache bypass or generation, the two paths may derive different or stale keys, causing inconsistent DB access or decryption failures. Align the arguments or document the intentional difference with guards and error handling. <b>[ Low confidence ]</b>
- [line 277](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/example/src/LaunchScreen.tsx#L277): The "Use Saved Wallet" path renders when `!!savedKeys.address` is truthy (line 277), but does not verify that `savedKeys.inboxId` is also present. It then calls `XMTP.Client.build(...)` with `savedKeys.inboxId!` (line 297). If `inboxId` is `null`/`undefined`, this non-null assertion is only a compile-time hint and will still pass `undefined` at runtime, potentially causing a runtime error or invalid client configuration. Add a guard to ensure both `address` and `inboxId` exist before rendering/enabling the button, or handle the missing `inboxId` case with a clear error. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ios/Wrappers/AuthParamsWrapper.swift — 0 comments posted, 8 evaluated, 8 filtered</summary>

- [line 55](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/ios/Wrappers/AuthParamsWrapper.swift#L55): `createForkRecoveryOptions` does not infer `ForkRecoveryPolicy` from the presence of `groupsToRequestRecovery`. If `groupsToRequestRecovery` is provided but `enableRecoveryRequestsString` is missing or not "groups", `convertToForkRecoveryPolicy` returns `.none`, making the provided groups ineffective. This leads to surprising behavior where a user-specified allowlist of groups is ignored unless an additional string flag is set. Consider inferring `.allowlistedGroups` when `groupsToRequestRecovery` is non-empty and no explicit policy is provided, or return an error for inconsistent inputs. <b>[ Low confidence ]</b>
- [line 63](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/ios/Wrappers/AuthParamsWrapper.swift#L63): `enableRecoveryRequests` string mapping is overly strict and case-sensitive. Values other than exactly "none", "all", or "groups" (e.g., "allowlistedGroups", "GROUPS", or differing case) will default to `.none`, silently ignoring user intent. This can cause incorrect fork recovery policy selection even when a valid intent string is supplied. Consider normalizing case and supporting synonyms (e.g., accept "allowlistedGroups") or validating with an error when an unknown value is provided. <b>[ Low confidence ]</b>
- [line 95](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/ios/Wrappers/AuthParamsWrapper.swift#L95): Calls to `setenv("XMTP_HISTORY_SERVER_ADDRESS", historySyncUrl, 1)` and `setenv("XMTP_NODE_ADDRESS", customLocalUrl, 1)` ignore the return value and potential errors. If setting the environment variable fails (e.g., due to memory allocation failure or invalid name/value per platform constraints), the code proceeds silently, leaving a partial or incorrect process state that downstream components may rely on. Consider checking the return code and logging or throwing an error, or avoiding global environment mutation and passing configuration explicitly. <b>[ Out of scope ]</b>
- [line 95](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/ios/Wrappers/AuthParamsWrapper.swift#L95): Global process environment mutation via `setenv` is unscoped and can cause cross-client contamination and race conditions. `authParamsFromJson` sets `XMTP_HISTORY_SERVER_ADDRESS` and `XMTP_NODE_ADDRESS` based on the parsed JSON without validation or a paired cleanup. In an app that may construct multiple clients with different `historySyncUrl` or `customLocalUrl`, the last call wins and affects all subsequent uses globally. There is no error handling on the return value of `setenv`, so failures are silently ignored. Consider passing these values through `ClientOptions` (as is already done for `historySyncUrl` and `customLocalUrl`) rather than mutating environment variables, or confining mutation to a clearly documented, single-run initialization path with validation and error handling. <b>[ Low confidence ]</b>
- [line 99](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/ios/Wrappers/AuthParamsWrapper.swift#L99): The code mutates global process environment via `setenv` without any scoping, rollback, or teardown. If `authParamsFromJson` is called multiple times (e.g., different users/sessions), or concurrently, environment changes persist and may affect unrelated parts of the app or background tasks. This violates the guideline to avoid persistent mutation of global objects unless explicitly documented and versioned. Consider passing configuration through explicit parameters or a scoped context rather than global env vars, or ensure a controlled, at-most-once initialization phase with clear lifecycle guarantees. <b>[ Out of scope ]</b>
- [line 110](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/ios/Wrappers/AuthParamsWrapper.swift#L110): Potential silent data loss when parsing `groupsToRequestRecovery`. `JSONSerialization` arrays are typed as `[Any]`; the cast `jsonOptions["groupsToRequestRecovery"] as? [String]` succeeds only if all elements are `String`. If any element is non-string (e.g., numbers or mixed types), the cast fails, and the code silently replaces the user-provided array with an empty array via `groupsToRequestRecovery ?? []`. This can disable intended group allowlisting without error reporting. Consider validating the array contents and either reject invalid entries with an error or map elements to `String` where possible. <b>[ Low confidence ]</b>
- [line 112](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/ios/Wrappers/AuthParamsWrapper.swift#L112): JSON numeric value for `workerIntervalNs` is parsed using `as? UInt64` at `authParamsFromJson` (and passed through `createForkRecoveryOptions`). `JSONSerialization` returns numbers as `NSNumber`, and casting directly to `UInt64` typically fails. As a result, providing a valid numeric `workerIntervalNs` in JSON will be silently dropped (parsed as `nil`), causing `ForkRecoveryOptions.workerIntervalNs` to be `nil` even when a value was supplied. To fix, parse as `NSNumber` and then convert (e.g., `if let n = jsonOptions["workerIntervalNs"] as? NSNumber { let workerIntervalNs = n.uint64Value }`). <b>[ Already posted ]</b>
- [line 112](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/ios/Wrappers/AuthParamsWrapper.swift#L112): Silent data loss when parsing `workerIntervalNs` from JSON. `JSONSerialization` returns numeric values as `NSNumber`, not `UInt64`. The cast `jsonOptions["workerIntervalNs"] as? UInt64` will fail for valid JSON numbers, resulting in `nil` and dropping a user-provided value without error. This silently changes behavior and may disable intended worker scheduling. To fix, read as `NSNumber` (or `Int`/`Double`) and convert to `UInt64`, or switch to `JSONDecoder` with a `Decodable` model. <b>[ Already posted ]</b>
</details>

<details>
<summary>src/index.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 953](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/src/index.ts#L953): `SendOptions.shouldPush` is propagated through `Dm._sendWithJSCodec` and `Group._sendWithJSCodec` into `sendWithContentType`, but in `sendWithContentType` the native codec branch (when `'contentKey' in codec` is true) ignores `shouldPush` entirely and calls `XMTPModule.sendMessage` without a push parameter. As a result, for native content types (e.g., `TextCodec`) the caller’s `shouldPush` preference is silently ignored. This violates the documented contract in `SendOptions` that the push behavior should default to the codec’s `shouldPush` when not specified, implying that an explicit value should be honored across all codec types. <b>[ Low confidence ]</b>
- [line 954](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/src/index.ts#L954): In `sendWithContentType`, when using a native codec (i.e., `'contentKey' in codec`), the function serializes the raw `content` with `JSON.stringify(content)` and passes the resulting string to `XMTPModule.sendMessage`. Other call sites (e.g., `Dm.send` and `Group.send`) pass a `NativeMessageContent` object (e.g., `{ text: content }` for `TextCodec`). This inconsistency can produce malformed payloads for native codecs because the module may expect a structured `NativeMessageContent` rather than a JSON string. For example, sending a text message via the native path yields `"hello"` instead of `{ text: "hello" }`. To preserve the contract parity, the native branch should use the codec to construct the native message object (e.g., `codec.encode(content)`) or otherwise pass a `NativeMessageContent` object. <b>[ Low confidence ]</b>
</details>

<details>
<summary>src/lib/Client.ts — 0 comments posted, 3 evaluated, 1 filtered</summary>

- [line 171](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/src/lib/Client.ts#L171): The signature processing path invoked by `Client.create` for non-`SCW` signers depends on Node-style `Buffer` to base64-encode a 65-byte ECDSA signature (`Buffer.from(sigBytes).toString('base64')`). `Buffer` is only declared (`declare const Buffer`) and may be undefined at runtime in environments without a global Buffer (e.g., some React Native setups). This will crash when the handler runs. A safe, environment-agnostic base64 encoder should be used or ensure `Buffer` is polyfilled. <b>[ Low confidence ]</b>
</details>

<details>
<summary>src/lib/Group.ts — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 108](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/src/lib/Group.ts#L108): `send()` ignores a caller-provided push directive. The private method `_sendWithJSCodec` now accepts an optional `shouldPush` parameter and correctly passes `shouldPush ?? codec.shouldPush(content) ?? true` to `XMTP.sendWithContentType`. However, the public `send()` method still calls `_sendWithJSCodec(content, opts.contentType)` and does not forward any `shouldPush` setting from `opts` (if present). As a result, a user intent to override push behavior via `SendOptions` will be silently ignored, causing incorrect behavior (e.g., unexpected push notifications or lack thereof). <b>[ Low confidence ]</b>
- [line 316](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/src/lib/Group.ts#L316): Unhandled exceptions in `streamMessages` event handler can lead to unhandled promise rejections. The listener for `EventTypes.ConversationMessage` is an `async` function that `await`s `callback(DecodedMessage.fromObject(message))` without a try/catch. If the user-provided `callback` throws/rejects, the returned Promise from the event handler rejects, which many event emitter implementations do not handle and can cause unhandled rejection warnings or crashes depending on environment. Wrap the `await callback(...)` in a try/catch to contain errors and optionally log or invoke an error handler. <b>[ Low confidence ]</b>
- [line 775](https://github.com/xmtp/xmtp-react-native/blob/beda5b815eced9d06a8ed72ddc3b039d2ddf5f43/src/lib/Group.ts#L775): `pausedForVersion()`’s documented behavior contradicts its TypeScript signature. The JSDoc says the Promise resolves to `null` unless the group is paused, but the signature is `Promise<string>`, which does not allow `null`. If the underlying `XMTP.pausedForVersion` returns `null` as documented, callers relying on the string type might attempt string operations and hit runtime errors. The signature should be `Promise<string | null>` (or the docs updated), to align with actual values. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->