### PR TITLE
Add insertedAt field and sortBy options

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.6.1-rc1"
+  implementation "org.xmtp:android:4.7.0-dev.252eebc"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/MessageQueryParamsWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/MessageQueryParamsWrapper.kt
@@ -9,11 +9,17 @@ class MessageQueryParamsWrapper(
     val direction: String?,
     val excludeContentTypes: List<String>?,
     val excludeSenderInboxIds: List<String>?,
+    val insertedAfterNs: Long?,
+    val insertedBeforeNs: Long?,
+    val sortBy: String?,
 ) {
     companion object {
         fun messageQueryParamsFromJson(paramsJson: String): MessageQueryParamsWrapper {
             if (paramsJson.isEmpty()) {
                 return MessageQueryParamsWrapper(
+                    null,
+                    null,
+                    null,
                     null,
                     null,
                     null,
@@ -69,6 +75,27 @@ class MessageQueryParamsWrapper(
                     null
                 }
 
+            val insertedAfterNs =
+                if (jsonOptions.has("insertedAfterNs")) {
+                    jsonOptions.get("insertedAfterNs").asLong
+                } else {
+                    null
+                }
+
+            val insertedBeforeNs =
+                if (jsonOptions.has("insertedBeforeNs")) {
+                    jsonOptions.get("insertedBeforeNs").asLong
+                } else {
+                    null
+                }
+
+            val sortBy =
+                if (jsonOptions.has("sortBy")) {
+                    jsonOptions.get("sortBy").asString
+                } else {
+                    null
+                }
+
             return MessageQueryParamsWrapper(
                 limit,
                 beforeNs,
@@ -76,6 +103,9 @@ class MessageQueryParamsWrapper(
                 direction,
                 excludeContentTypes,
                 excludeSenderInboxIds,
+                insertedAfterNs,
+                insertedBeforeNs,
+                sortBy,
             )
         }
     }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/MessageWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/MessageWrapper.kt
@@ -5,7 +5,6 @@ import org.xmtp.android.library.codecs.description
 import org.xmtp.android.library.libxmtp.DecodedMessage
 
 class MessageWrapper {
-
     companion object {
         fun encode(model: DecodedMessage): String {
             val gson = GsonBuilder().create()
@@ -24,9 +23,10 @@ class MessageWrapper {
                 "content" to ContentJson(model.encodedContent).toJsonMap(),
                 "senderInboxId" to model.senderInboxId,
                 "sentNs" to model.sentAtNs,
+                "insertedAtNs" to model.insertedAtNs,
                 "fallback" to fallback,
                 "deliveryStatus" to model.deliveryStatus.toString(),
-                "childMessages" to model.childMessages?.map { childMessage -> encodeMap(childMessage) }
+                "childMessages" to model.childMessages?.map { childMessage -> encodeMap(childMessage) },
             )
         }
     }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
   - EXImageLoader (5.0.0):
     - ExpoModulesCore
     - React-Core
-  - Expo (52.0.47):
+  - Expo (52.0.44):
     - ExpoModulesCore
   - ExpoAsset (11.0.5):
     - ExpoModulesCore
@@ -51,9 +51,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ExpoSplashScreen (0.29.24):
-    - ExpoModulesCore
-  - ExpoSystemUI (4.0.9):
+  - ExpoSplashScreen (0.29.22):
     - ExpoModulesCore
   - fast_float (6.1.4)
   - FBLazyVector (0.76.9)
@@ -1377,7 +1375,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-netinfo (11.4.1):
+  - react-native-netinfo (9.3.7):
     - React-Core
   - react-native-quick-base64 (2.1.2):
     - DoubleConversion
@@ -1425,31 +1423,12 @@ PODS:
     - Yoga
   - react-native-randombytes (3.6.1):
     - React-Core
-  - react-native-safe-area-context (4.12.0):
+  - react-native-safe-area-context (5.3.0):
     - React-Core
   - react-native-sqlite-storage (6.0.1):
     - React-Core
-  - react-native-webview (13.12.5):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.10.14.00)
-    - RCTRequired
-    - RCTTypeSafety
+  - react-native-webview (11.26.0):
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - React-nativeconfig (0.76.9)
   - React-NativeModulesApple (0.76.9):
     - glog
@@ -1722,11 +1701,11 @@ PODS:
     - React-logger
     - React-perflogger
     - React-utils (= 0.76.9)
-  - RNCAsyncStorage (1.23.1):
+  - RNCAsyncStorage (1.17.11):
     - React-Core
   - RNFS (2.20.0):
     - React-Core
-  - RNScreens (4.4.0):
+  - RNScreens (4.10.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1748,7 +1727,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSVG (15.8.0):
+  - RNSVG (15.11.2):
     - React-Core
   - SocketRocket (0.7.1)
   - SQLCipher (4.5.7):
@@ -1757,16 +1736,16 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.6.1-rc3):
+  - XMTP (4.7.0-dev.ff66c0f):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (5.0.6):
+  - XMTPReactNative (5.1.0-rc1):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.6.1-rc3)
+    - XMTP (= 4.7.0-dev.ff66c0f)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1785,7 +1764,6 @@ DEPENDENCIES:
   - ExpoKeepAwake (from `../node_modules/expo-keep-awake/ios`)
   - ExpoModulesCore (from `../node_modules/expo-modules-core`)
   - ExpoSplashScreen (from `../node_modules/expo-splash-screen/ios`)
-  - ExpoSystemUI (from `../node_modules/expo-system-ui/ios`)
   - fast_float (from `../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
@@ -1913,8 +1891,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-modules-core"
   ExpoSplashScreen:
     :path: "../node_modules/expo-splash-screen/ios"
-  ExpoSystemUI:
-    :path: "../node_modules/expo-system-ui/ios"
   fast_float:
     :podspec: "../node_modules/react-native/third-party-podspecs/fast_float.podspec"
   FBLazyVector:
@@ -2083,7 +2059,7 @@ SPEC CHECKSUMS:
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   EXConstants: fcfc75800824ac2d5c592b5bc74130bad17b146b
   EXImageLoader: e5da974e25b13585c196b658a440720c075482d5
-  Expo: 1687edb10c76b0c0f135306d6ae245379f50ed54
+  Expo: 75e002fc29a18a72aa3db967b41b29c2b206875d
   ExpoAsset: 48386d40d53a8c1738929b3ed509bcad595b5516
   ExpoClipboard: 44fd1c8959ee8f6175d059dc011b154c9709a969
   ExpoCrypto: e97e864c8d7b9ce4a000bca45dddb93544a1b2b4
@@ -2093,8 +2069,7 @@ SPEC CHECKSUMS:
   ExpoImagePicker: 24e5ba8da111f74519b1e6dc556e0b438b2b8464
   ExpoKeepAwake: b0171a73665bfcefcfcc311742a72a956e6aa680
   ExpoModulesCore: 725faec070d590810d2ea5983d9f78f7cf6a38ec
-  ExpoSplashScreen: 399ee9f85b6c8a61b965e13a1ecff8384db591c2
-  ExpoSystemUI: b82a45cf0f6a4fa18d07c46deba8725dd27688b4
+  ExpoSplashScreen: cb4e3d3ee646ed59810f7776cca0ae5c03ab4285
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 7605ea4810e0e10ae4815292433c09bf4324ba45
   fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
@@ -2138,13 +2113,13 @@ SPEC CHECKSUMS:
   react-native-encrypted-storage: 569d114e329b1c2c2d9f8c84bcdbe4478dda2258
   react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
   react-native-mmkv: f0574e88f254d13d1a87cf6d38c36bc5d3910d49
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
+  react-native-netinfo: be701059f57093572e5ba08cba14483d334b425d
   react-native-quick-base64: 5565249122493bef017004646d73f918e8c2dfb0
   react-native-quick-crypto: c168ffba24470d8edfd03961d9492638431b9869
   react-native-randombytes: 3c8f3e89d12487fd03a2f966c288d495415fc116
-  react-native-safe-area-context: 8b8404e70b0cbf2a56428a17017c14c1dcc16448
+  react-native-safe-area-context: fdb0a66feac038cb6eb1edafcf2ccee2b5cf0284
   react-native-sqlite-storage: 0c84826214baaa498796c7e46a5ccc9a82e114ed
-  react-native-webview: 69a5462ca94921ff695e1b52b12fffe62af7d312
+  react-native-webview: 5bb1454f1eb43e0bad229bb428a378d6b865a0ad
   React-nativeconfig: 8efdb1ef1e9158c77098a93085438f7e7b463678
   React-NativeModulesApple: cebca2e5320a3d66e123cade23bd90a167ffce5e
   React-perflogger: 72e653eb3aba9122f9e57cf012d22d2486f33358
@@ -2172,15 +2147,15 @@ SPEC CHECKSUMS:
   React-utils: ed818f19ab445000d6b5c4efa9d462449326cc9f
   ReactCodegen: f853a20cc9125c5521c8766b4b49375fec20648b
   ReactCommon: 300d8d9c5cb1a6cd79a67cf5d8f91e4d477195f9
-  RNCAsyncStorage: aa75595c1aefa18f868452091fa0c411a516ce11
+  RNCAsyncStorage: 357676e1dc19095208c80d4271066c407cd02ed1
   RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
-  RNScreens: 295d9c0aaeb7f680d03d7e9b476569a4959aae89
-  RNSVG: 8542aa11770b27563714bbd8494a8436385fc85f
+  RNScreens: 5cac36d8f7b3d92fb4304abcb44c5de336413df8
+  RNSVG: a07e14363aa208062c6483bad24a438d5986d490
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: d9e99e75df20472dd4845f5b9f0476e4748d1fd6
-  XMTPReactNative: ae7fe2223f35aae19235a1c792f3035f8ff70cb9
+  XMTP: fbef51f8aa0cb762cfac902668f9648b77465a7f
+  XMTPReactNative: 439874cb0553196c7f6804014f829a2f5ec9c215
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 5b1b93f724b9cde6043d1824960f7bfd9a7973cd

--- a/ios/Wrappers/MessageQueryParamsWrapper.swift
+++ b/ios/Wrappers/MessageQueryParamsWrapper.swift
@@ -8,6 +8,9 @@ struct MessageQueryParamsWrapper {
 	let direction: String?
 	let excludeContentTypes: [String]?
 	let excludeSenderInboxIds: [String]?
+	let insertedAfterNs: Int64?
+	let insertedBeforeNs: Int64?
+	let sortBy: String?
 
 	static func messageQueryParamsFromJson(_ paramsJson: String)
 		-> MessageQueryParamsWrapper
@@ -19,14 +22,17 @@ struct MessageQueryParamsWrapper {
 				afterNs: nil,
 				direction: nil,
 				excludeContentTypes: nil,
-				excludeSenderInboxIds: nil
+				excludeSenderInboxIds: nil,
+				insertedAfterNs: nil,
+				insertedBeforeNs: nil,
+				sortBy: nil
 			)
 		}
 
 		let data = paramsJson.data(using: .utf8) ?? Data()
 		let jsonOptions =
 			(try? JSONSerialization.jsonObject(with: data, options: []))
-			as? [String: Any] ?? [:]
+				as? [String: Any] ?? [:]
 
 		let limit = jsonOptions["limit"] as? Int
 		let beforeNs = jsonOptions["beforeNs"] as? Int64
@@ -34,6 +40,9 @@ struct MessageQueryParamsWrapper {
 		let direction = jsonOptions["direction"] as? String
 		let excludeContentTypes = jsonOptions["excludeContentTypes"] as? [String]
 		let excludeSenderInboxIds = jsonOptions["excludeSenderInboxIds"] as? [String]
+		let insertedAfterNs = jsonOptions["insertedAfterNs"] as? Int64
+		let insertedBeforeNs = jsonOptions["insertedBeforeNs"] as? Int64
+		let sortBy = jsonOptions["sortBy"] as? String
 
 		return MessageQueryParamsWrapper(
 			limit: limit,
@@ -41,7 +50,10 @@ struct MessageQueryParamsWrapper {
 			afterNs: afterNs,
 			direction: direction,
 			excludeContentTypes: excludeContentTypes,
-			excludeSenderInboxIds: excludeSenderInboxIds
+			excludeSenderInboxIds: excludeSenderInboxIds,
+			insertedAfterNs: insertedAfterNs,
+			insertedBeforeNs: insertedBeforeNs,
+			sortBy: sortBy
 		)
 	}
 }

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.6.1-rc3"
+  s.dependency "XMTP", "= 4.7.0-dev.ff66c0f"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/react-native-sdk",
-  "version": "5.1.0-rc1",
+  "version": "5.2.0-dev",
   "description": "Wraps for native xmtp sdks for react native",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,11 @@ import {
 import { DecodedMessageUnion } from './lib/types/DecodedMessageUnion'
 import { DefaultContentTypes } from './lib/types/DefaultContentType'
 import { LogLevel, LogRotation } from './lib/types/LogTypes'
-import { MessageId, MessageOrder } from './lib/types/MessagesOptions'
+import {
+  MessageId,
+  MessageOrder,
+  MessageSortBy,
+} from './lib/types/MessagesOptions'
 import { PermissionPolicySet } from './lib/types/PermissionPolicySet'
 
 export * from './context'
@@ -787,7 +791,10 @@ export async function conversationMessages<
   afterNs?: number | undefined,
   direction?: MessageOrder | undefined,
   excludeContentTypes?: string[] | undefined,
-  excludeSenderInboxIds?: string[] | undefined
+  excludeSenderInboxIds?: string[] | undefined,
+  insertedAfterNs?: number | undefined,
+  insertedBeforeNs?: number | undefined,
+  sortBy?: MessageSortBy | undefined
 ): Promise<DecodedMessageUnion<ContentTypes>[]> {
   const queryParamsJson = JSON.stringify({
     limit,
@@ -796,6 +803,9 @@ export async function conversationMessages<
     direction,
     excludeContentTypes,
     excludeSenderInboxIds,
+    insertedAfterNs,
+    insertedBeforeNs,
+    sortBy,
   })
   const messages = await XMTPModule.conversationMessages(
     clientInstallationId,
@@ -817,7 +827,10 @@ export async function conversationMessagesWithReactions<
   afterNs?: number | undefined,
   direction?: MessageOrder | undefined,
   excludeContentTypes?: string[] | undefined,
-  excludeSenderInboxIds?: string[] | undefined
+  excludeSenderInboxIds?: string[] | undefined,
+  insertedAfterNs?: number | undefined,
+  insertedBeforeNs?: number | undefined,
+  sortBy?: MessageSortBy | undefined
 ): Promise<DecodedMessageUnion<ContentTypes>[]> {
   const queryParamsJson = JSON.stringify({
     limit,
@@ -826,6 +839,9 @@ export async function conversationMessagesWithReactions<
     direction,
     excludeContentTypes,
     excludeSenderInboxIds,
+    insertedAfterNs,
+    insertedBeforeNs,
+    sortBy,
   })
   const messages = await XMTPModule.conversationMessagesWithReactions(
     clientInstallationId,
@@ -835,6 +851,27 @@ export async function conversationMessagesWithReactions<
   return messages.map((json: string) => {
     return DecodedMessage.from(json)
   })
+}
+
+export async function countMessages(
+  clientInstallationId: InstallationId,
+  conversationId: ConversationId,
+  beforeNs?: number | undefined,
+  afterNs?: number | undefined,
+  insertedAfterNs?: number | undefined,
+  insertedBeforeNs?: number | undefined
+): Promise<number> {
+  const queryParamsJson = JSON.stringify({
+    beforeNs,
+    afterNs,
+    insertedAfterNs,
+    insertedBeforeNs,
+  })
+  return await XMTPModule.countMessages(
+    clientInstallationId,
+    conversationId,
+    queryParamsJson
+  )
 }
 
 export async function findMessage<
@@ -1906,7 +1943,11 @@ export {
   ConversationTopic,
   ConversationFilterType,
 } from './lib/types/ConversationOptions'
-export { MessageId, MessageOrder } from './lib/types/MessagesOptions'
+export {
+  MessageId,
+  MessageOrder,
+  MessageSortBy,
+} from './lib/types/MessagesOptions'
 export { DecodedMessageUnion } from './lib/types/DecodedMessageUnion'
 export { DisappearingMessageSettings } from './lib/DisappearingMessageSettings'
 export { PublicIdentity } from './lib/PublicIdentity'

--- a/src/lib/DecodedMessage.ts
+++ b/src/lib/DecodedMessage.ts
@@ -29,6 +29,7 @@ export class DecodedMessage<
   contentTypeId: string
   senderInboxId: InboxId
   sentNs: number // timestamp in nanoseconds
+  insertedAtNs: number // timestamp when inserted into local db in nanoseconds
   nativeContent: NativeMessageContent
   fallback: string | undefined
   deliveryStatus: MessageDeliveryStatus = MessageDeliveryStatus.PUBLISHED
@@ -56,6 +57,7 @@ export class DecodedMessage<
       decoded.contentTypeId,
       decoded.senderInboxId,
       decoded.sentNs,
+      decoded.insertedAtNs,
       decoded.content,
       decoded.fallback,
       decoded.deliveryStatus,
@@ -72,6 +74,7 @@ export class DecodedMessage<
     contentTypeId: string
     senderInboxId: InboxId
     sentNs: number // timestamp in nanoseconds
+    insertedAtNs?: number // timestamp when inserted into local db in nanoseconds
     content: any
     fallback: string | undefined
     deliveryStatus: MessageDeliveryStatus | undefined
@@ -82,6 +85,7 @@ export class DecodedMessage<
       object.contentTypeId,
       object.senderInboxId,
       object.sentNs,
+      object.insertedAtNs ?? object.sentNs,
       object.content,
       object.fallback,
       object.deliveryStatus
@@ -94,6 +98,7 @@ export class DecodedMessage<
     contentTypeId: string,
     senderInboxId: InboxId,
     sentNs: number,
+    insertedAtNs: number,
     content: any,
     fallback: string | undefined,
     deliveryStatus: MessageDeliveryStatus = MessageDeliveryStatus.PUBLISHED,
@@ -104,6 +109,7 @@ export class DecodedMessage<
     this.contentTypeId = contentTypeId
     this.senderInboxId = senderInboxId
     this.sentNs = sentNs
+    this.insertedAtNs = insertedAtNs
     this.nativeContent = content
     // undefined comes back as null when bridged, ensure undefined so integrators don't have to add a new check for null as well
     this.fallback = fallback ?? undefined

--- a/src/lib/Dm.ts
+++ b/src/lib/Dm.ts
@@ -214,7 +214,10 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
       opts?.afterNs,
       opts?.direction,
       opts?.excludeContentTypes,
-      opts?.excludeSenderInboxIds
+      opts?.excludeSenderInboxIds,
+      opts?.insertedAfterNs,
+      opts?.insertedBeforeNs,
+      opts?.sortBy
     )
   }
 
@@ -240,7 +243,35 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
       opts?.afterNs,
       opts?.direction,
       opts?.excludeContentTypes,
-      opts?.excludeSenderInboxIds
+      opts?.excludeSenderInboxIds,
+      opts?.insertedAfterNs,
+      opts?.insertedBeforeNs,
+      opts?.sortBy
+    )
+  }
+
+  /**
+   * Returns the count of messages in the dm.
+   *
+   * @param {number | undefined} beforeNs - Optional filter for messages before this timestamp.
+   * @param {number | undefined} afterNs - Optional filter for messages after this timestamp.
+   * @param {number | undefined} insertedAfterNs - Optional filter for messages inserted after this timestamp.
+   * @param {number | undefined} insertedBeforeNs - Optional filter for messages inserted before this timestamp.
+   * @returns {Promise<number>} A Promise that resolves to the count of messages.
+   */
+  async countMessages(
+    beforeNs?: number,
+    afterNs?: number,
+    insertedAfterNs?: number,
+    insertedBeforeNs?: number
+  ): Promise<number> {
+    return await XMTP.countMessages(
+      this.client.installationId,
+      this.id,
+      beforeNs,
+      afterNs,
+      insertedAfterNs,
+      insertedBeforeNs
     )
   }
 

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -240,7 +240,10 @@ export class Group<
       opts?.afterNs,
       opts?.direction,
       opts?.excludeContentTypes,
-      opts?.excludeSenderInboxIds
+      opts?.excludeSenderInboxIds,
+      opts?.insertedAfterNs,
+      opts?.insertedBeforeNs,
+      opts?.sortBy
     )
   }
 
@@ -267,7 +270,35 @@ export class Group<
       opts?.afterNs,
       opts?.direction,
       opts?.excludeContentTypes,
-      opts?.excludeSenderInboxIds
+      opts?.excludeSenderInboxIds,
+      opts?.insertedAfterNs,
+      opts?.insertedBeforeNs,
+      opts?.sortBy
+    )
+  }
+
+  /**
+   * Returns the count of messages in the group.
+   *
+   * @param {number | undefined} beforeNs - Optional filter for messages before this timestamp.
+   * @param {number | undefined} afterNs - Optional filter for messages after this timestamp.
+   * @param {number | undefined} insertedAfterNs - Optional filter for messages inserted after this timestamp.
+   * @param {number | undefined} insertedBeforeNs - Optional filter for messages inserted before this timestamp.
+   * @returns {Promise<number>} A Promise that resolves to the count of messages.
+   */
+  async countMessages(
+    beforeNs?: number,
+    afterNs?: number,
+    insertedAfterNs?: number,
+    insertedBeforeNs?: number
+  ): Promise<number> {
+    return await XMTP.countMessages(
+      this.client.installationId,
+      this.id,
+      beforeNs,
+      afterNs,
+      insertedAfterNs,
+      insertedBeforeNs
     )
   }
 

--- a/src/lib/types/MessagesOptions.ts
+++ b/src/lib/types/MessagesOptions.ts
@@ -5,7 +5,11 @@ export type MessagesOptions = {
   direction?: MessageOrder | undefined
   excludeContentTypes?: string[] | undefined
   excludeSenderInboxIds?: string[] | undefined
+  insertedAfterNs?: number | undefined
+  insertedBeforeNs?: number | undefined
+  sortBy?: MessageSortBy | undefined
 }
 
 export type MessageOrder = 'ASCENDING' | 'DESCENDING'
+export type MessageSortBy = 'SENT' | 'INSERTED'
 export type MessageId = string & { readonly brand: unique symbol }


### PR DESCRIPTION
### TL;DR

Update XMTP SDK to support message sorting by insertion time and message counting functionality.

### What changed?

- Updated XMTP native dependencies:
  - Android: `org.xmtp:android:4.6.1-rc1` → `4.7.0-dev.252eebc`
  - iOS: `XMTP: 4.6.1-rc3` → `4.7.0-dev.ff66c0f`
- Added support for sorting messages by insertion time with new parameters:
  - `insertedAfterNs`
  - `insertedBeforeNs`
  - `sortBy` (with options `SENT` or `INSERTED`)
- Added `insertedAtNs` field to message objects
- Implemented new `countMessages` function to get message counts without fetching full messages
- Updated message query interfaces across Android and iOS implementations

### How to test?

1. Test the new message sorting functionality:
```typescript
// Sort by insertion time
const messages = await conversation.messages({
  sortBy: "INSERTED",
  insertedAfterNs: timestamp1,
  insertedBeforeNs: timestamp2
});
```

2. Test the new message counting functionality:
```typescript
// Count messages in a conversation
const count = await conversation.countMessages(
  beforeNs, // optional
  afterNs, // optional
  insertedAfterNs, // optional
  insertedBeforeNs // optional
);
```

3. Verify that the `insertedAtNs` field is available on message objects:
```typescript
const message = await conversation.messages({ limit: 1 });
console.log(message[0].insertedAtNs);
```

### Why make this change?

This change provides developers with more flexibility in how they query and display messages:

1. Sorting by insertion time allows for more accurate chronological display of messages as they were received by the client, rather than when they were sent.

2. The message counting functionality enables pagination and UI features that need to know the total count without fetching all messages, improving performance for conversations with many messages.

3. The `insertedAtNs` timestamp provides additional metadata that can be useful for tracking when messages were actually received by the client versus when they were sent.