### PR TITLE
Prepare v1.6.6 release

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.6.4"
+  implementation "org.xmtp:android:4.6.6"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.6.4"
+  s.dependency "XMTP", "= 4.6.6"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/react-native-sdk",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "Wraps for native xmtp sdks for react native",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
### TL;DR

Upgraded XMTP Android SDK from version 4.6.4 to 4.6.6.

### What changed?

Updated the XMTP Android SDK dependency in the `android/build.gradle` file from version 4.6.4 to 4.6.6.

### How to test?

1. Build the Android application
2. Verify that XMTP functionality works as expected
3. Check for any compatibility issues with the new SDK version

### Why make this change?

To incorporate the latest improvements, bug fixes, and features from the XMTP Android SDK. This update ensures the application stays current with the latest SDK capabilities and security updates.