### PR TITLE
Release v1.6.1 of libxmtp

### DIFF
--- a/.changeset/fluffy-balloons-search.md
+++ b/.changeset/fluffy-balloons-search.md
@@ -1,0 +1,7 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Updates to `libxmtp` v1.6.1 which includes many features and enhancements
+
+https://github.com/xmtp/libxmtp/releases/tag/v1.6.1

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.6.1-rc4"
+  implementation "org.xmtp:android:4.6.1"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.6.1-rc1"
+  implementation "org.xmtp:android:4.6.1-rc4"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1757,16 +1757,16 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.6.1-rc4):
+  - XMTP (4.6.1):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (5.1.0-rc4):
+  - XMTPReactNative (5.1.0):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.6.1-rc4)
+    - XMTP (= 4.6.1)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2179,8 +2179,8 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: e4701b82535b8d813763bddda9daf6855a09ff2d
-  XMTPReactNative: 55345cbed899890f5fb324750252d3310c4dfd91
+  XMTP: 4585965d1df0e575bf58fdd359d095b53523a5fd
+  XMTPReactNative: ada2f52cd459a68b0ffbcc8a5221b0ac69feca69
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 5b1b93f724b9cde6043d1824960f7bfd9a7973cd

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1757,16 +1757,16 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.28.2)
-  - XMTP (4.6.1-rc3):
+  - XMTP (4.6.1-rc4):
     - Connect-Swift (= 1.0.0)
     - CryptoSwift (= 1.8.3)
     - SQLCipher (= 4.5.7)
-  - XMTPReactNative (5.0.6):
+  - XMTPReactNative (5.1.0-rc4):
     - CSecp256k1 (~> 0.2)
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.6.1-rc3)
+    - XMTP (= 4.6.1-rc4)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2179,8 +2179,8 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: d9e99e75df20472dd4845f5b9f0476e4748d1fd6
-  XMTPReactNative: ae7fe2223f35aae19235a1c792f3035f8ff70cb9
+  XMTP: e4701b82535b8d813763bddda9daf6855a09ff2d
+  XMTPReactNative: 55345cbed899890f5fb324750252d3310c4dfd91
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
 PODFILE CHECKSUM: 5b1b93f724b9cde6043d1824960f7bfd9a7973cd

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.6.1-rc4"
+  s.dependency "XMTP", "= 4.6.1"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.6.1-rc3"
+  s.dependency "XMTP", "= 4.6.1-rc4"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/react-native-sdk",
-  "version": "5.1.0-rc1",
+  "version": "5.1.0-rc4",
   "description": "Wraps for native xmtp sdks for react native",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/react-native-sdk",
-  "version": "5.1.0-rc4",
+  "version": "5.1.0",
   "description": "Wraps for native xmtp sdks for react native",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update Android and iOS dependencies to XMTP 4.6.1 and bump package version to 5.1.0 for libxmtp v1.6.1 release
Switch Android Gradle and iOS Podspec to the stable `XMTP 4.6.1`, refresh `Podfile.lock`, and set `package.json` version to `5.1.0`. Add a changeset entry marking a patch release and linking libxmtp v1.6.1 notes.

#### 📍Where to Start
Start with dependency updates in [android/build.gradle](https://github.com/xmtp/xmtp-react-native/pull/754/files#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65a) and [ios/XMTPReactNative.podspec](https://github.com/xmtp/xmtp-react-native/pull/754/files#diff-436d31ee6882beb1548e398c63630ce3110bd3ae1ae8132f62d86d343c643eb3); then verify lockfile changes in [example/ios/Podfile.lock](https://github.com/xmtp/xmtp-react-native/pull/754/files#diff-b2790cc3d555682b207af1ca2fb897ebd2114c01149bf460fd85fc2b1503a687) and version bump in [package.json](https://github.com/xmtp/xmtp-react-native/pull/754/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 93a512b.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->