### PR TITLE
deleteMessage, prepareMessage noSend, streamMessageDeletions (libxmtp 1.9.0 updates)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,19 +95,19 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "org.xmtp:android:4.6.1"
+  // implementation "org.xmtp:android:4.6.1"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"
   // xmtp-android local testing setup below (comment org.xmtp:android above)
-  // implementation files('<PATH_TO_XMTP_ANDROID>/xmtp-android/library/build/outputs/aar/library-debug.aar')
-  // implementation 'com.google.crypto.tink:tink-android:1.8.0'
-  // implementation 'io.grpc:grpc-kotlin-stub:1.4.1'
-  // implementation 'io.grpc:grpc-okhttp:1.62.2'
-  // implementation 'io.grpc:grpc-protobuf-lite:1.62.2'
-  // implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0'
-  // implementation 'org.web3j:crypto:4.9.4'
-  // implementation "net.java.dev.jna:jna:5.17.0@aar"
-  // api 'com.google.protobuf:protobuf-kotlin-lite:3.22.3'
-  // api 'org.xmtp:proto-kotlin:3.72.4'
+  implementation files('/Users/cameronvoell/XMTP/xmtp-android/library/build/outputs/aar/library-debug.aar')
+  implementation 'com.google.crypto.tink:tink-android:1.8.0'
+  implementation 'io.grpc:grpc-kotlin-stub:1.4.1'
+  implementation 'io.grpc:grpc-okhttp:1.62.2'
+  implementation 'io.grpc:grpc-protobuf-lite:1.62.2'
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0'
+  implementation 'org.web3j:crypto:4.9.4'
+  implementation "net.java.dev.jna:jna:5.17.0@aar"
+  api 'com.google.protobuf:protobuf-kotlin-lite:3.22.3'
+  api 'org.xmtp:proto-kotlin:3.88.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,19 +95,19 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  // implementation "org.xmtp:android:4.6.1"
+  implementation "org.xmtp:android:4.9.0"
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation 'com.facebook.react:react-native:0.71.3'
   implementation "com.daveanthonythomas.moshipack:moshipack:1.0.1"
   // xmtp-android local testing setup below (comment org.xmtp:android above)
-  implementation files('/Users/cameronvoell/XMTP/xmtp-android/library/build/outputs/aar/library-debug.aar')
-  implementation 'com.google.crypto.tink:tink-android:1.8.0'
-  implementation 'io.grpc:grpc-kotlin-stub:1.4.1'
-  implementation 'io.grpc:grpc-okhttp:1.62.2'
-  implementation 'io.grpc:grpc-protobuf-lite:1.62.2'
-  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0'
-  implementation 'org.web3j:crypto:4.9.4'
-  implementation "net.java.dev.jna:jna:5.17.0@aar"
-  api 'com.google.protobuf:protobuf-kotlin-lite:3.22.3'
-  api 'org.xmtp:proto-kotlin:3.88.0'
+  // implementation files('<PATH_TO_XMTP_ANDROID>/xmtp-android/library/build/outputs/aar/library-debug.aar')
+  // implementation 'com.google.crypto.tink:tink-android:1.8.0'
+  // implementation 'io.grpc:grpc-kotlin-stub:1.4.1'
+  // implementation 'io.grpc:grpc-okhttp:1.62.2'
+  // implementation 'io.grpc:grpc-protobuf-lite:1.62.2'
+  // implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0'
+  // implementation 'org.web3j:crypto:4.9.4'
+  // implementation "net.java.dev.jna:jna:5.17.0@aar"
+  // api 'com.google.protobuf:protobuf-kotlin-lite:3.22.3'
+  // api 'org.xmtp:proto-kotlin:3.88.0'
 }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -1424,6 +1424,14 @@ class XMTPModule : Module() {
             }
         }
 
+        AsyncFunction("sendSyncRequest") Coroutine { installationId: String ->
+            withContext(Dispatchers.IO) {
+                logV("sendSyncRequest")
+                val client = clients[installationId] ?: throw XMTPException("No client")
+                client.sendSyncRequest()
+            }
+        }
+
         AsyncFunction("syncAllConversations") Coroutine { installationId: String, consentStringStates: List<String>? ->
             withContext(Dispatchers.IO) {
                 logV("syncAllConversations")

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -238,7 +238,6 @@ class XMTPModule : Module() {
             dbDirectory = authOptions.dbDirectory,
             historySyncUrl = historySyncUrl,
             deviceSyncEnabled = authOptions.deviceSyncEnabled,
-            debugEventsEnabled = authOptions.debugEventsEnabled,
             forkRecoveryOptions = authOptions.forkRecoveryOptions
         )
     }
@@ -584,7 +583,7 @@ class XMTPModule : Module() {
                 logV("ffiRevokeAllOtherInstallationsSignatureText")
                 val client = clients[installationId] ?: throw XMTPException("No client")
                 val sigRequest = client.ffiRevokeAllOtherInstallations()
-                sigRequest.let {
+                sigRequest?.let {
                     clientSignatureRequests[installationId] = it
                     it.signatureText()
                 }
@@ -2017,15 +2016,6 @@ class XMTPModule : Module() {
             withContext(Dispatchers.IO) {
                 val client = clients[installationId] ?: throw XMTPException("No client")
                 client.debugInformation.clearAllStatistics()
-            }
-        }
-
-        AsyncFunction("uploadDebugInformation") Coroutine { installationId: String, serverUrl: String? ->
-            withContext(Dispatchers.IO) {
-                val client = clients[installationId] ?: throw XMTPException("No client")
-                serverUrl.takeUnless { it.isNullOrBlank() }?.let {
-                    client.debugInformation.uploadDebugInformation(it)
-                } ?: client.debugInformation.uploadDebugInformation()
             }
         }
 

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -1145,6 +1145,16 @@ class XMTPModule : Module() {
             }
         }
 
+        AsyncFunction("publishMessage") Coroutine { installationId: String, id: String, messageId: String ->
+            withContext(Dispatchers.IO) {
+                logV("publishMessage")
+                val client = clients[installationId] ?: throw XMTPException("No client")
+                val conversation = client.conversations.findConversation(id)
+                    ?: throw XMTPException("no conversation found for $id")
+                conversation.publishMessage(messageId)
+            }
+        }
+
         AsyncFunction("publishPreparedMessages") Coroutine { installationId: String, id: String ->
             withContext(Dispatchers.IO) {
                 logV("publishPreparedMessages")
@@ -1155,7 +1165,7 @@ class XMTPModule : Module() {
             }
         }
 
-        AsyncFunction("prepareMessage") Coroutine { installationId: String, id: String, contentJson: String ->
+        AsyncFunction("prepareMessage") Coroutine { installationId: String, id: String, contentJson: String, noSend: Boolean ->
             withContext(Dispatchers.IO) {
                 logV("prepareMessage")
                 val client = clients[installationId] ?: throw XMTPException("No client")
@@ -1164,12 +1174,13 @@ class XMTPModule : Module() {
                 val sending = ContentJson.fromJson(contentJson)
                 conversation.prepareMessage(
                     content = sending.content,
-                    options = SendOptions(contentType = sending.type)
+                    options = SendOptions(contentType = sending.type),
+                    noSend = noSend
                 )
             }
         }
 
-        AsyncFunction("prepareEncodedMessage") Coroutine { installationId: String, conversationId: String, encodedContentData: List<Int>, shouldPush: Boolean ->
+        AsyncFunction("prepareEncodedMessage") Coroutine { installationId: String, conversationId: String, encodedContentData: List<Int>, shouldPush: Boolean, noSend: Boolean ->
             withContext(Dispatchers.IO) {
                 logV("prepareEncodedMessage")
                 val client = clients[installationId] ?: throw XMTPException("No client")
@@ -1185,7 +1196,7 @@ class XMTPModule : Module() {
                         }
                     }
                 val encodedContent = EncodedContent.parseFrom(encodedContentDataBytes)
-                conversation.prepareMessage(encodedContent = encodedContent, opts = MessageVisibilityOptions(shouldPush))
+                conversation.prepareMessage(encodedContent = encodedContent, opts = MessageVisibilityOptions(shouldPush), noSend = noSend)
             }
         }
 
@@ -1234,7 +1245,8 @@ class XMTPModule : Module() {
                     createGroupParams.groupName,
                     createGroupParams.groupImageUrl,
                     createGroupParams.groupDescription,
-                    createGroupParams.disappearingMessageSettings
+                    createGroupParams.disappearingMessageSettings,
+                    createGroupParams.appData
                 )
                 GroupWrapper.encode(client, group)
             }
@@ -1256,7 +1268,8 @@ class XMTPModule : Module() {
                     createGroupParams.groupName,
                     createGroupParams.groupImageUrl,
                     createGroupParams.groupDescription,
-                    createGroupParams.disappearingMessageSettings
+                    createGroupParams.disappearingMessageSettings,
+                    createGroupParams.appData
                 )
                 GroupWrapper.encode(client, group)
             }
@@ -1280,7 +1293,8 @@ class XMTPModule : Module() {
                     createGroupParams.groupName,
                     createGroupParams.groupImageUrl,
                     createGroupParams.groupDescription,
-                    createGroupParams.disappearingMessageSettings
+                    createGroupParams.disappearingMessageSettings,
+                    createGroupParams.appData
                 )
                 GroupWrapper.encode(client, group)
             }
@@ -1304,7 +1318,8 @@ class XMTPModule : Module() {
                     createGroupParams.groupName,
                     createGroupParams.groupImageUrl,
                     createGroupParams.groupDescription,
-                    createGroupParams.disappearingMessageSettings
+                    createGroupParams.disappearingMessageSettings,
+                    createGroupParams.appData
                 )
                 GroupWrapper.encode(client, group)
             }
@@ -1325,7 +1340,8 @@ class XMTPModule : Module() {
                     createGroupParams.groupName,
                     createGroupParams.groupImageUrl,
                     createGroupParams.groupDescription,
-                    createGroupParams.disappearingMessageSettings
+                    createGroupParams.disappearingMessageSettings,
+                    createGroupParams.appData
                 )
                 GroupWrapper.encode(client, group)
             }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt
@@ -1886,6 +1886,16 @@ class XMTPModule : Module() {
             }
         }
 
+        AsyncFunction("deleteMessage") Coroutine { clientInstallationId: String, conversationId: String, messageId: String ->
+            withContext(Dispatchers.IO) {
+                logV("deleteMessage")
+                val client = clients[clientInstallationId] ?: throw XMTPException("No client")
+                val conversation = client.conversations.findConversation(conversationId)
+                    ?: throw XMTPException("no conversation found for $conversationId")
+                conversation.deleteMessage(messageId)
+            }
+        }
+
         Function("subscribeToPreferenceUpdates") { installationId: String ->
             logV("subscribeToPreferenceUpdates")
 
@@ -2329,7 +2339,6 @@ class XMTPModule : Module() {
 
     private fun subscribeToMessageDeletions(installationId: String) {
         val client = clients[installationId] ?: throw XMTPException("No client")
-
         subscriptions[getMessageDeletionsCacheKey(installationId)]?.cancel()
         subscriptions[getMessageDeletionsCacheKey(installationId)] =
             CoroutineScope(Dispatchers.IO).launch {

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
@@ -144,14 +144,14 @@ class ContentJson(
                 )
             } else if (obj.has("reactionV2")) {
                 val reaction = obj.get("reactionV2").asJsonObject
+                // Use SDK Reaction type (not FfiReactionPayload); ReactionV2Codec encodes Reaction.
                 return ContentJson(
-                    ContentTypeReactionV2, FfiReactionPayload(
+                    ContentTypeReactionV2, Reaction(
                         reference = reaction.get("reference").asString,
-                        action = getReactionV2Action(reaction.get("action").asString.lowercase()),
-                        schema = getReactionV2Schema(reaction.get("schema").asString.lowercase()),
+                        action = getReactionAction(reaction.get("action").asString.lowercase()),
+                        schema = getReactionSchema(reaction.get("schema").asString.lowercase()),
                         content = reaction.get("content").asString,
-                        // Update if we add referenceInboxId to ../src/lib/types/ContentCodec.ts#L19-L24
-                        referenceInboxId = ""
+                        referenceInboxId = reaction.get("referenceInboxId")?.asString ?: ""
                     )
                 )
             } else if (obj.has("reply")) {

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
@@ -27,7 +27,10 @@ import org.xmtp.android.library.codecs.MultiRemoteAttachment
 import org.xmtp.android.library.codecs.Reaction
 import org.xmtp.android.library.codecs.ReactionCodec
 import org.xmtp.android.library.codecs.ReactionV2Codec
+import org.xmtp.android.library.codecs.ContentTypeDeleteMessageRequest
 import org.xmtp.android.library.codecs.ContentTypeLeaveRequest
+import org.xmtp.android.library.codecs.DeleteMessageCodec
+import org.xmtp.android.library.codecs.DeleteMessageRequest
 import org.xmtp.android.library.codecs.LeaveRequest
 import org.xmtp.android.library.codecs.LeaveRequestCodec
 import org.xmtp.android.library.codecs.ReadReceipt
@@ -75,7 +78,7 @@ class ContentJson(
             Client.register(GroupUpdatedCodec())
             Client.register(ReactionV2Codec())
             Client.register(LeaveRequestCodec())
-//            Client.register(DeleteMessageCodec())
+            Client.register(DeleteMessageCodec())
         }
 
         fun fromJsonObject(obj: JsonObject): ContentJson {
@@ -293,11 +296,11 @@ class ContentJson(
                 )
             )
 
-//            ContentTypeDeleteMessage.id -> mapOf(
-//                "deleteMessage" to mapOf(
-//                    "messageId" to ((content as? DeleteMessage)?.messageId ?: "")
-//                )
-//            )
+           ContentTypeDeleteMessageRequest.id -> mapOf(
+               "deleteMessage" to mapOf(
+                   "messageId" to ((content as? DeleteMessageRequest)?.messageId ?: "")
+               )
+           )
 
             else -> {
                 val json = JsonObject()

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
@@ -27,6 +27,9 @@ import org.xmtp.android.library.codecs.MultiRemoteAttachment
 import org.xmtp.android.library.codecs.Reaction
 import org.xmtp.android.library.codecs.ReactionCodec
 import org.xmtp.android.library.codecs.ReactionV2Codec
+import org.xmtp.android.library.codecs.ContentTypeLeaveRequest
+import org.xmtp.android.library.codecs.LeaveRequest
+import org.xmtp.android.library.codecs.LeaveRequestCodec
 import org.xmtp.android.library.codecs.ReadReceipt
 import org.xmtp.android.library.codecs.ReadReceiptCodec
 import org.xmtp.android.library.codecs.RemoteAttachment
@@ -71,6 +74,8 @@ class ContentJson(
             Client.register(ReadReceiptCodec())
             Client.register(GroupUpdatedCodec())
             Client.register(ReactionV2Codec())
+            Client.register(LeaveRequestCodec())
+            Client.register(DeleteMessageCodec())
         }
 
         fun fromJsonObject(obj: JsonObject): ContentJson {
@@ -279,6 +284,18 @@ class ContentJson(
                             "fieldName" to it.fieldName,
                         )
                     },
+                )
+            )
+
+            ContentTypeLeaveRequest.id -> mapOf(
+                "leaveRequest" to mapOf(
+                    "authenticatedNote" to ((content as? LeaveRequest)?.authenticatedNote ?: "")
+                )
+            )
+
+            ContentTypeDeleteMessage.id -> mapOf(
+                "deleteMessage" to mapOf(
+                    "messageId" to ((content as? DeleteMessage)?.messageId ?: "")
                 )
             )
 

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt
@@ -151,7 +151,7 @@ class ContentJson(
                         action = getReactionAction(reaction.get("action").asString.lowercase()),
                         schema = getReactionSchema(reaction.get("schema").asString.lowercase()),
                         content = reaction.get("content").asString,
-                        referenceInboxId = reaction.get("referenceInboxId")?.asString ?: ""
+                        referenceInboxId = reaction.get("referenceInboxId")?.takeIf { !it.isJsonNull }?.asString ?: ""
                     )
                 )
             } else if (obj.has("reply")) {

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJsonV2.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJsonV2.kt
@@ -11,6 +11,7 @@ import org.xmtp.android.library.Client
 import org.xmtp.android.library.codecs.Attachment
 import org.xmtp.android.library.codecs.AttachmentCodec
 import org.xmtp.android.library.codecs.ContentTypeAttachment
+import org.xmtp.android.library.codecs.ContentTypeDeleteMessageRequest
 import org.xmtp.android.library.codecs.ContentTypeGroupUpdated
 import org.xmtp.android.library.codecs.ContentTypeId
 import org.xmtp.android.library.codecs.ContentTypeMultiRemoteAttachment
@@ -28,6 +29,8 @@ import org.xmtp.android.library.codecs.Reaction
 import org.xmtp.android.library.codecs.ReactionCodec
 import org.xmtp.android.library.codecs.ReactionV2Codec
 import org.xmtp.android.library.codecs.ContentTypeLeaveRequest
+import org.xmtp.android.library.codecs.DeleteMessageCodec
+import org.xmtp.android.library.codecs.DeleteMessageRequest
 import org.xmtp.android.library.codecs.LeaveRequest
 import org.xmtp.android.library.codecs.LeaveRequestCodec
 import org.xmtp.android.library.codecs.ReadReceipt
@@ -70,7 +73,7 @@ class ContentJsonV2(
             Client.register(GroupUpdatedCodec())
             Client.register(ReactionV2Codec())
             Client.register(LeaveRequestCodec())
-//            Client.register(DeleteMessageCodec())
+            Client.register(DeleteMessageCodec())
         }
 
         fun fromJsonObject(obj: JsonObject): ContentJson {
@@ -311,11 +314,14 @@ class ContentJsonV2(
                 )
             }
 
-//            ContentTypeDeleteMessage.id -> mapOf(
-//                "deleteMessage" to mapOf(
-//                    "messageId" to ((content as? DeleteMessage)?.messageId ?: "")
-//                )
-//            )
+           ContentTypeDeleteMessageRequest.id -> {
+               val content: DeleteMessageRequest? = message.content<DeleteMessageRequest>()
+               mapOf(
+                   "deleteMessage" to mapOf(
+                       "messageId" to ((content as? DeleteMessageRequest)?.messageId ?: "")
+                   )
+               )
+           }
 
             else -> {
                 // Fallback for unhandled content types

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJsonV2.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJsonV2.kt
@@ -38,12 +38,14 @@ import org.xmtp.android.library.codecs.MultiRemoteAttachmentCodec
 import org.xmtp.android.library.codecs.RemoteAttachmentInfo
 import org.xmtp.android.library.codecs.Reply
 import org.xmtp.android.library.codecs.ReplyCodec
+import org.xmtp.android.library.libxmtp.Reply as LibxmtpReply
 import org.xmtp.android.library.codecs.TextCodec
 import org.xmtp.android.library.codecs.decoded
 import org.xmtp.android.library.codecs.description
 import org.xmtp.android.library.codecs.getReactionAction
 import org.xmtp.android.library.codecs.getReactionSchema
 import org.xmtp.android.library.codecs.id
+import org.xmtp.android.library.libxmtp.DecodedMessageV2
 import uniffi.xmtpv3.FfiMultiRemoteAttachment
 import uniffi.xmtpv3.FfiReactionAction
 import uniffi.xmtpv3.FfiReactionPayload
@@ -52,16 +54,9 @@ import uniffi.xmtpv3.decodeMultiRemoteAttachment
 import uniffi.xmtpv3.decodeReaction
 import java.net.URL
 
-class ContentJson(
-    val type: ContentTypeId,
-    val content: Any?,
-    private val encodedContent: EncodedContent? = null,
+class ContentJsonV2(
+    val message: DecodedMessageV2
 ) {
-    constructor(encoded: EncodedContent) : this(
-        type = encoded.type,
-        content = encoded.decoded(),
-        encodedContent = encoded
-    );
 
     companion object {
         init {
@@ -183,115 +178,138 @@ class ContentJson(
         fun bytesTo64(bytes: ByteArray): String = Base64.encodeToString(bytes, Base64.NO_WRAP)
     }
 
-    fun toJsonMap(): Map<String, Any> {
-        return when (type.id) {
+    fun toJsonMap(): Map<String, Any?> {
+        return when (message.contentTypeId.id) {
             ContentTypeText.id -> mapOf(
-                "text" to (content as String? ?: ""),
+                "text" to (message.content<String>()  ?: ""),
             )
 
-            ContentTypeAttachment.id -> mapOf(
-                "attachment" to mapOf(
-                    "filename" to (content as Attachment).filename,
-                    "mimeType" to content.mimeType,
-                    "data" to bytesTo64(content.data.toByteArray()),
+            ContentTypeAttachment.id -> {
+                val content: Attachment? = message.content<Attachment>()
+                return mapOf(
+                    "attachment" to mapOf(
+                        "filename" to content?.filename,
+                        "mimeType" to content?.mimeType,
+                        "data" to (content?.data?.toByteArray()?.let { bytesTo64(it) } ?: ""),
+                    )
                 )
-            )
+            }
 
-            ContentTypeRemoteAttachment.id -> mapOf(
-                "remoteAttachment" to mapOf(
-                    "scheme" to "https://",
-                    "url" to (content as RemoteAttachment).url.toString(),
-                ) + EncryptedAttachmentMetadata
-                    .fromRemoteAttachment(content)
-                    .toJsonMap()
-            )
+            ContentTypeRemoteAttachment.id -> {
+                val content: RemoteAttachment? = message.content<RemoteAttachment>()
+                if (content != null) {
+                    mapOf(
+                        "remoteAttachment" to mapOf(
+                            "scheme" to "https://",
+                            "url" to content.url.toString(),
+                        ) + EncryptedAttachmentMetadata
+                            .fromRemoteAttachment(content)
+                            .toJsonMap()
+                    )
+                } else {
+                    mapOf("remoteAttachment" to null)
+                }
+            }
 
             ContentTypeMultiRemoteAttachment.id -> {
-                 val multiRemoteAttachment: FfiMultiRemoteAttachment = decodeMultiRemoteAttachment(encodedContent!!.toByteArray())
-                 val attachmentMaps = multiRemoteAttachment.attachments.map { attachment ->
+                val multiRemoteAttachment: MultiRemoteAttachment? = message.content<MultiRemoteAttachment>()
+                val attachmentMaps = multiRemoteAttachment?.remoteAttachments?.map { attachment ->
                     mapOf(
                         "scheme" to "https://",
                         "url" to attachment.url,
                         "filename" to attachment.filename,
                         "contentLength" to attachment.contentLength.toString(),
                         "contentDigest" to attachment.contentDigest,
-                        "secret" to Hex.encodeHex(attachment.secret, false),
-                        "salt" to Hex.encodeHex(attachment.salt, false ),
-                        "nonce" to Hex.encodeHex(attachment.nonce, false)
+                        "secret" to Hex.encodeHex(attachment.secret.toByteArray(), false),
+                        "salt" to Hex.encodeHex(attachment.salt.toByteArray(), false),
+                        "nonce" to Hex.encodeHex(attachment.nonce.toByteArray(), false)
                     )
-                }
-                 mapOf(
-                     "multiRemoteAttachment" to mapOf(
-                         "attachments" to attachmentMaps
-                     )
-                 )
-            }
-
-            ContentTypeReaction.id -> mapOf(
-                "reaction" to mapOf(
-                    "reference" to (content as Reaction).reference,
-                    "action" to content.action.javaClass.simpleName.lowercase(),
-                    "schema" to content.schema.javaClass.simpleName.lowercase(),
-                    "content" to content.content,
-                )
-            )
-
-            ContentTypeReactionV2.id ->  {
-                val reaction: FfiReactionPayload = decodeReaction(encodedContent!!.toByteArray())
+                } ?: emptyList()
                 mapOf(
-                    "reaction" to mapOf(
-                        "reference" to reaction.reference,
-                        "action" to getReactionV2ActionString(reaction.action),
-                        "schema" to getReactionV2SchemaString(reaction.schema),
-                        "content" to reaction.content,
+                    "multiRemoteAttachment" to mapOf(
+                        "attachments" to attachmentMaps
                     )
                 )
             }
 
-            ContentTypeReply.id -> mapOf(
-                "reply" to mapOf(
-                    "reference" to (content as Reply).reference,
-                    "content" to ContentJson(
-                        content.contentType,
-                        content.content,
-                        encodedContent
-                    ).toJsonMap(),
-                    "contentType" to content.contentType.description
-                )
-            )
+            ContentTypeReaction.id, ContentTypeReactionV2.id -> {
+                message.content<Reaction>()?.let { content ->
+                    mapOf(
+                        "reaction" to mapOf(
+                            "reference" to content.reference,
+                            "action" to content.action.javaClass.simpleName.lowercase(),
+                            "schema" to content.schema.javaClass.simpleName.lowercase(),
+                            "content" to content.content,
+                        )
+                    )
+                } ?: mapOf("reaction" to emptyMap<String, Any>())
+            }
+
+            ContentTypeReply.id -> {
+                message.content<LibxmtpReply>()?.let { reply ->
+                    // LibxmtpReply has: referenceId, content (already decoded Any?), inReplyTo (DecodedMessageV2?)
+                    // Serialize the nested content - it's already decoded, so we need to determine its type
+                    val nestedContentMap = when (val content = reply.content) {
+                        is String -> mapOf("text" to content)
+                        else -> {
+                            // Try to serialize using Gson for complex types
+                            try {
+                                val gson = GsonBuilder().create()
+                                val jsonElement = gson.toJsonTree(content)
+                                if (jsonElement.isJsonObject) {
+                                    gson.fromJson<Map<String, Any>>(jsonElement, Map::class.java) ?: emptyMap()
+                                } else {
+                                    mapOf("content" to content.toString())
+                                }
+                            } catch (e: Exception) {
+                                mapOf("content" to content.toString())
+                            }
+                        }
+                    }
+                    mapOf(
+                        "reply" to mapOf(
+                            "reference" to reply.referenceId,
+                            "content" to nestedContentMap
+                        )
+                    )
+                } ?: mapOf("reply" to emptyMap<String, Any>())
+            }
 
             ContentTypeReadReceipt.id -> mapOf(
                 "readReceipt" to ""
             )
 
-            ContentTypeGroupUpdated.id -> mapOf(
-                "groupUpdated" to mapOf(
-                    "initiatedByInboxId" to (content as GroupUpdated).initiatedByInboxId,
-                    "membersAdded" to content.addedInboxesList.map {
-                        mapOf(
-                            "inboxId" to it.inboxId
+            ContentTypeGroupUpdated.id -> {
+                message.content<GroupUpdated>()?.let { content ->
+                    mapOf(
+                        "groupUpdated" to mapOf(
+                            "initiatedByInboxId" to content.initiatedByInboxId,
+                            "membersAdded" to content.addedInboxesList.map {
+                                mapOf("inboxId" to it.inboxId)
+                            },
+                            "membersRemoved" to content.removedInboxesList.map {
+                                mapOf("inboxId" to it.inboxId)
+                            },
+                            "metadataFieldsChanged" to content.metadataFieldChangesList.map {
+                                mapOf(
+                                    "oldValue" to it.oldValue,
+                                    "newValue" to it.newValue,
+                                    "fieldName" to it.fieldName,
+                                )
+                            },
                         )
-                    },
-                    "membersRemoved" to content.removedInboxesList.map {
-                        mapOf(
-                            "inboxId" to it.inboxId
-                        )
-                    },
-                    "metadataFieldsChanged" to content.metadataFieldChangesList.map {
-                        mapOf(
-                            "oldValue" to it.oldValue,
-                            "newValue" to it.newValue,
-                            "fieldName" to it.fieldName,
-                        )
-                    },
-                )
-            )
+                    )
+                } ?: mapOf("groupUpdated" to emptyMap<String, Any>())
+            }
 
-            ContentTypeLeaveRequest.id -> mapOf(
-                "leaveRequest" to mapOf(
-                    "authenticatedNote" to ((content as? LeaveRequest)?.authenticatedNote ?: "")
+            ContentTypeLeaveRequest.id -> {
+                val content: LeaveRequest? = message.content<LeaveRequest>()
+                mapOf(
+                    "leaveRequest" to mapOf(
+                        "authenticatedNote" to (content?.authenticatedNote ?: "")
+                    )
                 )
-            )
+            }
 
 //            ContentTypeDeleteMessage.id -> mapOf(
 //                "deleteMessage" to mapOf(
@@ -300,66 +318,41 @@ class ContentJson(
 //            )
 
             else -> {
-                val json = JsonObject()
-                encodedContent?.let {
-                    val typeJson = JsonObject()
-                    typeJson.addProperty("authorityId", encodedContent.type.authorityId)
-                    typeJson.addProperty("typeId", encodedContent.type.typeId)
-                    typeJson.addProperty("versionMajor", encodedContent.type.versionMajor)
-                    typeJson.addProperty("versionMinor", encodedContent.type.versionMinor)
-                    val parameters = GsonBuilder().create().toJson(encodedContent.parametersMap)
-
-                    json.addProperty("fallback", encodedContent.fallback)
-                    json.add("parameters", JsonParser.parseString(parameters))
-                    json.add("type", typeJson)
-                    json.addProperty("content", bytesTo64(encodedContent.content.toByteArray()))
-
-                }
-                val encodedContentJSON = json.toString()
-                if (encodedContentJSON.isNotBlank()) {
-                    mapOf("encoded" to encodedContentJSON)
+                // Fallback for unhandled content types
+                // DecodedMessageV2 doesn't expose raw encodedContent - content is already decoded via FFI
+                // Custom types are handled by FfiDecodedMessageContent.Custom -> encodedContentFromFfi
+                // This branch only hits if a new content type is added but not yet handled above
+                val content = message.content<Any>()
+                if (content != null) {
+                    // Try to serialize the decoded content using Gson
+                    try {
+                        val gson = GsonBuilder().create()
+                        val contentJson = gson.toJsonTree(content)
+                        mapOf(
+                            "unknown" to mapOf(
+                                "contentTypeId" to message.contentTypeId.description,
+                                "content" to contentJson
+                            )
+                        )
+                    } catch (e: Exception) {
+                        // Gson serialization failed, return just the type info
+                        mapOf(
+                            "unknown" to mapOf(
+                                "contentTypeId" to message.contentTypeId.description,
+                                "fallback" to (message.fallbackText ?: "Unsupported content type")
+                            )
+                        )
+                    }
                 } else {
+                    // Content decoding returned null
                     mapOf(
                         "unknown" to mapOf(
-                            "contentTypeId" to type.description
+                            "contentTypeId" to message.contentTypeId.description,
+                            "fallback" to (message.fallbackText ?: "Failed to decode content")
                         )
                     )
                 }
             }
         }
-    }
-}
-
-fun getReactionV2Schema(schema: String): FfiReactionSchema {
-    return when (schema) {
-        "unicode" -> FfiReactionSchema.UNICODE
-        "shortcode" -> FfiReactionSchema.SHORTCODE
-        "custom" -> FfiReactionSchema.CUSTOM
-        else -> FfiReactionSchema.UNKNOWN
-    }
-}
-
-fun getReactionV2Action(action: String): FfiReactionAction {
-    return when (action) {
-        "removed" -> FfiReactionAction.REMOVED
-        "added" -> FfiReactionAction.ADDED
-        else -> FfiReactionAction.UNKNOWN
-    }
-}
-
-fun getReactionV2SchemaString(schema: FfiReactionSchema): String {
-    return when (schema) {
-        FfiReactionSchema.UNICODE -> "unicode"
-        FfiReactionSchema.SHORTCODE -> "shortcode"
-        FfiReactionSchema.CUSTOM -> "custom"
-        FfiReactionSchema.UNKNOWN -> "unknown"
-    }
-}
-
-fun getReactionV2ActionString(action: FfiReactionAction): String {
-    return when (action) {
-        FfiReactionAction.REMOVED -> "removed"
-        FfiReactionAction.ADDED -> "added"
-        FfiReactionAction.UNKNOWN -> "unknown"
     }
 }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/CreateGroupParamsWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/CreateGroupParamsWrapper.kt
@@ -8,6 +8,7 @@ class CreateGroupParamsWrapper(
     val groupImageUrl: String,
     val groupDescription: String,
     val disappearingMessageSettings: DisappearingMessageSettings?,
+    val appData: String,
 ) {
     companion object {
         fun createGroupParamsFromJson(authParams: String): CreateGroupParamsWrapper {
@@ -27,7 +28,8 @@ class CreateGroupParamsWrapper(
                 if (jsonOptions.has("name")) jsonOptions.get("name").asString else "",
                 if (jsonOptions.has("imageUrl")) jsonOptions.get("imageUrl").asString else "",
                 if (jsonOptions.has("description")) jsonOptions.get("description").asString else "",
-                settings
+                settings,
+                if (jsonOptions.has("appData")) jsonOptions.get("appData").asString else "",
             )
         }
     }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/EnrichedMessageQueryParamsWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/EnrichedMessageQueryParamsWrapper.kt
@@ -1,0 +1,111 @@
+package expo.modules.xmtpreactnativesdk.wrappers
+
+import com.google.gson.JsonParser
+
+class EnrichedMessageQueryParamsWrapper(
+    val limit: Int?,
+    val beforeNs: Long?,
+    val afterNs: Long?,
+    val direction: String?,
+    val excludeSenderInboxIds: List<String>?,
+    val deliveryStatus: String?,
+    val insertedAfterNs: Long?,
+    val insertedBeforeNs: Long?,
+    val sortBy: String?,
+) {
+    companion object {
+        fun fromJson(paramsJson: String): EnrichedMessageQueryParamsWrapper {
+            if (paramsJson.isEmpty()) {
+                return EnrichedMessageQueryParamsWrapper(
+                    limit = null,
+                    beforeNs = null,
+                    afterNs = null,
+                    direction = null,
+                    excludeSenderInboxIds = null,
+                    deliveryStatus = null,
+                    insertedAfterNs = null,
+                    insertedBeforeNs = null,
+                    sortBy = null,
+                )
+            }
+
+            val jsonOptions = JsonParser.parseString(paramsJson).asJsonObject
+
+            val limit =
+                if (jsonOptions.has("limit")) {
+                    jsonOptions.get("limit").asInt
+                } else {
+                    null
+                }
+
+            val beforeNs =
+                if (jsonOptions.has("beforeNs")) {
+                    jsonOptions.get("beforeNs").asLong
+                } else {
+                    null
+                }
+
+            val afterNs =
+                if (jsonOptions.has("afterNs")) {
+                    jsonOptions.get("afterNs").asLong
+                } else {
+                    null
+                }
+
+            val direction =
+                if (jsonOptions.has("direction")) {
+                    jsonOptions.get("direction").asString
+                } else {
+                    null
+                }
+
+            val excludeSenderInboxIds =
+                if (jsonOptions.has("excludeSenderInboxIds")) {
+                    val idsArray = jsonOptions.getAsJsonArray("excludeSenderInboxIds")
+                    idsArray.map { it.asString }
+                } else {
+                    null
+                }
+
+            val deliveryStatus =
+                if (jsonOptions.has("deliveryStatus")) {
+                    jsonOptions.get("deliveryStatus").asString
+                } else {
+                    null
+                }
+
+            val insertedAfterNs =
+                if (jsonOptions.has("insertedAfterNs")) {
+                    jsonOptions.get("insertedAfterNs").asLong
+                } else {
+                    null
+                }
+
+            val insertedBeforeNs =
+                if (jsonOptions.has("insertedBeforeNs")) {
+                    jsonOptions.get("insertedBeforeNs").asLong
+                } else {
+                    null
+                }
+
+            val sortBy =
+                if (jsonOptions.has("sortBy")) {
+                    jsonOptions.get("sortBy").asString
+                } else {
+                    null
+                }
+
+            return EnrichedMessageQueryParamsWrapper(
+                limit = limit,
+                beforeNs = beforeNs,
+                afterNs = afterNs,
+                direction = direction,
+                excludeSenderInboxIds = excludeSenderInboxIds,
+                deliveryStatus = deliveryStatus,
+                insertedAfterNs = insertedAfterNs,
+                insertedBeforeNs = insertedBeforeNs,
+                sortBy = sortBy,
+            )
+        }
+    }
+}

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/MessageWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/MessageWrapper.kt
@@ -3,11 +3,18 @@ package expo.modules.xmtpreactnativesdk.wrappers
 import com.google.gson.GsonBuilder
 import org.xmtp.android.library.codecs.description
 import org.xmtp.android.library.libxmtp.DecodedMessage
+import org.xmtp.android.library.libxmtp.DecodedMessageV2
 
 class MessageWrapper {
 
     companion object {
         fun encode(model: DecodedMessage): String {
+            val gson = GsonBuilder().create()
+            val message = encodeMap(model)
+            return gson.toJson(message)
+        }
+
+        fun encode(model: DecodedMessageV2): String {
             val gson = GsonBuilder().create()
             val message = encodeMap(model)
             return gson.toJson(message)
@@ -27,6 +34,28 @@ class MessageWrapper {
                 "fallback" to fallback,
                 "deliveryStatus" to model.deliveryStatus.toString(),
                 "childMessages" to model.childMessages?.map { childMessage -> encodeMap(childMessage) }
+            )
+        }
+
+        fun encodeMap(model: DecodedMessageV2): Map<String, Any?> {
+            // reactions is List<DecodedMessageV2> (not nullable)
+            val reactions = model.reactions.map { reaction -> encodeMap(reaction) }
+            return mapOf(
+                "id" to model.id,
+                "conversationId" to model.conversationId,
+                "contentTypeId" to model.contentTypeId.description,
+                "nativeContent" to ContentJsonV2(model).toJsonMap(),
+                "senderInboxId" to model.senderInboxId,
+                "sentAt" to (model.sentAtNs / 1_000_000),
+                "sentAtNs" to model.sentAtNs,
+                "insertedAtNs" to model.insertedAtNs,
+                "expiresAtNs" to model.expiresAtNs,
+                "expiresAt" to model.expiresAt?.time,  // Date.time gives milliseconds
+                "fallbackText" to model.fallbackText,
+                "deliveryStatus" to model.deliveryStatus.toString(),
+                "reactions" to reactions,
+                "hasReactions" to model.hasReactions,
+                "reactionCount" to model.reactionCount.toLong()  // ULong -> Long for JSON
             )
         }
     }

--- a/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/PermissionPolicySetWrapper.kt
+++ b/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/PermissionPolicySetWrapper.kt
@@ -37,6 +37,7 @@ class PermissionPolicySetWrapper {
                 "updateGroupDescriptionPolicy" to fromPermissionOption(policySet.updateGroupDescriptionPolicy),
                 "updateGroupImagePolicy" to fromPermissionOption(policySet.updateGroupImagePolicy),
                 "updateMessageDisappearingPolicy" to fromPermissionOption(policySet.updateMessageDisappearingPolicy),
+                "updateAppDataPolicy" to fromPermissionOption(policySet.updateAppDataPolicy),
             )
         }
 
@@ -51,6 +52,7 @@ class PermissionPolicySetWrapper {
                 updateGroupDescriptionPolicy = createPermissionOptionFromString(jsonObj.get("updateGroupDescriptionPolicy").asString),
                 updateGroupImagePolicy = createPermissionOptionFromString(jsonObj.get("updateGroupImagePolicy").asString),
                 updateMessageDisappearingPolicy = createPermissionOptionFromString(jsonObj.get("updateMessageDisappearingPolicy").asString),
+                updateAppDataPolicy = createPermissionOptionFromString(jsonObj.get("updateAppDataPolicy").asString),
             )
         }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -65,9 +65,9 @@ PODS:
     - hermes-engine/Pre-built (= 0.76.9)
   - hermes-engine/Pre-built (0.76.9)
   - MessagePacker (0.4.7)
-  - MMKV (2.2.4):
-    - MMKVCore (~> 2.2.4)
-  - MMKVCore (2.2.4)
+  - MMKV (2.3.0):
+    - MMKVCore (~> 2.3.0)
+  - MMKVCore (2.3.0)
   - OpenSSL-Universal (3.3.3001)
   - RCT-Folly (2024.10.14.00):
     - boost
@@ -1757,7 +1757,7 @@ PODS:
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
   - SwiftProtobuf (1.30.0)
-  - XMTP (4.9.0-dev.90e114a):
+  - XMTP (4.9.0):
     - Connect-Swift (~> 1.2.0)
     - CryptoSwift (= 1.8.3)
     - SQLCipher (= 4.5.7)
@@ -1766,7 +1766,7 @@ PODS:
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.9.0-dev.90e114a)
+    - XMTP (= 4.9.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2102,8 +2102,8 @@ SPEC CHECKSUMS:
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 9e868dc7be781364296d6ee2f56d0c1a9ef0bb11
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
-  MMKV: 1a8e7dbce7f9cad02c52e1b1091d07bd843aefaf
-  MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
+  MMKV: c953dbaac0da392c24b005e763c03ce2638b4ed7
+  MMKVCore: d078dce7d6586a888b2c2ef5343b6242678e3ee8
   OpenSSL-Universal: 6082b0bf950e5636fe0d78def171184e2b3899c2
   RCT-Folly: 7b4f73a92ad9571b9dbdb05bb30fad927fa971e1
   RCTDeprecation: ebe712bb05077934b16c6bf25228bdec34b64f83
@@ -2179,8 +2179,8 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
   SwiftProtobuf: 3697407f0d5b23bedeba9c2eaaf3ec6fdff69349
-  XMTP: c921c08822265162615079094cd9698f903a67e7
-  XMTPReactNative: d0e97859fd2e721471bffc55afbd4436177bdbb8
+  XMTP: 322f5be971dca2b1f402727ffda2f62d4ab7f71d
+  XMTPReactNative: d5ad13db4801f0d3a73bf49917acea6a2cffb308
   Yoga: 40f19fff64dce86773bf8b602c7070796c007970
 
 PODFILE CHECKSUM: c76510e65e7d9673f44024ae2d0a10eec063a555

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - boost (1.84.0)
-  - Connect-Swift (1.0.0):
-    - SwiftProtobuf (~> 1.28.2)
+  - Connect-Swift (1.2.0):
+    - SwiftProtobuf (~> 1.30.0)
   - CryptoSwift (1.8.3)
   - CSecp256k1 (0.2.0)
   - DoubleConversion (1.1.6)
@@ -51,6 +51,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - ExpoSecureStore (14.0.1):
+    - ExpoModulesCore
   - ExpoSplashScreen (0.29.24):
     - ExpoModulesCore
   - ExpoSystemUI (4.0.9):
@@ -1351,8 +1353,6 @@ PODS:
     - react-native-config/App (= 1.5.5)
   - react-native-config/App (1.5.5):
     - React-Core
-  - react-native-encrypted-storage (4.0.3):
-    - React-Core
   - react-native-get-random-values (1.11.0):
     - React-Core
   - react-native-mmkv (2.12.2):
@@ -1756,9 +1756,9 @@ PODS:
   - SQLCipher/common (4.5.7)
   - SQLCipher/standard (4.5.7):
     - SQLCipher/common
-  - SwiftProtobuf (1.28.2)
-  - XMTP (4.6.1):
-    - Connect-Swift (= 1.0.0)
+  - SwiftProtobuf (1.30.0)
+  - XMTP (4.9.0-dev.90e114a):
+    - Connect-Swift (~> 1.2.0)
     - CryptoSwift (= 1.8.3)
     - SQLCipher (= 4.5.7)
   - XMTPReactNative (5.1.0):
@@ -1766,7 +1766,7 @@ PODS:
     - ExpoModulesCore
     - MessagePacker
     - SQLCipher (= 4.5.7)
-    - XMTP (= 4.6.1)
+    - XMTP (= 4.9.0-dev.90e114a)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1784,6 +1784,7 @@ DEPENDENCIES:
   - ExpoImagePicker (from `../node_modules/expo-image-picker/ios`)
   - ExpoKeepAwake (from `../node_modules/expo-keep-awake/ios`)
   - ExpoModulesCore (from `../node_modules/expo-modules-core`)
+  - ExpoSecureStore (from `../node_modules/expo-secure-store/ios`)
   - ExpoSplashScreen (from `../node_modules/expo-splash-screen/ios`)
   - ExpoSystemUI (from `../node_modules/expo-system-ui/ios`)
   - fast_float (from `../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
@@ -1824,7 +1825,6 @@ DEPENDENCIES:
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
   - react-native-blob-util (from `../node_modules/react-native-blob-util`)
   - react-native-config (from `../node_modules/react-native-config`)
-  - react-native-encrypted-storage (from `../node_modules/react-native-encrypted-storage`)
   - react-native-get-random-values (from `../node_modules/react-native-get-random-values`)
   - react-native-mmkv (from `../node_modules/react-native-mmkv`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
@@ -1911,6 +1911,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-keep-awake/ios"
   ExpoModulesCore:
     :path: "../node_modules/expo-modules-core"
+  ExpoSecureStore:
+    :path: "../node_modules/expo-secure-store/ios"
   ExpoSplashScreen:
     :path: "../node_modules/expo-splash-screen/ios"
   ExpoSystemUI:
@@ -1988,8 +1990,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-blob-util"
   react-native-config:
     :path: "../node_modules/react-native-config"
-  react-native-encrypted-storage:
-    :path: "../node_modules/react-native-encrypted-storage"
   react-native-get-random-values:
     :path: "../node_modules/react-native-get-random-values"
   react-native-mmkv:
@@ -2077,24 +2077,25 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  Connect-Swift: 84e043b904f63dc93a2c01c6c125da25e765b50d
+  Connect-Swift: 82bcc0834587bd537f17a9720f62ea9fc7d9f3a5
   CryptoSwift: 967f37cea5a3294d9cce358f78861652155be483
   CSecp256k1: 2a59c03e52637ded98896a33be4b2649392cb843
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
-  EXConstants: fcfc75800824ac2d5c592b5bc74130bad17b146b
-  EXImageLoader: e5da974e25b13585c196b658a440720c075482d5
-  Expo: 1687edb10c76b0c0f135306d6ae245379f50ed54
-  ExpoAsset: 48386d40d53a8c1738929b3ed509bcad595b5516
-  ExpoClipboard: 44fd1c8959ee8f6175d059dc011b154c9709a969
-  ExpoCrypto: e97e864c8d7b9ce4a000bca45dddb93544a1b2b4
-  ExpoDocumentPicker: 6d3d499cf15b692688a804f42927d0f35de5ebaa
-  ExpoFileSystem: 42d363d3b96f9afab980dcef60d5657a4443c655
-  ExpoFont: f354e926f8feae5e831ec8087f36652b44a0b188
-  ExpoImagePicker: 24e5ba8da111f74519b1e6dc556e0b438b2b8464
-  ExpoKeepAwake: b0171a73665bfcefcfcc311742a72a956e6aa680
-  ExpoModulesCore: 725faec070d590810d2ea5983d9f78f7cf6a38ec
-  ExpoSplashScreen: 399ee9f85b6c8a61b965e13a1ecff8384db591c2
-  ExpoSystemUI: b82a45cf0f6a4fa18d07c46deba8725dd27688b4
+  EXConstants: a1f35b9aabbb3c6791f8e67722579b1ffcdd3f18
+  EXImageLoader: 759063a65ab016b836f73972d3bb25404888713d
+  Expo: 3ddf0d76db6b3eef5d1d9f869676d3b69d95305f
+  ExpoAsset: 0687fe05f5d051c4a34dd1f9440bd00858413cfe
+  ExpoClipboard: 5250b207b6d545f4e9aac5ea3c6e61c4f16d0aed
+  ExpoCrypto: 1eaf79360c8135af1f2ebb133394fd3513ca9a3d
+  ExpoDocumentPicker: 8c1f88c2809ab2287350e8fac65964bf423578be
+  ExpoFileSystem: c8c19bf80d914c83dda3beb8569d7fb603be0970
+  ExpoFont: 773955186469acc5108ff569712a2d243857475f
+  ExpoImagePicker: 482b2a6198b365dd18b5a0cb6d4caeec880cb8e1
+  ExpoKeepAwake: 2a5f15dd4964cba8002c9a36676319a3394c85c7
+  ExpoModulesCore: c2eeb11b2fc321dfc21b892be14c124dcac0a1e8
+  ExpoSecureStore: d006eea5e316283099d46f80a6b10055b89a6008
+  ExpoSplashScreen: 1832984021b0795fda9302cf84ac62f0490eeadd
+  ExpoSystemUI: fb8213e39d19e0861320fa69eb60cad7a839c080
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 7605ea4810e0e10ae4815292433c09bf4324ba45
   fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
@@ -2104,85 +2105,84 @@ SPEC CHECKSUMS:
   MMKV: 1a8e7dbce7f9cad02c52e1b1091d07bd843aefaf
   MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
   OpenSSL-Universal: 6082b0bf950e5636fe0d78def171184e2b3899c2
-  RCT-Folly: ea9d9256ba7f9322ef911169a9f696e5857b9e17
+  RCT-Folly: 7b4f73a92ad9571b9dbdb05bb30fad927fa971e1
   RCTDeprecation: ebe712bb05077934b16c6bf25228bdec34b64f83
   RCTRequired: ca91e5dd26b64f577b528044c962baf171c6b716
   RCTTypeSafety: e7678bd60850ca5a41df9b8dc7154638cb66871f
   React: 4641770499c39f45d4e7cde1eba30e081f9d8a3d
   React-callinvoker: 4bef67b5c7f3f68db5929ab6a4d44b8a002998ea
-  React-Core: a68cea3e762814e60ecc3fa521c7f14c36c99245
-  React-CoreModules: d81b1eaf8066add66299bab9d23c9f00c9484c7c
-  React-cxxreact: 984f8b1feeca37181d4e95301fcd6f5f6501c6ab
+  React-Core: 0a06707a0b34982efc4a556aff5dae4b22863455
+  React-CoreModules: 907334e94314189c2e5eed4877f3efe7b26d85b0
+  React-cxxreact: 3a1d5e8f4faa5e09be26614e9c8bbcae8d11b73d
   React-debug: 817160c07dc8d24d020fbd1eac7b3558ffc08964
-  React-defaultsnativemodule: 21f216e8db975897eb32b5f13247f5bbfaa97f41
-  React-domnativemodule: 19270ad4b8d33312838d257f24731a0026809d49
-  React-Fabric: f6dade7007533daeb785ba5925039d83f343be4b
-  React-FabricComponents: b0655cc3e1b5ae12a4a1119aa7d8308f0ad33520
-  React-FabricImage: 9b157c4c01ac2bf433f834f0e1e5fe234113a576
+  React-defaultsnativemodule: a965cb39fb0a79276ab611793d39f52e59a9a851
+  React-domnativemodule: d647f94e503c62c44f54291334b1aa22a30fa08b
+  React-Fabric: 64586dc191fc1c170372a638b8e722e4f1d0a09b
+  React-FabricComponents: b0ebd032387468ea700574c581b139f57a7497fb
+  React-FabricImage: 81f0e0794caf25ad1224fa406d288fbc1986607f
   React-featureflags: f2792b067a351d86fdc7bec23db3b9a2f2c8d26c
-  React-featureflagsnativemodule: 3a8731d8fd9f755be57e00d9fa8a7f92aa77e87d
-  React-graphics: 68969e4e49d73f89da7abef4116c9b5f466aa121
-  React-hermes: ac0bcba26a5d288ebc99b500e1097da2d0297ddf
-  React-idlecallbacksnativemodule: 9a2c5b5c174c0c476f039bedc1b9497a8272133e
-  React-ImageManager: e906eec93a9eb6102a06576b89d48d80a4683020
-  React-jserrorhandler: ac5dde01104ff444e043cad8f574ca02756e20d6
-  React-jsi: 496fa2b9d63b726aeb07d0ac800064617d71211d
-  React-jsiexecutor: dd22ab48371b80f37a0a30d0e8915b6d0f43a893
-  React-jsinspector: 4629ac376f5765e684d19064f2093e55c97fd086
-  React-jsitracing: 7a1c9cd484248870cf660733cd3b8114d54c035f
-  React-logger: c4052eb941cca9a097ef01b59543a656dc088559
-  React-Mapbuffer: 33546a3ebefbccb8770c33a1f8a5554fa96a54de
-  React-microtasksnativemodule: 5c3d795318c22ab8df55100e50b151384a4a60b3
-  react-native-blob-util: f7234c91ad0e3faeee51b3edee80b61553f74993
-  react-native-config: 644074ab88db883fcfaa584f03520ec29589d7df
-  react-native-encrypted-storage: 569d114e329b1c2c2d9f8c84bcdbe4478dda2258
-  react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
-  react-native-mmkv: f0574e88f254d13d1a87cf6d38c36bc5d3910d49
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-quick-base64: 5565249122493bef017004646d73f918e8c2dfb0
-  react-native-quick-crypto: c168ffba24470d8edfd03961d9492638431b9869
-  react-native-randombytes: 3c8f3e89d12487fd03a2f966c288d495415fc116
-  react-native-safe-area-context: 8b8404e70b0cbf2a56428a17017c14c1dcc16448
-  react-native-sqlite-storage: 0c84826214baaa498796c7e46a5ccc9a82e114ed
-  react-native-webview: 69a5462ca94921ff695e1b52b12fffe62af7d312
+  React-featureflagsnativemodule: 95a02d895475de8ace78fedd76143866838bb720
+  React-graphics: cbebe910e4a15b65b0bff94a4d3ed278894d6386
+  React-hermes: ec18c10f5a69d49fb9b5e17ae95494e9ea13d4d3
+  React-idlecallbacksnativemodule: 0c1ae840cc5587197cd926a3cb76828ad059d116
+  React-ImageManager: f2a4c01c2ccb2193e60a20c135da74c7ca4d36f2
+  React-jserrorhandler: 61d205b5a7cbc57fed3371dd7eed48c97f49fc64
+  React-jsi: 95f7676103137861b79b0f319467627bcfa629ee
+  React-jsiexecutor: 41e0fe87cda9ea3970ffb872ef10f1ff8dbd1932
+  React-jsinspector: 15578208796723e5c6f39069b6e8bf36863ef6e2
+  React-jsitracing: 3758cdb155ea7711f0e77952572ea62d90c69f0b
+  React-logger: dbca7bdfd4aa5ef69431362bde6b36d49403cb20
+  React-Mapbuffer: 6efad4a606c1fae7e4a93385ee096681ef0300dc
+  React-microtasksnativemodule: 8732b71aa66045da4bb341ddee1bb539f71e5f38
+  react-native-blob-util: 39a20f2ef11556d958dc4beb0aa07d1ef2690745
+  react-native-config: 3367df9c1f25bb96197007ec531c7087ed4554c3
+  react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
+  react-native-mmkv: e842cad766fc2ad46e70e161f4bbaf0b7e90d41d
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-quick-base64: 764b8014da7dc834e5b8ad756c980addf919c177
+  react-native-quick-crypto: 4a5011fb16940bf07059cb6d3f3388da95d77813
+  react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
+  react-native-safe-area-context: 142fade490cbebbe428640b8cbdb09daf17e8191
+  react-native-sqlite-storage: f6d515e1c446d1e6d026aa5352908a25d4de3261
+  react-native-webview: 0a19ebf8e1b6f1a5689bdd771ca158dcc88c5ef4
   React-nativeconfig: 8efdb1ef1e9158c77098a93085438f7e7b463678
-  React-NativeModulesApple: cebca2e5320a3d66e123cade23bd90a167ffce5e
-  React-perflogger: 72e653eb3aba9122f9e57cf012d22d2486f33358
-  React-performancetimeline: cd6a9374a72001165995d2ab632f672df04076dc
+  React-NativeModulesApple: 958d4f6c5c2ace4c0f427cf7ef82e28ae6538a22
+  React-perflogger: 9b4f13c0afe56bc7b4a0e93ec74b1150421ee22d
+  React-performancetimeline: 359db1cb889aa0282fafc5838331b0987c4915a9
   React-RCTActionSheet: aacf2375084dea6e7c221f4a727e579f732ff342
-  React-RCTAnimation: 395ab53fd064dff81507c15efb781c8684d9a585
-  React-RCTAppDelegate: 1e5b43833e3e36e9fa34eec20be98174bc0e14a2
-  React-RCTBlob: 13311e554c1a367de063c10ee7c5e6573b2dd1d6
-  React-RCTFabric: bd906861a4e971e21d8df496c2d8f3ca6956f840
-  React-RCTImage: 1b1f914bcc12187c49ba5d949dac38c2eb9f5cc8
-  React-RCTLinking: 4ac7c42beb65e36fba0376f3498f3cd8dd0be7fa
-  React-RCTNetwork: 938902773add4381e84426a7aa17a2414f5f94f7
-  React-RCTSettings: e848f1ba17a7a18479cf5a31d28145f567da8223
-  React-RCTText: 7e98fafdde7d29e888b80f0b35544e0cb07913cf
-  React-RCTVibration: cd7d80affd97dc7afa62f9acd491419558b64b78
+  React-RCTAnimation: d8c82deebebe3aaf7a843affac1b57cb2dc073d4
+  React-RCTAppDelegate: 6c0377d9c4058773ea7073bb34bb9ebd6ddf5a84
+  React-RCTBlob: 70a58c11a6a3500d1a12f2e51ca4f6c99babcff8
+  React-RCTFabric: 7eb6dd2c8fda98cb860a572e3f4e4eb60d62c89e
+  React-RCTImage: 5e9d655ba6a790c31e3176016f9b47fd0978fbf0
+  React-RCTLinking: 2a48338252805091f7521eaf92687206401bdf2a
+  React-RCTNetwork: 0c1282b377257f6b1c81934f72d8a1d0c010e4c3
+  React-RCTSettings: f757b679a74e5962be64ea08d7865a7debd67b40
+  React-RCTText: e7d20c490b407d3b4a2daa48db4bcd8ec1032af2
+  React-RCTVibration: 8228e37144ca3122a91f1de16ba8e0707159cfec
   React-rendererconsistency: b4917053ecbaa91469c67a4319701c9dc0d40be6
-  React-rendererdebug: aa181c36dd6cf5b35511d1ed875d6638fd38f0ec
+  React-rendererdebug: 81becbc8852b38d9b1b68672aa504556481330d5
   React-rncore: 120d21715c9b4ba8f798bffe986cb769b988dd74
-  React-RuntimeApple: d033becbbd1eba6f9f6e3af6f1893030ce203edd
-  React-RuntimeCore: 38af280bb678e66ba000a3c3d42920b2a138eebb
+  React-RuntimeApple: 52ed0e9e84a7c2607a901149fb13599a3c057655
+  React-RuntimeCore: ca6189d2e53d86db826e2673fe8af6571b8be157
   React-runtimeexecutor: 877596f82f5632d073e121cba2d2084b76a76899
-  React-RuntimeHermes: 37aad735ff21ca6de2d8450a96de1afe9f86c385
-  React-runtimescheduler: 8ec34cc885281a34696ea16c4fd86892d631f38d
+  React-RuntimeHermes: 3b752dc5d8a1661c9d1687391d6d96acfa385549
+  React-runtimescheduler: 8321bb09175ace2a4f0b3e3834637eb85bf42ebe
   React-timing: 331cbf9f2668c67faddfd2e46bb7f41cbd9320b9
-  React-utils: ed818f19ab445000d6b5c4efa9d462449326cc9f
-  ReactCodegen: f853a20cc9125c5521c8766b4b49375fec20648b
-  ReactCommon: 300d8d9c5cb1a6cd79a67cf5d8f91e4d477195f9
-  RNCAsyncStorage: aa75595c1aefa18f868452091fa0c411a516ce11
-  RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
-  RNScreens: 295d9c0aaeb7f680d03d7e9b476569a4959aae89
-  RNSVG: 8542aa11770b27563714bbd8494a8436385fc85f
+  React-utils: 54df9ada708578c8ad40d92895d6fed03e0e8a9e
+  ReactCodegen: 21a52ccddc6479448fc91903a437dd23ddc7366c
+  ReactCommon: bfd3600989d79bc3acbe7704161b171a1480b9fd
+  RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
+  RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
+  RNScreens: 02c4adf5b4820807807b1d7d4f8bc27eeaed8e11
+  RNSVG: 8b1a777d54096b8c2a0fd38fc9d5a454332bbb4d
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SQLCipher: 5e6bfb47323635c8b657b1b27d25c5f1baf63bf5
-  SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
-  XMTP: 4585965d1df0e575bf58fdd359d095b53523a5fd
-  XMTPReactNative: ada2f52cd459a68b0ffbcc8a5221b0ac69feca69
-  Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
+  SwiftProtobuf: 3697407f0d5b23bedeba9c2eaaf3ec6fdff69349
+  XMTP: c921c08822265162615079094cd9698f903a67e7
+  XMTPReactNative: d0e97859fd2e721471bffc55afbd4436177bdbb8
+  Yoga: 40f19fff64dce86773bf8b602c7070796c007970
 
-PODFILE CHECKSUM: 5b1b93f724b9cde6043d1824960f7bfd9a7973cd
+PODFILE CHECKSUM: c76510e65e7d9673f44024ae2d0a10eec063a555
 
 COCOAPODS: 1.16.2

--- a/example/src/contentTypes/contentTypes.ts
+++ b/example/src/contentTypes/contentTypes.ts
@@ -6,6 +6,8 @@ import {
   RemoteAttachmentCodec,
   StaticAttachmentCodec,
   MultiRemoteAttachmentCodec,
+  LeaveRequestCodec,
+  DeleteMessageCodec,
 } from 'xmtp-react-native-sdk'
 
 export const supportedCodecs = [
@@ -16,6 +18,8 @@ export const supportedCodecs = [
   new MultiRemoteAttachmentCodec(),
   new StaticAttachmentCodec(),
   new GroupUpdatedCodec(),
+  new LeaveRequestCodec(),
+  new DeleteMessageCodec(),
 ]
 
 export type SupportedContentTypes = typeof supportedCodecs

--- a/example/src/hooks.tsx
+++ b/example/src/hooks.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
 import * as SecureStore from 'expo-secure-store'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import RNFS from 'react-native-fs'
 import crypto from 'react-native-quick-crypto'
 import { useMutation, useQuery, UseQueryResult } from 'react-query'

--- a/example/src/tests/clientTests.ts
+++ b/example/src/tests/clientTests.ts
@@ -1119,18 +1119,6 @@ test('can revoke installations', async () => {
   return true
 })
 
-test('can upload archive debug information', async () => {
-  const [alix] = await createClients(1)
-  const uploadKey = await alix.debugInformation.uploadDebugInformation()
-
-  assert(
-    typeof uploadKey === 'string' && uploadKey.length > 0,
-    'uploadKey should not be empty'
-  )
-
-  return true
-})
-
 test('can create, inspect, import and resync archive', async () => {
   const [bo] = await createClients(1)
   const key = crypto.getRandomValues(new Uint8Array(32))

--- a/example/src/tests/conversationTests.ts
+++ b/example/src/tests/conversationTests.ts
@@ -1396,12 +1396,20 @@ test('sender can delete their own message', async () => {
   const alixGroup = await alix.conversations.newGroup([bo.inboxId])
   await alixGroup.sync()
 
+  let messages = await alixGroup.messages()
+  let messagesString = messages.map((m) => `- ${m.id}: ${m.contentTypeId}`).join('\n')
+  console.log('After group creation::\n' + messagesString)
+
   const messageId = await alixGroup.send({
     text: 'Hello, this message will be deleted',
   })
   await alixGroup.sync()
 
-  let messages = await alixGroup.messages()
+  messages = await alixGroup.messages()
+  messagesString = messages.map((m) => `- ${m.id}: ${m.contentTypeId}`).join('\n')
+  console.log('After send and sync::\n' + messagesString)
+
+  messages = await alixGroup.messages()
   assert(
     messages.some((m) => m.id === messageId),
     'Message should exist before deletion'
@@ -1412,9 +1420,29 @@ test('sender can delete their own message', async () => {
 
   await alixGroup.sync()
   messages = await alixGroup.messages()
+
+  messages = await alixGroup.messages()
+  messagesString = messages.map((m) => `- ${m.id}: ${m.contentTypeId}`).join('\n')
+  console.log('After delete and sync::\n' + messagesString)
   assert(
     messages.some((m) => m.id === deletionMessageId),
     'Deletion message should exist after deletion'
+  )
+
+  // format the list of messages and the contents nicely and print them out
+  messagesString = messages
+    .map((m) => {
+      const base = `- ${m.id}: ${m.contentTypeId}`
+      if (m.contentTypeId.includes('text')) {
+        return `${base} - "${m.content()}"`
+      }
+    })
+    .join('\n')
+  console.log('Messages after deletion:\n' + messagesString)
+
+  assert(
+    !messages.some((m) => m.id === messageId),
+    'Original message should no longer exist after deletion'
   )
 
   return true

--- a/example/src/tests/conversationTests.ts
+++ b/example/src/tests/conversationTests.ts
@@ -2055,10 +2055,7 @@ test('enriched messages with custom JS content type', async () => {
       unknown?: { content?: unknown; contentTypeId?: string }
       encoded?: string
     }
-    console.log(
-      'Custom message nativeContent:',
-      JSON.stringify(nativeContent)
-    )
+    console.log('Custom message nativeContent:', JSON.stringify(nativeContent))
 
     // If it's in the "unknown" branch, verify content is a proper object, not a string like "NumberRef(...)"
     if (nativeContent.unknown?.content) {

--- a/example/src/tests/conversationTests.ts
+++ b/example/src/tests/conversationTests.ts
@@ -2053,6 +2053,13 @@ test('enriched messages with custom JS content type', async () => {
   return true
 })
 
+// NOTE: Test for transforming codec limitation removed.
+// KNOWN LIMITATION: enrichedMessages() uses the native FFI layer which decodes
+// content before sending to JS. This means JSContentCodec.decode() transformations
+// are NOT applied. The content is returned as-is from FFI.
+// For custom content types that need transformation in decode(), use messages() instead.
+// See DecodedMessageV2.ts for detailed documentation of this limitation.
+
 test('enriched messages can exclude sender inbox ids', async () => {
   const [alix, bo] = await createClients(2)
 

--- a/example/src/tests/groupPermissionsTests.ts
+++ b/example/src/tests/groupPermissionsTests.ts
@@ -472,6 +472,7 @@ test('can create a group with custom permissions', async () => {
     updateGroupDescriptionPolicy: 'allow',
     updateGroupImagePolicy: 'admin',
     updateMessageDisappearingPolicy: 'deny',
+    updateAppDataPolicy: 'allow',
   }
 
   // Bo creates a group with Alix and Caro with custom permissions
@@ -552,6 +553,7 @@ test('creating a group with invalid permissions should fail', async () => {
     updateGroupDescriptionPolicy: 'allow',
     updateGroupImagePolicy: 'admin',
     updateMessageDisappearingPolicy: 'admin',
+    updateAppDataPolicy: 'allow',
   }
 
   // Bo creates a group with Alix and Caro

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -2092,6 +2092,7 @@ test('handles disappearing messages in a group', async () => {
     updateGroupDescriptionPolicy: 'allow',
     updateGroupImagePolicy: 'admin',
     updateMessageDisappearingPolicy: 'deny',
+    updateAppDataPolicy: 'allow',
   }
 
   // Create group with disappearing messages enabled

--- a/example/src/tests/groupTests.ts
+++ b/example/src/tests/groupTests.ts
@@ -762,7 +762,9 @@ test('unpublished messages handling', async () => {
       millis = Math.floor(sentNs / 1_000_000)
     }
     const timestamp = new Date(millis).toISOString()
-    debugLog(`Message ${index}: contentTypeId = "${message.contentTypeId}" timestamp = ${timestamp}`)
+    debugLog(
+      `Message ${index}: contentTypeId = "${message.contentTypeId}" timestamp = ${timestamp}`
+    )
   })
   debugLog('=====================================')
 
@@ -772,29 +774,29 @@ test('unpublished messages handling', async () => {
     `the message should have a content type id of xmtp.org/group_updated:1.0 but it was ${alixMessages[0].contentTypeId}`
   )
 
-  // // Publish the prepared message
-  // await alixGroup.publishPreparedMessages()
+  // Publish the prepared message
+  await alixGroup.publishPreparedMessages()
 
-  // // Sync the group after publishing the message
-  // await alixGroup.sync()
-  // messageCount = (await alixGroup.messages()).length
-  // if (messageCount !== 2) {
-  //   throw new Error(`Message count should be 2, but it is ${messageCount}`)
-  // }
+  // Sync the group after publishing the message
+  await alixGroup.sync()
+  messageCount = (await alixGroup.messages()).length
+  if (messageCount !== 2) {
+    throw new Error(`Message count should be 2, but it is ${messageCount}`)
+  }
 
-  // // Check if the group is allowed after preparing the message
-  // const isGroupAllowed = await alixClient.preferences.conversationConsentState(
-  //   boGroup.id
-  // )
-  // if (isGroupAllowed !== 'allowed') {
-  //   throw new Error('Group should be allowed after preparing a message')
-  // }
+  // Check if the group is allowed after preparing the message
+  const isGroupAllowed = await alixClient.preferences.conversationConsentState(
+    boGroup.id
+  )
+  if (isGroupAllowed !== 'allowed') {
+    throw new Error('Group should be allowed after preparing a message')
+  }
 
-  // // Retrieve all messages and verify the prepared message ID
-  // const messages = await alixGroup.messages({ direction: 'DESCENDING' })
-  // if (preparedMessageId !== messages[0].id) {
-  //   throw new Error(`Message ID should match the prepared message ID`)
-  // }
+  // Retrieve all messages and verify the prepared message ID
+  const messages = await alixGroup.messages({ direction: 'DESCENDING' })
+  if (preparedMessageId !== messages[0].id) {
+    throw new Error(`Message ID should match the prepared message ID`)
+  }
 
   return true
 })
@@ -2418,7 +2420,7 @@ test('streams deleted messages when disappearing messages occur a group', async 
     'BoGroup should have disappearing enabled'
   )
 
-  boClient.conversations.cancelStreamMessageDeletions()
+  await boClient.conversations.cancelStreamMessageDeletions()
 
   await assertEqual(() => deletedMessages, 1, 'Deleted messages should be 1')
 
@@ -2474,18 +2476,18 @@ test('can leave a group', async () => {
 
   // Inspect the leave group message content
   const boMessages = await boGroup.messages()
-  
+
   // Log all messages to see what's available
   console.log('All messages after leave:')
   boMessages.forEach((m) => {
     console.log(`  - ${m.id}: ${m.contentTypeId}`)
     console.log(`    nativeContent: ${JSON.stringify(m.nativeContent)}`)
   })
-  
+
   const leaveMessage = boMessages.find(
     (m) => m.contentTypeId === 'xmtp.org/leave_request:1.0'
   )
-  
+
   if (!leaveMessage) {
     console.log('No leave_request message found, checking for group_updated...')
     const groupUpdatedMessage = boMessages.find(
@@ -2493,23 +2495,30 @@ test('can leave a group', async () => {
     )
     if (groupUpdatedMessage) {
       console.log('Found group_updated message instead')
-      console.log('nativeContent:', JSON.stringify(groupUpdatedMessage.nativeContent))
+      console.log(
+        'nativeContent:',
+        JSON.stringify(groupUpdatedMessage.nativeContent)
+      )
     }
   }
-  
+
   assert(leaveMessage !== undefined, 'Leave message should exist')
 
-  console.log('Leave message nativeContent:', JSON.stringify(leaveMessage?.nativeContent))
-  const leaveContent: LeaveRequestContent = (leaveMessage?.nativeContent as any)?.leaveRequest as LeaveRequestContent
+  console.log(
+    'Leave message nativeContent:',
+    JSON.stringify(leaveMessage?.nativeContent)
+  )
+  const leaveContent: LeaveRequestContent = (leaveMessage?.nativeContent as any)
+    ?.leaveRequest as LeaveRequestContent
   console.log('Leave group message content:', JSON.stringify(leaveContent))
 
   // LeaveRequestContent only has an optional authenticatedNote field
   // The actual leave is indicated by the message existing with the leave_request content type
-  assert(
-    leaveContent !== undefined,
-    'Leave content should be defined'
+  assert(leaveContent !== undefined, 'Leave content should be defined')
+  console.log(
+    'Leave request authenticatedNote:',
+    leaveContent?.authenticatedNote
   )
-  console.log('Leave request authenticatedNote:', leaveContent?.authenticatedNote)
 
   return true
 })

--- a/example/src/tests/test-utils.ts
+++ b/example/src/tests/test-utils.ts
@@ -14,6 +14,7 @@ import {
   JSContentCodec,
   LeaveRequestCodec,
   DeleteMessageCodec,
+  ReplyCodec,
 } from 'xmtp-react-native-sdk'
 
 // Debug logging state
@@ -76,6 +77,7 @@ export async function createClients(
     Client.register(new ReactionV2Codec())
     Client.register(new LeaveRequestCodec())
     Client.register(new DeleteMessageCodec())
+    Client.register(new ReplyCodec())
     for (const codec of customCodecs ?? []) {
       Client.register(codec)
     }

--- a/example/src/tests/test-utils.ts
+++ b/example/src/tests/test-utils.ts
@@ -12,6 +12,8 @@ import {
   MultiRemoteAttachmentCodec,
   PublicIdentity,
   JSContentCodec,
+  LeaveRequestCodec,
+  DeleteMessageCodec,
 } from 'xmtp-react-native-sdk'
 
 // Debug logging state
@@ -72,6 +74,8 @@ export async function createClients(
     Client.register(new MultiRemoteAttachmentCodec())
     Client.register(new ReactionCodec())
     Client.register(new ReactionV2Codec())
+    Client.register(new LeaveRequestCodec())
+    Client.register(new DeleteMessageCodec())
     for (const codec of customCodecs ?? []) {
       Client.register(codec)
     }

--- a/example/src/tests/test-utils.ts
+++ b/example/src/tests/test-utils.ts
@@ -11,6 +11,7 @@ import {
   ReactionV2Codec,
   MultiRemoteAttachmentCodec,
   PublicIdentity,
+  JSContentCodec,
 } from 'xmtp-react-native-sdk'
 
 // Debug logging state
@@ -52,7 +53,8 @@ export function assert(condition: boolean, msg: string) {
 
 export async function createClients(
   numClients: number,
-  env?: XMTPEnvironment | undefined
+  env?: XMTPEnvironment | undefined,
+  customCodecs?: JSContentCodec<any>[]
 ): Promise<Client[]> {
   const clients = []
   for (let i = 0; i < numClients; i++) {
@@ -70,6 +72,9 @@ export async function createClients(
     Client.register(new MultiRemoteAttachmentCodec())
     Client.register(new ReactionCodec())
     Client.register(new ReactionV2Codec())
+    for (const codec of customCodecs ?? []) {
+      Client.register(codec)
+    }
     clients.push(client)
   }
   return clients

--- a/ios/Wrappers/CreateGroupParamsWrapper.swift
+++ b/ios/Wrappers/CreateGroupParamsWrapper.swift
@@ -6,6 +6,7 @@ struct CreateGroupParamsWrapper {
 	let groupImageUrl: String
 	let groupDescription: String
 	let disappearingMessageSettings: DisappearingMessageSettings?
+	let appData: String
 
 	static func createGroupParamsFromJson(_ authParams: String)
 		-> CreateGroupParamsWrapper
@@ -29,12 +30,14 @@ struct CreateGroupParamsWrapper {
 		let groupName = jsonOptions["name"] as? String ?? ""
 		let groupImageUrl = jsonOptions["imageUrl"] as? String ?? ""
 		let groupDescription = jsonOptions["description"] as? String ?? ""
+		let appData = jsonOptions["appData"] as? String ?? ""
 
 		return CreateGroupParamsWrapper(
 			groupName: groupName,
 			groupImageUrl: groupImageUrl,
 			groupDescription: groupDescription,
-			disappearingMessageSettings: settings
+			disappearingMessageSettings: settings,
+			appData: appData
 		)
 	}
 }

--- a/ios/Wrappers/EnrichedMessageQueryParamsWrapper.swift
+++ b/ios/Wrappers/EnrichedMessageQueryParamsWrapper.swift
@@ -1,0 +1,57 @@
+import Foundation
+import XMTP
+
+struct EnrichedMessageQueryParamsWrapper {
+	let limit: Int?
+	let beforeNs: Int64?
+	let afterNs: Int64?
+	let direction: String?
+	let excludeSenderInboxIds: [String]?
+	let deliveryStatus: String?
+	let insertedAfterNs: Int64?
+	let insertedBeforeNs: Int64?
+	let sortBy: String?
+
+	static func fromJson(_ paramsJson: String) -> EnrichedMessageQueryParamsWrapper {
+		guard !paramsJson.isEmpty else {
+			return EnrichedMessageQueryParamsWrapper(
+				limit: nil,
+				beforeNs: nil,
+				afterNs: nil,
+				direction: nil,
+				excludeSenderInboxIds: nil,
+				deliveryStatus: nil,
+				insertedAfterNs: nil,
+				insertedBeforeNs: nil,
+				sortBy: nil
+			)
+		}
+
+		let data = paramsJson.data(using: .utf8) ?? Data()
+		let jsonOptions =
+			(try? JSONSerialization.jsonObject(with: data, options: []))
+			as? [String: Any] ?? [:]
+
+		let limit = jsonOptions["limit"] as? Int
+		let beforeNs = jsonOptions["beforeNs"] as? Int64
+		let afterNs = jsonOptions["afterNs"] as? Int64
+		let direction = jsonOptions["direction"] as? String
+		let excludeSenderInboxIds = jsonOptions["excludeSenderInboxIds"] as? [String]
+		let deliveryStatus = jsonOptions["deliveryStatus"] as? String
+		let insertedAfterNs = jsonOptions["insertedAfterNs"] as? Int64
+		let insertedBeforeNs = jsonOptions["insertedBeforeNs"] as? Int64
+		let sortBy = jsonOptions["sortBy"] as? String
+
+		return EnrichedMessageQueryParamsWrapper(
+			limit: limit,
+			beforeNs: beforeNs,
+			afterNs: afterNs,
+			direction: direction,
+			excludeSenderInboxIds: excludeSenderInboxIds,
+			deliveryStatus: deliveryStatus,
+			insertedAfterNs: insertedAfterNs,
+			insertedBeforeNs: insertedBeforeNs,
+			sortBy: sortBy
+		)
+	}
+}

--- a/ios/Wrappers/MessageWrapper.swift
+++ b/ios/Wrappers/MessageWrapper.swift
@@ -115,13 +115,12 @@ struct ContentJson {
 				schema: ReactionSchema(rawValue: reaction["schema"] as? String ?? "")
 			))
 		} else if let reaction = obj["reactionV2"] as? [String: Any] {
-            return ContentJson(type: ContentTypeReactionV2, content: FfiReactionPayload(
+			// Use SDK Reaction type (not FfiReactionPayload); ReactionV2Codec encodes Reaction.
+			return ContentJson(type: ContentTypeReactionV2, content: Reaction(
 				reference: reaction["reference"] as? String ?? "",
-				// Update if we add referenceInboxId to ../src/lib/types/ContentCodec.ts#L19-L24
-                referenceInboxId: "",
-				action: ReactionV2Action.fromString(reaction["action"] as? String ?? ""),
+				action: ReactionAction(rawValue: reaction["action"] as? String ?? ""),
 				content: reaction["content"] as? String ?? "",
-				schema: ReactionV2Schema.fromString(reaction["schema"] as? String ?? "")
+				schema: ReactionSchema(rawValue: reaction["schema"] as? String ?? "")
 			))
 		}else if let reply = obj["reply"] as? [String: Any] {
 			guard let nestedContent = reply["content"] as? [String: Any] else {

--- a/ios/Wrappers/MessageWrapper.swift
+++ b/ios/Wrappers/MessageWrapper.swift
@@ -300,11 +300,11 @@ struct ContentJson {
 			return ["leaveRequest": [
 				"authenticatedNote": noteString
 			]]
-//		case ContentTypeDeleteMessage.id where content is XMTP.DeleteMessage:
-//			let deleteMessage = content as! XMTP.DeleteMessage
-//			return ["deleteMessage": [
-//				"messageId": deleteMessage.messageId,
-//			]]
+		case ContentTypeDeleteMessageRequest.id where content is XMTP.DeleteMessageRequest:
+			let deleteMessage = content as! XMTP.DeleteMessageRequest
+			return ["deleteMessage": [
+				"messageId": deleteMessage.messageId,
+			]]
 		default:
 			if let encodedContent, let encodedContentJSON = try? encodedContent.jsonString() {
 				return ["encoded": encodedContentJSON]

--- a/ios/Wrappers/MessageWrapper.swift
+++ b/ios/Wrappers/MessageWrapper.swift
@@ -34,7 +34,7 @@ struct MessageWrapper {
 			try? encodeToObjV2(reaction)
 		}
 		let reactionCount = reactionsList.count
-		return [
+		var result: [String: Any] = [
 			"id": model.id,
 			"conversationId": model.conversationId,
 			"contentTypeId": model.contentTypeId.description,
@@ -43,14 +43,21 @@ struct MessageWrapper {
 			"sentAt": model.sentAtNs / 1_000_000,
 			"sentAtNs": model.sentAtNs,
 			"insertedAtNs": model.insertedAtNs,
-			"expiresAtNs": model.expiresAtNs as Any,
-			"expiresAt": model.expiresAt.map { Int64($0.timeIntervalSince1970 * 1000) } as Any,
-			"fallbackText": (try? model.fallback) as Any,
 			"deliveryStatus": model.deliveryStatus.rawValue.uppercased(),
 			"reactions": reactions,
 			"hasReactions": reactionCount > 0,
 			"reactionCount": Int64(reactionCount)
 		]
+		if let expiresAtNs = model.expiresAtNs {
+			result["expiresAtNs"] = expiresAtNs
+		}
+		if let expiresAt = model.expiresAt {
+			result["expiresAt"] = Int64(expiresAt.timeIntervalSince1970 * 1000)
+		}
+		if let fallbackText = try? model.fallback {
+			result["fallbackText"] = fallbackText
+		}
+		return result
 	}
 
 	static func encodeV2(_ model: XMTP.DecodedMessageV2) throws -> String {

--- a/ios/Wrappers/MessageWrapper.swift
+++ b/ios/Wrappers/MessageWrapper.swift
@@ -441,6 +441,14 @@ struct ContentJsonV2 {
 			}
 			return ["leaveRequest": [:]]
 			
+		case ContentTypeDeleteMessageRequest.id:
+			if let deleteMessageRequest: XMTP.DeleteMessageRequest = try? message.content() {
+				return ["deleteMessage": [
+					"messageId": deleteMessageRequest.messageId,
+				]]
+			}
+			return ["deleteMessage": [:]]
+			
 		default:
 			// For unknown/custom content types, try to serialize the content
 			// Match Android's approach: check types first, then use fallback

--- a/ios/Wrappers/MessageWrapper.swift
+++ b/ios/Wrappers/MessageWrapper.swift
@@ -51,6 +51,8 @@ struct ContentJson {
 		MultiRemoteAttachmentCodec(),
 		ReadReceiptCodec(),
 		GroupUpdatedCodec(),
+		LeaveRequestCodec(),
+		DeleteMessageCodec(),
 	]
 
 	static func initCodecs() {
@@ -262,6 +264,17 @@ struct ContentJson {
 					]
 				}
 			]]
+		case ContentTypeLeaveRequest.id where content is XMTP.LeaveRequest:
+			let leaveRequest = content as! XMTP.LeaveRequest
+			let noteString = leaveRequest.authenticatedNote.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+			return ["leaveRequest": [
+				"authenticatedNote": noteString
+			]]
+//		case ContentTypeDeleteMessage.id where content is XMTP.DeleteMessage:
+//			let deleteMessage = content as! XMTP.DeleteMessage
+//			return ["deleteMessage": [
+//				"messageId": deleteMessage.messageId,
+//			]]
 		default:
 			if let encodedContent, let encodedContentJSON = try? encodedContent.jsonString() {
 				return ["encoded": encodedContentJSON]

--- a/ios/Wrappers/PermissionPolicySetWrapper.swift
+++ b/ios/Wrappers/PermissionPolicySetWrapper.swift
@@ -50,7 +50,8 @@ class PermissionPolicySetWrapper {
             "updateGroupNamePolicy": fromPermissionOption(policySet.updateGroupNamePolicy),
             "updateGroupDescriptionPolicy": fromPermissionOption(policySet.updateGroupDescriptionPolicy),
             "updateGroupImagePolicy": fromPermissionOption(policySet.updateGroupImagePolicy),
-            "updateMessageDisappearingPolicy": fromPermissionOption(policySet.updateMessageDisappearingPolicy)
+            "updateMessageDisappearingPolicy": fromPermissionOption(policySet.updateMessageDisappearingPolicy),
+            "updateAppDataPolicy": fromPermissionOption(policySet.updateAppDataPolicy)
         ]
     }
     public static func createPermissionPolicySet(from json: String) throws -> PermissionPolicySet {
@@ -71,7 +72,8 @@ class PermissionPolicySetWrapper {
             updateGroupNamePolicy: createPermissionOption(from: jsonDict["updateGroupNamePolicy"] as? String ?? ""),
             updateGroupDescriptionPolicy: createPermissionOption(from: jsonDict["updateGroupDescriptionPolicy"] as? String ?? ""),
             updateGroupImagePolicy: createPermissionOption(from: jsonDict["updateGroupImagePolicy"] as? String ?? ""),
-            updateMessageDisappearingPolicy: createPermissionOption(from: jsonDict["updateMessageDisappearingPolicy"] as? String ?? "")
+            updateMessageDisappearingPolicy: createPermissionOption(from: jsonDict["updateMessageDisappearingPolicy"] as? String ?? ""),
+            updateAppDataPolicy: createPermissionOption(from: jsonDict["updateAppDataPolicy"] as? String ?? "")
         )
     }
     

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -1760,6 +1760,15 @@ public class XMTPModule: Module {
 			try await client.conversations.sync()
 		}
 
+		AsyncFunction("sendSyncRequest") { (installationId: String) in
+			guard
+				let client = await clientsManager.getClient(key: installationId)
+			else {
+				throw Error.noClient
+			}
+			try await client.sendSyncRequest()
+		}
+
 		AsyncFunction("syncAllConversations") {
 			(installationId: String, consentStringStates: [String]?) -> UInt64
 			in

--- a/ios/XMTPModule.swift
+++ b/ios/XMTPModule.swift
@@ -16,6 +16,10 @@ extension Conversation {
 	}
 }
 
+func getMessageDeletionsCacheKey(installationId: String) -> String {
+	return "\(installationId):messageDeletions"
+}
+
 actor IsolatedManager<T> {
 	private var map: [String: T] = [:]
 
@@ -138,12 +142,14 @@ public class XMTPModule: Module {
 			"conversationMessage",
 			"consent",
 			"preferences",
+			"messageDeletion",
 			// Stream Closed
 			"conversationClosed",
 			"messageClosed",
 			"conversationMessageClosed",
 			"consentClosed",
-			"preferencesClosed"
+			"preferencesClosed",
+			"messageDeletionClosed"
 		)
 
 		AsyncFunction("inboxId") { (installationId: String) -> String in
@@ -537,13 +543,15 @@ public class XMTPModule: Module {
 		}
 
 		AsyncFunction("ffiRevokeAllOtherInstallationsSignatureText") {
-			(installationId: String) -> String in
+			(installationId: String) -> String? in
 			guard
 				let client = await clientsManager.getClient(key: installationId)
 			else {
 				throw Error.noClient
 			}
-			let sigRequest = try await client.ffiRevokeAllOtherInstallations()
+			guard let sigRequest = try await client.ffiRevokeAllOtherInstallations() else {
+				return nil
+			}
 			await clientsManager.updateSignatureRequest(
 				key: client.installationID, signatureRequest: sigRequest
 			)
@@ -1273,6 +1281,23 @@ public class XMTPModule: Module {
 			)
 		}
 
+		AsyncFunction("publishMessage") {
+			(installationId: String, id: String, messageId: String) in
+			guard
+				let client = await clientsManager.getClient(key: installationId)
+			else {
+				throw Error.noClient
+			}
+			guard
+				let conversation = try await client.conversations
+					.findConversation(conversationId: id)
+			else {
+				throw Error.conversationNotFound(
+					"no conversation found for \(id)")
+			}
+			try await conversation.publishMessage(messageId: messageId)
+		}
+
 		AsyncFunction("publishPreparedMessages") {
 			(installationId: String, id: String) in
 			guard
@@ -1293,7 +1318,7 @@ public class XMTPModule: Module {
 		}
 
 		AsyncFunction("prepareMessage") {
-			(installationId: String, id: String, contentJson: String) -> String
+			(installationId: String, id: String, contentJson: String, noSend: Bool) -> String
 			in
 			guard
 				let client = await clientsManager.getClient(key: installationId)
@@ -1312,7 +1337,8 @@ public class XMTPModule: Module {
 			let sending = try ContentJson.fromJson(contentJson)
 			return try await conversation.prepareMessage(
 				content: sending.content,
-				options: SendOptions(contentType: sending.type)
+				options: SendOptions(contentType: sending.type),
+				noSend: noSend
 			)
 		}
 
@@ -1321,7 +1347,8 @@ public class XMTPModule: Module {
 				installationId: String,
 				conversationId: String,
 				encodedContentData: [UInt8],
-				shouldPush: Bool
+				shouldPush: Bool,
+				noSend: Bool
 			) -> String in
 			guard
 				let client = await clientsManager.getClient(key: installationId)
@@ -1339,7 +1366,7 @@ public class XMTPModule: Module {
 			let encodedContent = try EncodedContent(
 				serializedBytes: Data(encodedContentData))
 			return try await conversation.prepareMessage(
-				encodedContent: encodedContent, visibilityOptions: MessageVisibilityOptions(shouldPush: shouldPush)
+				encodedContent: encodedContent, visibilityOptions: MessageVisibilityOptions(shouldPush: shouldPush), noSend: noSend
 			)
 		}
 
@@ -1431,7 +1458,8 @@ public class XMTPModule: Module {
 					imageUrl: createGroupParams.groupImageUrl,
 					description: createGroupParams.groupDescription,
 					disappearingMessageSettings: createGroupParams
-						.disappearingMessageSettings
+						.disappearingMessageSettings,
+					appData: createGroupParams.appData
 				)
 				return try await GroupWrapper.encode(group, client: client)
 			} catch {
@@ -1465,7 +1493,8 @@ public class XMTPModule: Module {
 						imageUrl: createGroupParams.groupImageUrl,
 						description: createGroupParams.groupDescription,
 						disappearingMessageSettings: createGroupParams
-							.disappearingMessageSettings
+							.disappearingMessageSettings,
+						appData: createGroupParams.appData
 					)
 				return try await GroupWrapper.encode(group, client: client)
 			} catch {
@@ -1510,7 +1539,8 @@ public class XMTPModule: Module {
 						imageUrl: createGroupParams.groupImageUrl,
 						description: createGroupParams.groupDescription,
 						disappearingMessageSettings: createGroupParams
-							.disappearingMessageSettings
+							.disappearingMessageSettings,
+						appData: createGroupParams.appData
 					)
 				return try await GroupWrapper.encode(group, client: client)
 			} catch {
@@ -1548,7 +1578,8 @@ public class XMTPModule: Module {
 						imageUrl: createGroupParams.groupImageUrl,
 						description: createGroupParams.groupDescription,
 						disappearingMessageSettings: createGroupParams
-							.disappearingMessageSettings
+							.disappearingMessageSettings,
+						appData: createGroupParams.appData
 					)
 				return try await GroupWrapper.encode(group, client: client)
 			} catch {
@@ -1587,7 +1618,8 @@ public class XMTPModule: Module {
 					groupImageUrlSquare: createGroupParams.groupImageUrl,
 					groupDescription: createGroupParams.groupDescription,
 					disappearingMessageSettings: createGroupParams
-						.disappearingMessageSettings
+						.disappearingMessageSettings,
+					appData: createGroupParams.appData
 				)
 				return try await GroupWrapper.encode(group, client: client)
 			} catch {
@@ -2644,6 +2676,13 @@ public class XMTPModule: Module {
 			)
 		}
 
+		AsyncFunction("subscribeToMessageDeletions") {
+			(installationId: String) in
+			try await subscribeToMessageDeletions(
+				installationId: installationId
+			)
+		}
+
 		AsyncFunction("unsubscribeFromPreferenceUpdates") {
 			(installationId: String) in
 			await subscriptionsManager.get(
@@ -2675,6 +2714,13 @@ public class XMTPModule: Module {
 			try await unsubscribeFromMessages(
 				installationId: installationId, id: id
 			)
+		}
+
+		AsyncFunction("unsubscribeFromMessageDeletions") {
+			(installationId: String) in
+			await subscriptionsManager.get(
+				getMessageDeletionsCacheKey(installationId: installationId))?
+				.cancel()
 		}
 
 		AsyncFunction("registerPushToken") {
@@ -2782,20 +2828,6 @@ public class XMTPModule: Module {
 			client.debugInformation.clearAllStatistics()
 		}
 
-		AsyncFunction("uploadDebugInformation") {
-			(installationId: String, serverUrl: String?) -> String in
-			guard
-				let client = await clientsManager.getClient(key: installationId)
-			else {
-				throw Error.noClient
-			}
-			return try await
-				(serverUrl?.isEmpty == false
-					? client.debugInformation.uploadDebugInformation(
-						serverUrl: serverUrl!)
-					: client.debugInformation.uploadDebugInformation())
-		}
-
 		AsyncFunction("createArchive") {
 			(
 				installationId: String, path: String, encryptionKey: [UInt8],
@@ -2875,6 +2907,26 @@ public class XMTPModule: Module {
             }
             try await group.leaveGroup()
         }
+
+		AsyncFunction("deleteMessage") { (
+			installationId: String,
+			conversationId: String,
+			messageId: String
+		) -> String in
+			guard
+				let client = await clientsManager.getClient(key: installationId)
+			else {
+				throw Error.noClient
+			}
+			guard
+				let conversation = try await client.conversations.findConversation(
+					conversationId: conversationId)
+			else {
+				throw Error.conversationNotFound(
+					"no conversation found for \(conversationId)")
+			}
+			return try await conversation.deleteMessage(messageId: messageId)
+		}
 	}
 
 	//
@@ -3355,6 +3407,48 @@ public class XMTPModule: Module {
 					print("Error in group messages subscription: \(error)")
 					await subscriptionsManager.get(
 						converation.cacheKey(installationId))?.cancel()
+				}
+			}
+		)
+	}
+
+	func subscribeToMessageDeletions(installationId: String) async throws {
+		guard let client = await clientsManager.getClient(key: installationId)
+		else {
+			throw Error.noClient
+		}
+
+		await subscriptionsManager.get(
+			getMessageDeletionsCacheKey(installationId: installationId))?
+			.cancel()
+		await subscriptionsManager.set(
+			getMessageDeletionsCacheKey(installationId: installationId),
+			Task {
+				do {
+					for try await message in await client.conversations.streamMessageDeletions(
+						onClose: { [weak self] in
+							self?.sendEvent(
+								"messageDeletionClosed",
+								[
+									"installationId": installationId,
+								]
+							)
+						}
+					) {
+						try sendEvent(
+							"messageDeletion",
+							[
+								"installationId": installationId,
+								"messageId": message.id,
+								"conversationId": message.conversationId,
+							]
+						)
+					}
+				} catch {
+					print("Error in message deletions subscription: \(error)")
+					await subscriptionsManager.get(
+						getMessageDeletionsCacheKey(installationId: installationId))?
+						.cancel()
 				}
 			}
 		)

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.9.0-dev.90e114a"
+  s.dependency "XMTP", "= 4.9.0"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/ios/XMTPReactNative.podspec
+++ b/ios/XMTPReactNative.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,swift}"
 
   s.dependency "MessagePacker"
-  s.dependency "XMTP", "= 4.6.1"
+  s.dependency "XMTP", "= 4.9.0-dev.90e114a"
   s.dependency 'CSecp256k1', '~> 0.2'
   s.dependency "SQLCipher", "= 4.5.7"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/react-native-sdk",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Wraps for native xmtp sdks for react native",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1322,6 +1322,12 @@ export async function syncConversations(installationId: InstallationId) {
   await XMTPModule.syncConversations(installationId)
 }
 
+export async function sendSyncRequest(
+  installationId: InstallationId
+): Promise<void> {
+  return await XMTPModule.sendSyncRequest(installationId)
+}
+
 export async function syncAllConversations(
   installationId: InstallationId,
   consentStates?: ConsentState[] | undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -984,6 +984,18 @@ export async function sendMessage(
   )
 }
 
+export async function publishMessage(
+  installationId: InstallationId,
+  conversationId: ConversationId,
+  messageId: MessageId
+): Promise<void> {
+  return await XMTPModule.publishMessage(
+    installationId,
+    conversationId,
+    messageId
+  )
+}
+
 export async function publishPreparedMessages(
   installationId: InstallationId,
   conversationId: ConversationId
@@ -997,13 +1009,15 @@ export async function publishPreparedMessages(
 export async function prepareMessage(
   installationId: InstallationId,
   conversationId: ConversationId,
-  content: any
+  content: any,
+  noSend: boolean
 ): Promise<MessageId> {
   const contentJson = JSON.stringify(content)
   return await XMTPModule.prepareMessage(
     installationId,
     conversationId,
-    contentJson
+    contentJson,
+    noSend
   )
 }
 
@@ -1011,10 +1025,11 @@ export async function prepareMessageWithContentType<T>(
   installationId: InstallationId,
   conversationId: ConversationId,
   content: any,
-  codec: ContentCodec<T>
+  codec: ContentCodec<T>,
+  noSend: boolean
 ): Promise<MessageId> {
   if ('contentKey' in codec) {
-    return prepareMessage(installationId, conversationId, content)
+    return prepareMessage(installationId, conversationId, content, noSend)
   }
   const encodedContent = codec.encode(content)
   encodedContent.fallback = codec.fallback(content)
@@ -1023,7 +1038,8 @@ export async function prepareMessageWithContentType<T>(
     installationId,
     conversationId,
     Array.from(encodedContentData),
-    codec.shouldPush(content)
+    codec.shouldPush(content),
+    noSend
   )
 }
 
@@ -1075,7 +1091,8 @@ export async function createGroup<
   imageUrl: string = '',
   description: string = '',
   disappearStartingAtNs: number | undefined = undefined,
-  retentionDurationInNs: number | undefined = undefined
+  retentionDurationInNs: number | undefined = undefined,
+  appData: string = ''
 ): Promise<Group<ContentTypes>> {
   const options: CreateGroupParams = {
     name,
@@ -1083,6 +1100,7 @@ export async function createGroup<
     description,
     disappearStartingAtNs,
     retentionDurationInNs,
+    appData,
   }
   const group = JSON.parse(
     await XMTPModule.createGroup(
@@ -1106,7 +1124,8 @@ export async function createGroupCustomPermissionsWithIdentities<
   imageUrl: string = '',
   description: string = '',
   disappearStartingAtNs: number | undefined = undefined,
-  retentionDurationInNs: number | undefined = undefined
+  retentionDurationInNs: number | undefined = undefined,
+  appData: string = ''
 ): Promise<Group<ContentTypes>> {
   const options: CreateGroupParams = {
     name,
@@ -1114,6 +1133,7 @@ export async function createGroupCustomPermissionsWithIdentities<
     description,
     disappearStartingAtNs,
     retentionDurationInNs,
+    appData,
   }
   const identities = peerIdentities.map((identity) => JSON.stringify(identity))
   const group = JSON.parse(
@@ -1138,7 +1158,8 @@ export async function createGroupWithIdentities<
   imageUrl: string = '',
   description: string = '',
   disappearStartingAtNs: number | undefined = undefined,
-  retentionDurationInNs: number | undefined = undefined
+  retentionDurationInNs: number | undefined = undefined,
+  appData: string = ''
 ): Promise<Group<ContentTypes>> {
   const options: CreateGroupParams = {
     name,
@@ -1146,6 +1167,7 @@ export async function createGroupWithIdentities<
     description,
     disappearStartingAtNs,
     retentionDurationInNs,
+    appData,
   }
   const identities = peerIdentities.map((identity) => JSON.stringify(identity))
   const group = JSON.parse(
@@ -1170,7 +1192,8 @@ export async function createGroupCustomPermissions<
   imageUrl: string = '',
   description: string = '',
   disappearStartingAtNs: number | undefined = undefined,
-  retentionDurationInNs: number | undefined = undefined
+  retentionDurationInNs: number | undefined = undefined,
+  appData: string = ''
 ): Promise<Group<ContentTypes>> {
   const options: CreateGroupParams = {
     name,
@@ -1178,6 +1201,7 @@ export async function createGroupCustomPermissions<
     description,
     disappearStartingAtNs,
     retentionDurationInNs,
+    appData,
   }
   const group = JSON.parse(
     await XMTPModule.createGroupCustomPermissions(
@@ -1200,7 +1224,8 @@ export async function createGroupOptimistic<
   imageUrl: string = '',
   description: string = '',
   disappearStartingAtNs: number | undefined = undefined,
-  retentionDurationInNs: number | undefined = undefined
+  retentionDurationInNs: number | undefined = undefined,
+  appData: string = ''
 ): Promise<Group<ContentTypes>> {
   const options: CreateGroupParams = {
     name,
@@ -1208,6 +1233,7 @@ export async function createGroupOptimistic<
     description,
     disappearStartingAtNs,
     retentionDurationInNs,
+    appData,
   }
   const group = JSON.parse(
     await XMTPModule.createGroupOptimistic(
@@ -1903,6 +1929,7 @@ interface CreateGroupParams {
   description: string
   disappearStartingAtNs: number | undefined
   retentionDurationInNs: number | undefined
+  appData: string
 }
 
 export { Client } from './lib/Client'

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,8 @@ export { GroupUpdatedCodec } from './lib/NativeCodecs/GroupUpdatedCodec'
 export { ReactionCodec } from './lib/NativeCodecs/ReactionCodec'
 export { ReactionV2Codec } from './lib/NativeCodecs/ReactionV2Codec'
 export { ReadReceiptCodec } from './lib/NativeCodecs/ReadReceiptCodec'
+export { LeaveRequestCodec } from './lib/NativeCodecs/LeaveRequestCodec'
+export { DeleteMessageCodec } from './lib/NativeCodecs/DeleteMessageCodec'
 export { RemoteAttachmentCodec } from './lib/NativeCodecs/RemoteAttachmentCodec'
 export { MultiRemoteAttachmentCodec } from './lib/NativeCodecs/MultiRemoteAttachmentCodec'
 export { ReplyCodec } from './lib/NativeCodecs/ReplyCodec'
@@ -1766,10 +1768,10 @@ export async function unsubscribeFromMessages(
   return await XMTPModule.unsubscribeFromMessages(installationId, id)
 }
 
-export function unsubscribeFromMessageDeletions(
+export async function unsubscribeFromMessageDeletions(
   installationId: InstallationId
 ) {
-  return XMTPModule.unsubscribeFromMessageDeletions(installationId)
+  return await XMTPModule.unsubscribeFromMessageDeletions(installationId)
 }
 
 export function registerPushToken(pushServer: string, token: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
 import { Conversation, ConversationVersion } from './lib/Conversation'
 import { ConversationDebugInfo } from './lib/ConversationDebugInfo'
 import { DecodedMessage, MessageDeliveryStatus } from './lib/DecodedMessage'
+import { DecodedMessageV2 } from './lib/DecodedMessageV2'
 import { DisappearingMessageSettings } from './lib/DisappearingMessageSettings'
 import { Dm } from './lib/Dm'
 import { Group, PermissionUpdateOption } from './lib/Group'
@@ -38,10 +39,18 @@ import {
   ConversationId,
   ConversationTopic,
 } from './lib/types/ConversationOptions'
-import { DecodedMessageUnion } from './lib/types/DecodedMessageUnion'
+import {
+  DecodedMessageUnion,
+  DecodedMessageUnionV2,
+} from './lib/types/DecodedMessageUnion'
 import { DefaultContentTypes } from './lib/types/DefaultContentType'
 import { LogLevel, LogRotation } from './lib/types/LogTypes'
-import { MessageId, MessageOrder } from './lib/types/MessagesOptions'
+import {
+  MessageId,
+  MessageOrder,
+  EnrichedMessageDeliveryStatus,
+  EnrichedMessageSortBy,
+} from './lib/types/MessagesOptions'
 import { PermissionPolicySet } from './lib/types/PermissionPolicySet'
 
 export * from './context'
@@ -806,6 +815,42 @@ export async function conversationMessages<
   )
   return messages.map((json: string) => {
     return DecodedMessage.from(json)
+  })
+}
+
+export async function conversationEnrichedMessages<
+  ContentTypes extends DefaultContentTypes = DefaultContentTypes,
+>(
+  clientInstallationId: InstallationId,
+  conversationId: ConversationId,
+  limit?: number | undefined,
+  beforeNs?: number | undefined,
+  afterNs?: number | undefined,
+  direction?: MessageOrder | undefined,
+  excludeSenderInboxIds?: string[] | undefined,
+  deliveryStatus?: EnrichedMessageDeliveryStatus | undefined,
+  insertedAfterNs?: number | undefined,
+  insertedBeforeNs?: number | undefined,
+  sortBy?: EnrichedMessageSortBy | undefined
+): Promise<DecodedMessageUnionV2<ContentTypes>[]> {
+  const queryParamsJson = JSON.stringify({
+    limit,
+    beforeNs,
+    afterNs,
+    direction,
+    excludeSenderInboxIds,
+    deliveryStatus,
+    insertedAfterNs,
+    insertedBeforeNs,
+    sortBy,
+  })
+  const messages = await XMTPModule.conversationEnrichedMessages(
+    clientInstallationId,
+    conversationId,
+    queryParamsJson
+  )
+  return messages.map((json: string) => {
+    return DecodedMessageV2.from(json)
   })
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1888,14 +1888,6 @@ export async function clearAllNetworkStatistics(
   return await XMTPModule.clearAllNetworkStatistics(installationId)
 }
 
-export async function uploadDebugInformation(
-  installationId: InstallationId,
-  serverUrl?: string
-): Promise<string> {
-  const key = await XMTPModule.uploadDebugInformation(installationId, serverUrl)
-  return key
-}
-
 export async function createArchive(
   installationId: InstallationId,
   path: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1866,6 +1866,14 @@ export async function leaveGroup(
   return await XMTPModule.leaveGroup(installationId, id)
 }
 
+export async function deleteMessage(
+  installationId: InstallationId,
+  id: ConversationId,
+  messageId: MessageId
+): Promise<string> {
+  return await XMTPModule.deleteMessage(installationId, id, messageId)
+}
+
 export const emitter = new EventEmitter(XMTPModule ?? NativeModulesProxy.XMTP)
 
 interface AuthParams {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1709,6 +1709,12 @@ export async function subscribeToMessages(
   return await XMTPModule.subscribeToMessages(installationId, id)
 }
 
+export async function subscribeToMessageDeletions(
+  installationId: InstallationId
+) {
+  return await XMTPModule.subscribeToMessageDeletions(installationId)
+}
+
 export function unsubscribeFromPreferenceUpdates(
   installationId: InstallationId
 ) {
@@ -1732,6 +1738,12 @@ export async function unsubscribeFromMessages(
   id: ConversationId
 ) {
   return await XMTPModule.unsubscribeFromMessages(installationId, id)
+}
+
+export function unsubscribeFromMessageDeletions(
+  installationId: InstallationId
+) {
+  return XMTPModule.unsubscribeFromMessageDeletions(installationId)
 }
 
 export function registerPushToken(pushServer: string, token: string) {

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -902,6 +902,13 @@ export class Client<
   }
 
   /**
+   * Manually trigger a device sync request to sync records from another active device using this inbox.
+   */
+  async sendSyncRequest(): Promise<void> {
+    return await XMTPModule.sendSyncRequest(this.installationId)
+  }
+
+  /**
    * Make a request for your inbox state.
    *
    * @param {boolean} refreshFromNetwork - If you want to refresh the current state of in the inbox from the network or not.

--- a/src/lib/Conversation.ts
+++ b/src/lib/Conversation.ts
@@ -69,6 +69,7 @@ export interface ConversationBase<ContentTypes extends DefaultContentTypes> {
   getConversationHmacKeys(): Promise<keystore.GetConversationHmacKeysResponse>
   getConversationPushTopics(): Promise<ConversationTopic[]>
   getDebugInformation(): Promise<ConversationDebugInfo>
+  deleteMessage(messageId: MessageId): Promise<string>
 }
 
 export type Conversation<

--- a/src/lib/Conversation.ts
+++ b/src/lib/Conversation.ts
@@ -40,44 +40,184 @@ export interface ConversationBase<ContentTypes extends DefaultContentTypes> {
   lastMessage?: DecodedMessage<ContentTypes[number]>
   commitLogForkStatus?: CommitLogForkStatus
 
+  /**
+   * Sends a message to the conversation.
+   *
+   * @param {ConversationSendPayload} content - The content of the message to send.
+   * @param {SendOptions} opts - Optional send options.
+   * @returns {Promise<MessageId>} A Promise that resolves to the ID of the sent message.
+   */
   send<SendContentTypes extends DefaultContentTypes = ContentTypes>(
     content: ConversationSendPayload<SendContentTypes>,
     opts?: SendOptions
   ): Promise<MessageId>
+
+  /**
+   * Prepares a message to be sent, storing it locally.
+   *
+   * @param {ConversationSendPayload} content - The content of the message to prepare.
+   * @param {SendOptions} opts - Optional send options.
+   * @param {boolean} noSend - If true, the message will only be sent when publishMessage is called.
+   * @returns {Promise<MessageId>} A Promise that resolves to the ID of the prepared message.
+   */
   prepareMessage<SendContentTypes extends DefaultContentTypes = ContentTypes>(
     content: ConversationSendPayload<SendContentTypes>,
     opts?: SendOptions,
     noSend?: boolean
   ): Promise<MessageId>
+
+  /**
+   * Publishes a previously prepared message.
+   *
+   * @param {MessageId} messageId - The ID of the prepared message to publish.
+   * @returns {Promise<void>}
+   */
   publishMessage(messageId: MessageId): Promise<void>
-  sync()
+
+  /**
+   * Synchronizes the conversation with the network to fetch the latest messages.
+   */
+  sync(): Promise<void>
+
+  /**
+   * Returns an array of messages associated with the conversation.
+   * To get the latest messages from the network, call sync() first.
+   *
+   * @param {MessagesOptions} opts - Optional parameters for filtering messages.
+   * @returns {Promise<DecodedMessageUnion<ContentTypes>[]>} A Promise that resolves to an array of DecodedMessage objects.
+   */
   messages(opts?: MessagesOptions): Promise<DecodedMessageUnion<ContentTypes>[]>
+
+  /**
+   * Returns an array of enriched messages (V2) associated with the conversation.
+   * Enriched messages include additional metadata like reactions, delivery status, and more.
+   * To get the latest messages from the network, call sync() first.
+   *
+   * @param {EnrichedMessagesOptions} opts - Optional parameters for filtering messages.
+   * @returns {Promise<DecodedMessageUnionV2<ContentTypes>[]>} A Promise that resolves to an array of DecodedMessageV2 objects.
+   */
   enrichedMessages(
     opts?: EnrichedMessagesOptions
   ): Promise<DecodedMessageUnionV2<ContentTypes>[]>
+
+  /**
+   * Sets up a real-time message stream for the conversation.
+   *
+   * @param {Function} callback - A callback function to be invoked when a message is received.
+   * @param {Function} onClose - Optional callback when the stream is closed.
+   * @returns {Promise<() => void>} A function that can be called to cancel the message stream.
+   */
   streamMessages(
     callback: (message: DecodedMessage<ContentTypes[number]>) => Promise<void>,
     onClose?: () => void
   ): Promise<() => void>
+
+  /**
+   * Returns the current consent state of the conversation.
+   *
+   * @returns {Promise<ConsentState>} The consent state ('allowed', 'denied', or 'unknown').
+   */
   consentState(): Promise<ConsentState>
+
+  /**
+   * Updates the consent state of the conversation.
+   *
+   * @param {ConsentState} state - The new consent state to set.
+   * @returns {Promise<void>}
+   */
   updateConsent(state: ConsentState): Promise<void>
+
+  /**
+   * Returns the disappearing message settings for the conversation.
+   *
+   * @returns {Promise<DisappearingMessageSettings | undefined>} The settings, or undefined if not enabled.
+   */
   disappearingMessageSettings(): Promise<
     DisappearingMessageSettings | undefined
   >
+
+  /**
+   * Checks if disappearing messages are enabled for the conversation.
+   *
+   * @returns {Promise<boolean>} True if disappearing messages are enabled.
+   */
   isDisappearingMessagesEnabled(): Promise<boolean>
+
+  /**
+   * Checks if the conversation is active.
+   *
+   * @returns {Promise<boolean>} True if the conversation is active.
+   */
   isActive(): Promise<boolean>
+
+  /**
+   * Clears the disappearing message settings for the conversation.
+   *
+   * @returns {Promise<void>}
+   */
   clearDisappearingMessageSettings(): Promise<void>
+
+  /**
+   * Updates the disappearing message settings for the conversation.
+   *
+   * @param {DisappearingMessageSettings} disappearingMessageSettings - The new settings to apply.
+   * @returns {Promise<void>}
+   */
   updateDisappearingMessageSettings(
     disappearingMessageSettings: DisappearingMessageSettings
   ): Promise<void>
+
+  /**
+   * Processes an encrypted message received via push notification.
+   *
+   * @param {string} encryptedMessage - The encrypted message to process.
+   * @returns {Promise<DecodedMessage<ContentTypes[number]>>} The decoded message.
+   */
   processMessage(
     encryptedMessage: string
   ): Promise<DecodedMessage<ContentTypes[number]>>
+
+  /**
+   * Returns the list of members in the conversation.
+   *
+   * @returns {Promise<Member[]>} An array of Member objects.
+   */
   members(): Promise<Member[]>
+
+  /**
+   * Returns the version number if the conversation is paused due to a version mismatch.
+   *
+   * @returns {Promise<string>} The version string, or null if not paused.
+   */
   pausedForVersion(): Promise<string>
+
+  /**
+   * Returns the HMAC keys for the conversation (used for push notifications).
+   *
+   * @returns {Promise<keystore.GetConversationHmacKeysResponse>}
+   */
   getConversationHmacKeys(): Promise<keystore.GetConversationHmacKeysResponse>
+
+  /**
+   * Returns the push notification topics for the conversation.
+   *
+   * @returns {Promise<ConversationTopic[]>}
+   */
   getConversationPushTopics(): Promise<ConversationTopic[]>
+
+  /**
+   * Returns debug information about the conversation.
+   *
+   * @returns {Promise<ConversationDebugInfo>}
+   */
   getDebugInformation(): Promise<ConversationDebugInfo>
+
+  /**
+   * Deletes a message from the conversation.
+   *
+   * @param {MessageId} messageId - The ID of the message to delete.
+   * @returns {Promise<string>} The ID of the deletion message.
+   */
   deleteMessage(messageId: MessageId): Promise<string>
 }
 

--- a/src/lib/Conversation.ts
+++ b/src/lib/Conversation.ts
@@ -42,8 +42,10 @@ export interface ConversationBase<ContentTypes extends DefaultContentTypes> {
   ): Promise<MessageId>
   prepareMessage<SendContentTypes extends DefaultContentTypes = ContentTypes>(
     content: ConversationSendPayload<SendContentTypes>,
-    opts?: SendOptions
+    opts?: SendOptions,
+    noSend?: boolean
   ): Promise<MessageId>
+  publishMessage(messageId: MessageId): Promise<void>
   sync()
   messages(opts?: MessagesOptions): Promise<DecodedMessageUnion<ContentTypes>[]>
   streamMessages(

--- a/src/lib/Conversation.ts
+++ b/src/lib/Conversation.ts
@@ -6,6 +6,7 @@ import {
   ConversationTopic,
   MessageId,
   MessagesOptions,
+  EnrichedMessagesOptions,
   SendOptions,
 } from './types'
 import {
@@ -18,7 +19,10 @@ import {
   ConversationDebugInfo,
 } from '../index'
 import { CommitLogForkStatus } from './ConversationDebugInfo'
-import { DecodedMessageUnion } from './types/DecodedMessageUnion'
+import {
+  DecodedMessageUnion,
+  DecodedMessageUnionV2,
+} from './types/DecodedMessageUnion'
 import { DefaultContentTypes } from './types/DefaultContentType'
 
 export enum ConversationVersion {
@@ -48,6 +52,9 @@ export interface ConversationBase<ContentTypes extends DefaultContentTypes> {
   publishMessage(messageId: MessageId): Promise<void>
   sync()
   messages(opts?: MessagesOptions): Promise<DecodedMessageUnion<ContentTypes>[]>
+  enrichedMessages(
+    opts?: EnrichedMessagesOptions
+  ): Promise<DecodedMessageUnionV2<ContentTypes>[]>
   streamMessages(
     callback: (message: DecodedMessage<ContentTypes[number]>) => Promise<void>,
     onClose?: () => void

--- a/src/lib/Conversations.ts
+++ b/src/lib/Conversations.ts
@@ -606,7 +606,9 @@ export default class Conversations<
     return async () => {
       messageDeletionSubscription.remove()
       closedMessageDeletionSubscription?.remove()
-      XMTPModule.unsubscribeFromMessageDeletions(this.client.installationId)
+      await XMTPModule.unsubscribeFromMessageDeletions(
+        this.client.installationId
+      )
     }
   }
 
@@ -652,6 +654,6 @@ export default class Conversations<
       this.subscriptions[EventTypes.MessageDeletionClosed].remove()
       delete this.subscriptions[EventTypes.MessageDeletionClosed]
     }
-    XMTPModule.unsubscribeFromMessageDeletions(this.client.installationId)
+    await XMTPModule.unsubscribeFromMessageDeletions(this.client.installationId)
   }
 }

--- a/src/lib/DecodedMessageV2.ts
+++ b/src/lib/DecodedMessageV2.ts
@@ -31,7 +31,7 @@ export class DecodedMessageV2<
   insertedAtNs: number
   expiresAtNs: number | undefined
   expiresAt: Date | undefined
-  deliveryStatus: MessageDeliveryStatus = MessageDeliveryStatus.PUBLISHED
+  deliveryStatus: MessageDeliveryStatus
   reactions: DecodedMessageV2<ContentType>[]
   hasReactions: boolean
   reactionCount: number

--- a/src/lib/DecodedMessageV2.ts
+++ b/src/lib/DecodedMessageV2.ts
@@ -1,0 +1,209 @@
+import { Buffer } from 'buffer'
+
+import { Client, ExtractDecodedType, InboxId } from './Client'
+import {
+  ContentTypeId,
+  JSContentCodec,
+  NativeContentCodec,
+  NativeMessageContent,
+  contentTypeIdToString,
+} from './ContentCodec'
+import { MessageDeliveryStatus } from './DecodedMessage'
+import { ConversationId, MessageId } from './types'
+import {
+  DecodedMessageUnionV2,
+} from './types/DecodedMessageUnion'
+import { DefaultContentTypes } from './types/DefaultContentType'
+
+const allowEmptyProperties: (keyof NativeMessageContent)[] = [
+  'text',
+  'readReceipt',
+]
+
+export class DecodedMessageV2<
+  ContentType extends DefaultContentTypes[number] = DefaultContentTypes[number],
+> {
+  id: MessageId
+  conversationId: ConversationId
+  senderInboxId: InboxId
+  sentAt: Date
+  sentAtNs: number // timestamp in nanoseconds
+  insertedAtNs: number
+  expiresAtNs: number | undefined
+  expiresAt: Date | undefined
+  deliveryStatus: MessageDeliveryStatus = MessageDeliveryStatus.PUBLISHED
+  reactions: DecodedMessageV2<ContentType>[]
+  hasReactions: boolean
+  reactionCount: number
+  fallbackText: string | undefined
+  contentTypeId: ContentTypeId
+  nativeContent: NativeMessageContent
+
+  static from<
+    ContentType extends
+      DefaultContentTypes[number] = DefaultContentTypes[number],
+    ContentTypes extends DefaultContentTypes = ContentType[],
+  >(json: string): DecodedMessageUnionV2<ContentTypes> {
+    const decoded = JSON.parse(json)
+    if (!decoded) {
+      throw new Error('Tried to parse null as a DecodedMessage')
+    }
+    // Parse any child messages recursively
+    const reactions = decoded.reactions?.map((reactionJson: any) =>
+      DecodedMessageV2.fromObject<ContentType>({
+        ...reactionJson,
+        deliveryStatus: reactionJson.deliveryStatus,
+      })
+    )
+    return new DecodedMessageV2<ContentType>(
+      decoded.id,
+      decoded.conversationId,
+      decoded.senderInboxId,
+      decoded.sentAt,
+      decoded.sentAtNs,
+      decoded.insertedAtNs,
+      decoded.expiresAtNs,
+      decoded.expiresAt,
+      decoded.deliveryStatus,
+      decoded.reactions,
+      decoded.hasReactions,
+      decoded.reactionCount,
+      decoded.fallbackText,
+      decoded.contentTypeId,
+      decoded.nativeContent
+    ) as DecodedMessageUnionV2<ContentTypes>
+  }
+
+  static fromObject<
+    ContentType extends
+      DefaultContentTypes[number] = DefaultContentTypes[number],
+  >(object: {
+    id: MessageId
+    conversationId: ConversationId
+    senderInboxId: InboxId
+    sentAt: Date
+    sentAtNs: number // timestamp in nanoseconds
+    insertedAtNs: number
+    expiresAtNs: number | undefined
+    expiresAt: Date | undefined
+    deliveryStatus: MessageDeliveryStatus
+    reactions: DecodedMessageV2<ContentType>[]
+    hasReactions: boolean
+    reactionCount: number
+    fallbackText: string | undefined
+    contentTypeId: ContentTypeId
+    nativeContent: NativeMessageContent
+  }): DecodedMessageV2<ContentType> {
+    return new DecodedMessageV2(
+      object.id,
+      object.conversationId,
+      object.senderInboxId,
+      object.sentAt,
+      object.sentAtNs,
+      object.insertedAtNs,
+      object.expiresAtNs,
+      object.expiresAt,
+      object.deliveryStatus,
+      object.reactions,
+      object.hasReactions,
+      object.reactionCount,
+      object.fallbackText,
+      object.contentTypeId,
+      object.nativeContent
+    )
+  }
+
+  constructor(
+    id: MessageId,
+    conversationId: ConversationId,
+    senderInboxId: InboxId,
+    sentAt: Date,
+    sentAtNs: number, // timestamp in nanoseconds
+    insertedAtNs: number,
+    expiresAtNs: number | undefined,
+    expiresAt: Date | undefined,
+    deliveryStatus: MessageDeliveryStatus,
+    reactions: DecodedMessageV2<ContentType>[],
+    hasReactions: boolean,
+    reactionCount: number,
+    fallbackText: string | undefined,
+    contentTypeId: ContentTypeId,
+    nativeContent: NativeMessageContent
+  ) {
+    this.id = id
+    this.conversationId = conversationId
+    this.senderInboxId = senderInboxId
+    this.sentAt = sentAt
+    this.sentAtNs = sentAtNs
+    this.insertedAtNs = insertedAtNs
+    this.expiresAtNs = expiresAtNs
+    this.expiresAt = expiresAt
+    this.deliveryStatus = deliveryStatus
+    this.reactions = reactions
+    this.hasReactions = hasReactions
+    this.reactionCount = reactionCount
+    this.fallbackText = fallbackText
+    this.contentTypeId = contentTypeId
+    this.nativeContent = nativeContent
+  }
+
+  content(): ExtractDecodedType<ContentType> {
+    const encodedJSON = this.nativeContent.encoded
+    if (encodedJSON) {
+      const encoded = JSON.parse(encodedJSON)
+      const codec = Client.codecRegistry[
+        contentTypeIdToString(this.contentTypeId)
+      ] as JSContentCodec<ExtractDecodedType<ContentType>>
+      if (!codec) {
+        throw new Error(
+          `no content type found ${JSON.stringify(this.contentTypeId)}`
+        )
+      }
+      if (encoded.content) {
+        encoded.content = new Uint8Array(Buffer.from(encoded.content, 'base64'))
+      }
+      return codec.decode(encoded)
+    } else if (this.nativeContent.unknown) {
+      // Handle unknown/custom content types from DecodedMessageV2
+      // The native layer returns {"unknown": {"contentTypeId": "...", "content": "..."}}
+      const unknownContent = this.nativeContent.unknown
+      const contentTypeIdStr =
+        unknownContent.contentTypeId ??
+        contentTypeIdToString(this.contentTypeId)
+      const codec = Client.codecRegistry[contentTypeIdStr] as JSContentCodec<
+        ExtractDecodedType<ContentType>
+      >
+      if (!codec) {
+        throw new Error(
+          `no content type found for unknown content: ${JSON.stringify(this.nativeContent)}`
+        )
+      }
+      // The content is already JSON-stringified, parse it directly
+      if (unknownContent.content) {
+        return JSON.parse(
+          unknownContent.content
+        ) as ExtractDecodedType<ContentType>
+      }
+      throw new Error(
+        `unknown content has no content field: ${JSON.stringify(this.nativeContent)}`
+      )
+    } else {
+      for (const codec of Object.values(Client.codecRegistry)) {
+        if (
+          ('contentKey' in codec && this.nativeContent[codec.contentKey]) ||
+          allowEmptyProperties.some((prop) =>
+            this.nativeContent.hasOwnProperty(prop)
+          )
+        ) {
+          return (
+            codec as NativeContentCodec<ExtractDecodedType<ContentType>>
+          ).decode(this.nativeContent)
+        }
+      }
+
+      throw new Error(
+        `no content type found ${JSON.stringify(this.nativeContent)}`
+      )
+    }
+  }
+}

--- a/src/lib/DecodedMessageV2.ts
+++ b/src/lib/DecodedMessageV2.ts
@@ -10,9 +10,7 @@ import {
 } from './ContentCodec'
 import { MessageDeliveryStatus } from './DecodedMessage'
 import { ConversationId, MessageId } from './types'
-import {
-  DecodedMessageUnionV2,
-} from './types/DecodedMessageUnion'
+import { DecodedMessageUnionV2 } from './types/DecodedMessageUnion'
 import { DefaultContentTypes } from './types/DefaultContentType'
 
 const allowEmptyProperties: (keyof NativeMessageContent)[] = [

--- a/src/lib/Dm.ts
+++ b/src/lib/Dm.ts
@@ -462,4 +462,17 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
   async getDebugInformation(): Promise<ConversationDebugInfo> {
     return await XMTP.getDebugInformation(this.client.installationId, this.id)
   }
+
+  /**
+   * Deletes a message from the dm. You must be the sender of the message or a super admin of the conversation in order to delete the message.
+   * @param {MessageId} messageId The id of the message to delete.
+   * @returns {Promise<string>} A Promise that resolves to the id of the deleted message.
+   */
+  async deleteMessage(messageId: MessageId): Promise<string> {
+    return await XMTP.deleteMessage(
+      this.client.installationId,
+      this.id,
+      messageId
+    )
+  }
 }

--- a/src/lib/Dm.ts
+++ b/src/lib/Dm.ts
@@ -15,10 +15,17 @@ import {
 } from '../index'
 import { CommitLogForkStatus } from './ConversationDebugInfo'
 import { ConversationSendPayload } from './types/ConversationCodecs'
-import { DecodedMessageUnion } from './types/DecodedMessageUnion'
+import {
+  DecodedMessageUnion,
+  DecodedMessageUnionV2,
+} from './types/DecodedMessageUnion'
 import { DefaultContentTypes } from './types/DefaultContentType'
 import { EventTypes } from './types/EventTypes'
-import { MessageId, MessagesOptions } from './types/MessagesOptions'
+import {
+  MessageId,
+  MessagesOptions,
+  EnrichedMessagesOptions,
+} from './types/MessagesOptions'
 import { SendOptions } from './types/SendOptions'
 
 export interface DmParams {
@@ -232,6 +239,32 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
       opts?.direction,
       opts?.excludeContentTypes,
       opts?.excludeSenderInboxIds
+    )
+  }
+
+  /**
+   * This method returns an array of enriched messages (V2) associated with the dm.
+   * Enriched messages include additional metadata like reactions, delivery status, and more.
+   * To get the latest messages from the network, call sync() first.
+   *
+   * @param {EnrichedMessagesOptions} opts - Optional parameters for filtering messages.
+   * @returns {Promise<DecodedMessageUnionV2<ContentTypes>[]>} A Promise that resolves to an array of DecodedMessageV2 objects.
+   */
+  async enrichedMessages(
+    opts?: EnrichedMessagesOptions
+  ): Promise<DecodedMessageUnionV2<ContentTypes>[]> {
+    return await XMTP.conversationEnrichedMessages(
+      this.client.installationId,
+      this.id,
+      opts?.limit,
+      opts?.beforeNs,
+      opts?.afterNs,
+      opts?.direction,
+      opts?.excludeSenderInboxIds,
+      opts?.deliveryStatus,
+      opts?.insertedAfterNs,
+      opts?.insertedBeforeNs,
+      opts?.sortBy
     )
   }
 

--- a/src/lib/Dm.ts
+++ b/src/lib/Dm.ts
@@ -126,17 +126,22 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
    * Prepare a dm message to be sent.
    *
    * @param {string | MessageContent} content - The content of the message. It can be either a string or a structured MessageContent object.
-   * @returns {Promise<string>} A Promise that resolves to a string identifier for the prepared message to be sent.
+   * @param {SendOptions} opts - The options for the message.
+   * @param {boolean} noSend - When true, the prepared message will not be published until
+   *               [publishMessage] is called with the returned message ID.
+   *               When false (default), uses optimistic sending and the message
+   *               will be published with the next [publishMessages] call.   * @returns {Promise<string>} A Promise that resolves to a string identifier for the prepared message to be sent.
    * @throws {Error} Throws an error if there is an issue with sending the message.
    */
   async prepareMessage<
     SendContentTypes extends DefaultContentTypes = ContentTypes,
   >(
     content: ConversationSendPayload<SendContentTypes>,
-    opts?: SendOptions
+    opts?: SendOptions,
+    noSend?: boolean
   ): Promise<MessageId> {
     if (opts && opts.contentType) {
-      return await this._prepareWithJSCodec(content, opts.contentType)
+      return await this._prepareWithJSCodec(content, opts.contentType, noSend)
     }
 
     try {
@@ -147,7 +152,8 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
       return await XMTP.prepareMessage(
         this.client.installationId,
         this.id,
-        content
+        content,
+        noSend ?? false
       )
     } catch (e) {
       console.info('ERROR in prepareMessage()', e.message)
@@ -157,7 +163,8 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
 
   private async _prepareWithJSCodec<T>(
     content: T,
-    contentType: XMTP.ContentTypeId
+    contentType: XMTP.ContentTypeId,
+    noSend?: boolean
   ): Promise<MessageId> {
     const codec =
       Client.codecRegistry[
@@ -172,8 +179,18 @@ export class Dm<ContentTypes extends DefaultContentTypes = DefaultContentTypes>
       this.client.installationId,
       this.id,
       content,
-      codec
+      codec,
+      noSend ?? false
     )
+  }
+
+  /**
+   * Publishes a message that was prepared with noSend = true.
+   * @param {MessageId} messageId The id of the message to publish.
+   * @returns {Promise<void>} A Promise that resolves when the message is published.
+   */
+  publishMessage(messageId: MessageId): Promise<void> {
+    return XMTP.publishMessage(this.client.installationId, this.id, messageId)
   }
 
   /**

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -346,6 +346,7 @@ export class Group<
       await XMTP.unsubscribeFromMessages(this.client.installationId, this.id)
     }
   }
+
   /**
    *
    * @param inboxIds inboxIds to add to the group

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -813,4 +813,17 @@ export class Group<
   async leaveGroup(): Promise<void> {
     return await XMTP.leaveGroup(this.client.installationId, this.id)
   }
+
+  /**
+   * Deletes a message from the dm. You must be the sender of the message or a super admin of the conversation in order to delete the message.
+   * @param {MessageId} messageId The id of the message to delete.
+   * @returns {Promise<string>} A Promise that resolves to the id of the deleted message.
+   */
+  async deleteMessage(messageId: MessageId): Promise<string> {
+    return await XMTP.deleteMessage(
+      this.client.installationId,
+      this.id,
+      messageId
+    )
+  }
 }

--- a/src/lib/Group.ts
+++ b/src/lib/Group.ts
@@ -16,10 +16,17 @@ import {
   PublicIdentity,
 } from '../index'
 import { ConversationSendPayload } from './types/ConversationCodecs'
-import { DecodedMessageUnion } from './types/DecodedMessageUnion'
+import {
+  DecodedMessageUnion,
+  DecodedMessageUnionV2,
+} from './types/DecodedMessageUnion'
 import { DefaultContentTypes } from './types/DefaultContentType'
 import { EventTypes } from './types/EventTypes'
-import { MessageId, MessagesOptions } from './types/MessagesOptions'
+import {
+  MessageId,
+  MessagesOptions,
+  EnrichedMessagesOptions,
+} from './types/MessagesOptions'
 import { PermissionPolicySet } from './types/PermissionPolicySet'
 import { SendOptions } from './types/SendOptions'
 
@@ -259,6 +266,32 @@ export class Group<
       opts?.direction,
       opts?.excludeContentTypes,
       opts?.excludeSenderInboxIds
+    )
+  }
+
+  /**
+   * This method returns an array of enriched messages (V2) associated with the group.
+   * Enriched messages include additional metadata like reactions, delivery status, and more.
+   * To get the latest messages from the network, call sync() first.
+   *
+   * @param {EnrichedMessagesOptions} opts - Optional parameters for filtering messages.
+   * @returns {Promise<DecodedMessageUnionV2<ContentTypes>[]>} A Promise that resolves to an array of DecodedMessageV2 objects.
+   */
+  async enrichedMessages(
+    opts?: EnrichedMessagesOptions
+  ): Promise<DecodedMessageUnionV2<ContentTypes>[]> {
+    return await XMTP.conversationEnrichedMessages(
+      this.client.installationId,
+      this.id,
+      opts?.limit,
+      opts?.beforeNs,
+      opts?.afterNs,
+      opts?.direction,
+      opts?.excludeSenderInboxIds,
+      opts?.deliveryStatus,
+      opts?.insertedAfterNs,
+      opts?.insertedBeforeNs,
+      opts?.sortBy
     )
   }
 

--- a/src/lib/NativeCodecs/DeleteMessageCodec.ts
+++ b/src/lib/NativeCodecs/DeleteMessageCodec.ts
@@ -1,38 +1,37 @@
 import {
-    ContentTypeId,
-    DeleteMessageContent,
-    NativeContentCodec,
-    NativeMessageContent,
-  } from '../ContentCodec'
-  
-  export class DeleteMessageCodec
-    implements NativeContentCodec<DeleteMessageContent>
-  {
-    contentKey: 'deleteMessage' = 'deleteMessage'
-  
-    contentType: ContentTypeId = {
-      authorityId: 'xmtp.org',
-      typeId: 'deletedMessage',
-      versionMajor: 1,
-      versionMinor: 0,
-    }
-  
-    encode(content: DeleteMessageContent): NativeMessageContent {
-      return {
-        deleteMessage: content,
-      }
-    }
-  
-    decode(nativeContent: NativeMessageContent): DeleteMessageContent {
-      return nativeContent.deleteMessage!
-    }
-  
-    fallback(content: DeleteMessageContent): string | undefined {
-      return content.messageId ?? 'Message ID is required'
-    }
-  
-    shouldPush(content: DeleteMessageContent): boolean {
-      return false
+  ContentTypeId,
+  DeleteMessageContent,
+  NativeContentCodec,
+  NativeMessageContent,
+} from '../ContentCodec'
+
+export class DeleteMessageCodec
+  implements NativeContentCodec<DeleteMessageContent>
+{
+  contentKey: 'deleteMessage' = 'deleteMessage'
+
+  contentType: ContentTypeId = {
+    authorityId: 'xmtp.org',
+    typeId: 'deletedMessage',
+    versionMajor: 1,
+    versionMinor: 0,
+  }
+
+  encode(content: DeleteMessageContent): NativeMessageContent {
+    return {
+      deleteMessage: content,
     }
   }
-  
+
+  decode(nativeContent: NativeMessageContent): DeleteMessageContent {
+    return nativeContent.deleteMessage!
+  }
+
+  fallback(content: DeleteMessageContent): string | undefined {
+    return content.messageId ?? 'Message ID is required'
+  }
+
+  shouldPush(content: DeleteMessageContent): boolean {
+    return false
+  }
+}

--- a/src/lib/NativeCodecs/DeleteMessageCodec.ts
+++ b/src/lib/NativeCodecs/DeleteMessageCodec.ts
@@ -5,6 +5,11 @@ import {
   NativeMessageContent,
 } from '../ContentCodec'
 
+/**
+ * Native codec for delete-message content.
+ * contentType must match Android ContentTypeDeleteMessageRequest and iOS ContentTypeDeleteMessageRequest
+ * (authorityId/typeId/version). Serialized under key "deleteMessage" in ContentJson/ContentJsonV2/MessageWrapper.
+ */
 export class DeleteMessageCodec
   implements NativeContentCodec<DeleteMessageContent>
 {
@@ -12,7 +17,7 @@ export class DeleteMessageCodec
 
   contentType: ContentTypeId = {
     authorityId: 'xmtp.org',
-    typeId: 'deletedMessage',
+    typeId: 'deleteMessage',
     versionMajor: 1,
     versionMinor: 0,
   }

--- a/src/lib/NativeCodecs/DeleteMessageCodec.ts
+++ b/src/lib/NativeCodecs/DeleteMessageCodec.ts
@@ -1,0 +1,38 @@
+import {
+    ContentTypeId,
+    DeleteMessageContent,
+    NativeContentCodec,
+    NativeMessageContent,
+  } from '../ContentCodec'
+  
+  export class DeleteMessageCodec
+    implements NativeContentCodec<DeleteMessageContent>
+  {
+    contentKey: 'deleteMessage' = 'deleteMessage'
+  
+    contentType: ContentTypeId = {
+      authorityId: 'xmtp.org',
+      typeId: 'deletedMessage',
+      versionMajor: 1,
+      versionMinor: 0,
+    }
+  
+    encode(content: DeleteMessageContent): NativeMessageContent {
+      return {
+        deleteMessage: content,
+      }
+    }
+  
+    decode(nativeContent: NativeMessageContent): DeleteMessageContent {
+      return nativeContent.deleteMessage!
+    }
+  
+    fallback(content: DeleteMessageContent): string | undefined {
+      return content.messageId ?? 'Message ID is required'
+    }
+  
+    shouldPush(content: DeleteMessageContent): boolean {
+      return false
+    }
+  }
+  

--- a/src/lib/NativeCodecs/LeaveRequestCodec.ts
+++ b/src/lib/NativeCodecs/LeaveRequestCodec.ts
@@ -1,0 +1,38 @@
+import {
+  ContentTypeId,
+  LeaveRequestContent,
+  NativeContentCodec,
+  NativeMessageContent,
+  ReadReceiptContent,
+} from '../ContentCodec'
+
+export class LeaveRequestCodec
+  implements NativeContentCodec<LeaveRequestContent>
+{
+  contentKey: 'leaveRequest' = 'leaveRequest'
+
+  contentType: ContentTypeId = {
+    authorityId: 'xmtp.org',
+    typeId: 'leave_request',
+    versionMajor: 1,
+    versionMinor: 0,
+  }
+
+  encode(content: LeaveRequestContent): NativeMessageContent {
+    return {
+      leaveRequest: content,
+    }
+  }
+
+  decode(nativeContent: NativeMessageContent): LeaveRequestContent {
+    return nativeContent.leaveRequest!
+  }
+
+  fallback(content: LeaveRequestContent): string | undefined {
+    return content.authenticatedNote ?? 'User requested to leave the group'
+  }
+
+  shouldPush(content: LeaveRequestContent): boolean {
+    return false
+  }
+}

--- a/src/lib/XMTPDebugInformation.ts
+++ b/src/lib/XMTPDebugInformation.ts
@@ -20,13 +20,6 @@ export default class XMTPDebugInformation {
     )
   }
 
-  async uploadDebugInformation(serverUrl?: string): Promise<string> {
-    return await XMTPModule.uploadDebugInformation(
-      this.client.installationId,
-      serverUrl
-    )
-  }
-
   async getKeyPackageStatuses(
     installationIds: InstallationId[]
   ): Promise<KeyPackageStatuses> {

--- a/src/lib/types/ContentCodec.ts
+++ b/src/lib/types/ContentCodec.ts
@@ -5,8 +5,18 @@ import { InboxId } from '../Client'
 export type EncodedContent = content.EncodedContent
 export type ContentTypeId = content.ContentTypeId
 
+/**
+ * Converts a ContentTypeId to a string that can be used as a hash key.
+ * Format: "authorityId/typeId:versionMajor.versionMinor"
+ * Example: "xmtp.org/text:1.0"
+ */
+export function contentTypeIdToString(contentTypeId: ContentTypeId): string {
+  return `${contentTypeId.authorityId}/${contentTypeId.typeId}:${contentTypeId.versionMajor}.${contentTypeId.versionMinor}`
+}
+
 export type UnknownContent = {
   contentTypeId: string
+  content?: string
 }
 
 export type ReadReceiptContent = object

--- a/src/lib/types/ContentCodec.ts
+++ b/src/lib/types/ContentCodec.ts
@@ -53,6 +53,14 @@ export type EncryptedLocalAttachment = {
   metadata: RemoteAttachmentMetadata
 }
 
+export type LeaveRequestContent = {
+  authenticatedNote?: string
+}
+
+export type DeleteMessageContent = {
+  messageId?: string
+}
+
 export type MultiRemoteAttachmentMetadata = {
   filename?: string
   secret: string
@@ -101,6 +109,8 @@ export type NativeMessageContent = {
   readReceipt?: ReadReceiptContent
   encoded?: string
   groupUpdated?: GroupUpdatedContent
+  leaveRequest?: LeaveRequestContent
+  deleteMessage?: DeleteMessageContent
 }
 
 export interface JSContentCodec<T> {

--- a/src/lib/types/DecodedMessageUnion.ts
+++ b/src/lib/types/DecodedMessageUnion.ts
@@ -1,11 +1,20 @@
 import { DefaultContentTypes } from './DefaultContentType'
 import { ContentCodec } from '../ContentCodec'
 import { DecodedMessage } from '../DecodedMessage'
+import { DecodedMessageV2 } from '../DecodedMessageV2'
 
 export type DecodedMessageUnion<
   ContentTypes extends DefaultContentTypes = DefaultContentTypes,
 > = {
   [K in keyof ContentTypes]: ContentTypes[K] extends ContentCodec<any>
     ? DecodedMessage<ContentTypes[K]>
+    : never
+}[number]
+
+export type DecodedMessageUnionV2<
+  ContentTypes extends DefaultContentTypes = DefaultContentTypes,
+> = {
+  [K in keyof ContentTypes]: ContentTypes[K] extends ContentCodec<any>
+    ? DecodedMessageV2<ContentTypes[K]>
     : never
 }[number]

--- a/src/lib/types/EventTypes.ts
+++ b/src/lib/types/EventTypes.ts
@@ -47,4 +47,12 @@ export enum EventTypes {
    * A preference stream was closed
    */
   PreferenceUpdatesClosed = 'preferencesClosed',
+  /**
+   * A message deletion event
+   */
+  MessageDeletion = 'messageDeletion',
+  /**
+   * A message deletion stream was closed
+   */
+  MessageDeletionClosed = 'messageDeletionClosed',
 }

--- a/src/lib/types/MessagesOptions.ts
+++ b/src/lib/types/MessagesOptions.ts
@@ -7,5 +7,24 @@ export type MessagesOptions = {
   excludeSenderInboxIds?: string[] | undefined
 }
 
+export type EnrichedMessageDeliveryStatus =
+  | 'ALL'
+  | 'PUBLISHED'
+  | 'UNPUBLISHED'
+  | 'FAILED'
+export type EnrichedMessageSortBy = 'SENT_TIME' | 'INSERTED_TIME'
+
+export type EnrichedMessagesOptions = {
+  limit?: number | undefined
+  beforeNs?: number | undefined
+  afterNs?: number | undefined
+  direction?: MessageOrder | undefined
+  excludeSenderInboxIds?: string[] | undefined
+  deliveryStatus?: EnrichedMessageDeliveryStatus | undefined
+  insertedAfterNs?: number | undefined
+  insertedBeforeNs?: number | undefined
+  sortBy?: EnrichedMessageSortBy | undefined
+}
+
 export type MessageOrder = 'ASCENDING' | 'DESCENDING'
 export type MessageId = string & { readonly brand: unique symbol }

--- a/src/lib/types/PermissionPolicySet.ts
+++ b/src/lib/types/PermissionPolicySet.ts
@@ -15,4 +15,5 @@ export type PermissionPolicySet = {
   updateGroupDescriptionPolicy: PermissionOption
   updateGroupImagePolicy: PermissionOption
   updateMessageDisappearingPolicy: PermissionOption
+  updateAppDataPolicy: PermissionOption
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add `Client.sendSyncRequest()`, extend message preparation with `noSend`, implement `Conversations.streamMessageDeletions()`, and upgrade native SDKs to libxmtp 1.9.0 across iOS (XMTP 4.9.0) and Android (org.xmtp:android 4.9.0)
Introduce manual device sync via `Client.sendSyncRequest()`, support deferred publishing with `Conversation.prepareMessage(..., noSend)`, add real-time deletion streaming with `Conversations.streamMessageDeletions()`, implement enriched message decoding/serialization (`DecodedMessageV2`) and deletion/leave-request codecs, expose publish/delete/enriched messages APIs, and pass `appData` through group creation; bump native dependencies to XMTP 4.9.0.

#### 📍Where to Start
Start with the deletion streaming flow at `Conversations.streamMessageDeletions` in [Conversations.ts](https://github.com/xmtp/xmtp-react-native/pull/765/files#diff-c5227210ea741b70a7f1c730d3dc81ff6c90156a21cee65f6fbb29f86099c9f8), then review the platform handlers in [XMTPModule.swift](https://github.com/xmtp/xmtp-react-native/pull/765/files#diff-6260b37315249e4d7814a7eed83d9c53d15c299d753edd037d00ddd617d5a2b9) and [XMTPModule.kt](https://github.com/xmtp/xmtp-react-native/pull/765/files#diff-3d1b8496c4f066a0a1d2f776063d85d49f70545d6a94a57fe91eb6efecd50a48).

<!-- Macroscope's changelog starts here -->
#### Changes since #765 opened

- Changed `DecodedMessageV2.from()` factory method to assign the recursively parsed reactions array or an empty array instead of passing through the decoded reactions directly [68233db]
- Updated `DecodedMessageV2.content()` and `DecodedMessageV2.decodedContent()` methods to document FFI limitations with `enrichedMessages()` for unknown or custom content types and adjusted codec handling [68233db]
- Added documentation in conversation tests explaining a removed test and the limitation where `enrichedMessages()` does not apply `JSContentCodec.decode()` transformations [68233db]
- Modified `ContentJsonV2.toJsonMap` in iOS to serialize unknown and custom content types as structured JSON [a789e15]
- Added assertions and logging to the custom content type test to validate structured JSON in `nativeContent` [a789e15]
- Consolidated `DecodedMessageUnionV2` import and removed default initialization of `deliveryStatus` in `DecodedMessageV2` [a789e15]
- Changed `MessageWrapper.encodeToObjV2` to conditionally include optional fields in result dictionary [e13af0a]
- Removed debug information upload functionality including the `uploadDebugInformation` exported function, the `XMTPDebugInformation.uploadDebugInformation` instance method, and the associated test case that verified upload key generation [df5dc25]
- Added `updateAppDataPolicy: 'allow'` field to `customPermissionsPolicySet` objects in group permissions tests [2e00272]
- Updated `reactionV2` content parsing in `ContentJson` wrapper to use `Reaction` payload type instead of `FfiReactionPayload`, changed helper functions from `getReactionV2Action` and `getReactionV2Schema` to `getReactionAction` and `getReactionSchema`, and populated `referenceInboxId` field from JSON data instead of using hardcoded empty string [cc2c241]
- Replaced `FfiReactionPayload` construction with `Reaction` construction in the reactionV2 branch of `ContentJson.fromJsonObj` parser [57d55a3]
- Changed `DeleteMessageCodec.contentType.typeId` from 'deletedMessage' to 'deleteMessage' [68d2712]
- Added test verifying native codec content type IDs match expected native SDK values [68d2712]
- Added delete message content type handling to JSON serialization [7eed895]
- Modified reaction object parsing in `ContentJson` wrapper to handle JSON null values for `referenceInboxId` [6da1e24]
- Updated package version from 5.1.0 to 5.2.0 [1f6cb9d]
<!-- Macroscope's changelog ends here -->

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7eed895. 30 files reviewed, 51 issues evaluated, 33 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt — 0 comments posted, 5 evaluated, 4 filtered</summary>

- [line 246](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L246): The `debugEventsEnabled` parameter from `authOptions` is no longer passed to `ClientOptions`. The value is still parsed from JSON in `authParamsFromJson` and stored in `AuthParamsWrapper`, but the removal of this line means debug events configuration will be silently ignored. If `ClientOptions` still supports this parameter, users setting `debugEventsEnabled: true` will not get expected debug event behavior. <b>[ Already posted ]</b>
- [line 593](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L593): The change from `sigRequest.let` to `sigRequest?.let` in `ffiRevokeAllOtherInstallationsSignatureText` means the function will now silently return `null` if `client.ffiRevokeAllOtherInstallations()` returns null. Callers expecting a non-null signature text string may encounter unexpected null values, potentially causing `NullPointerException` downstream. <b>[ Low confidence ]</b>
- [line 2424](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L2424): Catching `Exception` on line 2424 will also catch `CancellationException`, which can interfere with structured concurrency. When the coroutine is cancelled (e.g., via `subscriptions[...].cancel()`), the `CancellationException` will be caught, logged as an error, and not rethrown. This prevents proper cancellation propagation and could cause the coroutine to not terminate cleanly. The catch block should either catch a more specific exception type or rethrow `CancellationException`. <b>[ Already posted ]</b>
- [line 2426](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/XMTPModule.kt#L2426): In the catch block at line 2426, the code calls `cancel()` on the same job that is currently executing and failing. This is effectively a no-op since the job is already completing exceptionally, and represents dead code that suggests confusion about the coroutine lifecycle. <b>[ Already posted ]</b>
</details>

<details>
<summary>android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 154](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt#L154): If `referenceInboxId` key exists in the JSON but has a `null` value (e.g., `"referenceInboxId": null`), `reaction.get("referenceInboxId")` will return `JsonNull` (not Kotlin `null`), so the safe call `?.asString` won't protect against it—calling `asString` on `JsonNull` throws `UnsupportedOperationException`. Consider using `reaction.get("referenceInboxId")?.takeIf { !it.isJsonNull }?.asString ?: ""` instead. <b>[ Already posted ]</b>
- [line 176](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJson.kt#L176): The `fromJsonObject` method does not handle `"leaveRequest"` or `"deleteMessage"` JSON keys, but `toJsonMap()` serializes them with those keys. If a caller serializes a `LeaveRequest` or `DeleteMessageRequest` via `toJsonMap()` and then attempts to deserialize it via `fromJson()`, it will throw `"Unknown content type"` exception instead of round-tripping correctly. <b>[ Already posted ]</b>
</details>

<details>
<summary>android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJsonV2.kt — 0 comments posted, 10 evaluated, 7 filtered</summary>

- [line 143](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJsonV2.kt#L143): In `fromJsonObject` at line 143, the `reactionV2` branch creates a `ContentJson` with `FfiReactionPayload` as content type, but `ContentJson` (shown in the diff) was updated to use the SDK `Reaction` type instead. The comment on line 147 in `ContentJson` explicitly states "ReactionV2Codec encodes Reaction" - using `FfiReactionPayload` here will cause a type mismatch when the codec tries to encode the content, likely resulting in a `ClassCastException` or encoding failure. <b>[ Already posted ]</b>
- [line 143](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJsonV2.kt#L143): In `ContentJsonV2.fromJsonObject`, when parsing `reactionV2`, the code still creates `FfiReactionPayload` (line 143) and uses `getReactionV2Action`/`getReactionV2Schema` (lines 145-146), but the `ReactionV2Codec` was updated to encode `Reaction` type instead. The diff comment in `ContentJson.kt` explicitly states "Use SDK Reaction type (not FfiReactionPayload); ReactionV2Codec encodes Reaction." This inconsistency means messages created via `ContentJsonV2.fromJson` with `reactionV2` content will fail when encoded because the codec expects `Reaction` but receives `FfiReactionPayload`. <b>[ Already posted ]</b>
- [line 143](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJsonV2.kt#L143): In `ContentJsonV2.fromJsonObject()`, the `reactionV2` handling creates a `ContentJson` with `FfiReactionPayload` type at line 143, but the diff shows that `ContentJson.kt` was updated to use `Reaction` type instead. The `ReactionV2Codec` (per the comment in the updated `ContentJson.kt`) encodes `Reaction`, not `FfiReactionPayload`. This type mismatch will cause encoding failures or incorrect behavior when processing reactionV2 content through `ContentJsonV2`. <b>[ Already posted ]</b>
- [line 143](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJsonV2.kt#L143): In `fromJsonObject`, the `reactionV2` branch creates a `ContentJson` with `FfiReactionPayload` as the content type (lines 142-151), but according to the changes in `ContentJson.kt`, `ReactionV2Codec` now expects the SDK `Reaction` type instead. This is an incomplete change - `ContentJson.kt` was updated to use `Reaction` with `getReactionAction`/`getReactionSchema`, but `ContentJsonV2.kt` still uses the old `FfiReactionPayload` with `getReactionV2Action`/`getReactionV2Schema`. This type mismatch will cause encoding failures when sending reactionV2 messages via `ContentJsonV2.fromJsonObject`. <b>[ Already posted ]</b>
- [line 145](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJsonV2.kt#L145): At line 145-146, `getReactionV2Action` and `getReactionV2Schema` are used which return `FfiReactionAction` and `FfiReactionSchema` types, but since the code constructs `FfiReactionPayload` (which requires these FFI types), if this is corrected to use `Reaction` type instead, these functions should be replaced with `getReactionAction` and `getReactionSchema` which return the SDK-compatible types. <b>[ Already posted ]</b>
- [line 145](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJsonV2.kt#L145): In `ContentJsonV2.fromJsonObject()`, the `reactionV2` branch uses `getReactionV2Action()` and `getReactionV2Schema()` at lines 145-146, but `ContentJson.kt` was updated to use `getReactionAction()` and `getReactionSchema()` instead. These functions return different types (`FfiReactionAction`/`FfiReactionSchema` vs SDK `ReactionAction`/`ReactionSchema`), causing type incompatibility with the expected `Reaction` constructor parameters. <b>[ Already posted ]</b>
- [line 321](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/ContentJsonV2.kt#L321): At line 321, there is a redundant safe cast `(content as? DeleteMessageRequest)?.messageId` when `content` is already declared as `DeleteMessageRequest?` on line 318. This is unnecessary but harmless. <b>[ Low confidence ]</b>
</details>

<details>
<summary>android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/EnrichedMessageQueryParamsWrapper.kt — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 32](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/EnrichedMessageQueryParamsWrapper.kt#L32): If `paramsJson` contains malformed JSON that is not an object (e.g., `"hello"`, `123`, or `[]`), the `.asJsonObject` call on line 32 will throw an `IllegalStateException`. Consider wrapping this in a try-catch or validating the JSON structure. <b>[ Already posted ]</b>
- [line 36](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/EnrichedMessageQueryParamsWrapper.kt#L36): When a JSON field exists but has a `null` value (e.g., `{"limit": null}`), `jsonOptions.has("limit")` returns `true`, but calling `.asInt`, `.asLong`, or `.asString` on a `JsonNull` element will throw an `UnsupportedOperationException`. This affects all field extractions (lines 36, 43, 50, 57, 72, 79, 86, 93). The code should check `!jsonOptions.get("field").isJsonNull` before calling the type conversion methods. <b>[ Already posted ]</b>
- [line 64](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/EnrichedMessageQueryParamsWrapper.kt#L64): If `excludeSenderInboxIds` exists in the JSON but is not an array (e.g., a string or object), `getAsJsonArray("excludeSenderInboxIds")` on line 64 will throw an `IllegalStateException`. <b>[ Already posted ]</b>
- [line 65](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/EnrichedMessageQueryParamsWrapper.kt#L65): If the `excludeSenderInboxIds` array contains `null` elements in the JSON (e.g., `{"excludeSenderInboxIds": ["id1", null]}`), the `it.asString` call on line 65 will throw an `UnsupportedOperationException` when it encounters the null element. <b>[ Already posted ]</b>
</details>

<details>
<summary>android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/PermissionPolicySetWrapper.kt — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 55](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/android/src/main/java/expo/modules/xmtpreactnativesdk/wrappers/PermissionPolicySetWrapper.kt#L55): In `createPermissionPolicySetFromJson`, calling `jsonObj.get("updateAppDataPolicy").asString` will throw a `NullPointerException` if the JSON input doesn't contain the `updateAppDataPolicy` field. This breaks backward compatibility with any existing JSON data that was created before this field was added. The `get()` method returns `null` for missing keys, and calling `.asString` on `null` crashes. <b>[ Already posted ]</b>
</details>

<details>
<summary>ios/Wrappers/CreateGroupParamsWrapper.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 22](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/ios/Wrappers/CreateGroupParamsWrapper.swift#L22): The cast `as? Int64` for `disappearStartingAtNs` and `retentionDurationInNs` will silently fail even when valid numeric values are present in the JSON. `JSONSerialization` returns `NSNumber` for numeric values, which doesn't bridge directly to `Int64`. This will cause `DisappearingMessageSettings` to never be created even when the values are provided. Use `(jsonOptions["disappearStartingAtNs"] as? NSNumber)?.int64Value` instead. <b>[ Already posted ]</b>
</details>

<details>
<summary>ios/Wrappers/EnrichedMessageQueryParamsWrapper.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 36](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/ios/Wrappers/EnrichedMessageQueryParamsWrapper.swift#L36): The casts `as? Int64` for `beforeNs`, `afterNs`, `insertedAfterNs`, and `insertedBeforeNs` will silently fail and return `nil` even when valid numeric values are present in the JSON. `JSONSerialization` returns `NSNumber` for numeric values, which doesn't bridge directly to `Int64`. Use `(jsonOptions["beforeNs"] as? NSNumber)?.int64Value` pattern instead. <b>[ Already posted ]</b>
</details>

<details>
<summary>ios/Wrappers/MessageWrapper.swift — 1 comment posted, 6 evaluated, 4 filtered</summary>

- [line 31](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/ios/Wrappers/MessageWrapper.swift#L31): The method `encodeToObjV2` is marked with `throws` but never actually throws an error - all internal throwing calls use `try?` to swallow errors. While not a runtime crash, this is misleading since `encodeV2` uses `try encodeToObjV2(model)` expecting potential errors that will never come from this method. <b>[ Low confidence ]</b>
- [line 33](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/ios/Wrappers/MessageWrapper.swift#L33): Using `try?` with `compactMap` on line 33-34 silently drops any reactions that fail to encode. If `encodeToObjV2(reaction)` throws for any reaction, it will be filtered out of the results without any error or warning. This causes silent data loss where the consumer receives an incomplete `reactions` array and a `reactionCount` that doesn't match the number of reactions returned. <b>[ Already posted ]</b>
- [line 123](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/ios/Wrappers/MessageWrapper.swift#L123): Similar to the action issue, changing from `ReactionV2Schema.fromString()` to `ReactionSchema(rawValue:)` may fail silently. `ReactionV2Schema.fromString` handles "unicode", "shortcode", "custom" with a fallback to `.unknown`, but `ReactionSchema(rawValue:)` returns `nil` for unrecognized values. If the raw value strings differ between the V2 helper and `ReactionSchema` enum, the schema would be `nil`. <b>[ Already posted ]</b>
- [line 385](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/ios/Wrappers/MessageWrapper.swift#L385): Inconsistent `scheme` value between `ContentTypeRemoteAttachment` (line 385: `"https://"`) and `ContentTypeMultiRemoteAttachment` (line 395: `"https"`). If downstream consumers expect a consistent format, this mismatch will cause parsing or URL reconstruction failures. <b>[ Already posted ]</b>
</details>

<details>
<summary>src/lib/Conversations.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 591](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/src/lib/Conversations.ts#L591): The `streamMessageDeletions` method assigns the new subscription to `this.subscriptions[EventTypes.MessageDeletion]` without removing any existing subscription at that key. If `streamMessageDeletions` is called multiple times on the same `Conversations` instance (e.g., in a component lifecycle or multiple subscribers), the reference to the previous subscription is overwritten and lost. Since `cancelStreamMessageDeletions` uses this key to find the subscription to remove, the overwritten subscription can never be cleaned up via that method. This results in a permanent memory leak of the event listener and duplicate execution of callbacks for incoming deletion events. <b>[ Already posted ]</b>
</details>

<details>
<summary>src/lib/DecodedMessageV2.ts — 0 comments posted, 7 evaluated, 5 filtered</summary>

- [line 51](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/src/lib/DecodedMessageV2.ts#L51): The `DecodedMessageV2.from` method incorrectly propagates the parent message's generic `ContentType` to nested `reactions`. When a parent message (e.g., `TextCodec`) is parsed, its reactions are instantiated as `DecodedMessageV2<TextCodec>` via `fromObject<ContentType>`. However, at runtime, `reaction.content()` decodes the payload using the reaction's actual codec (found via `this.contentTypeId` from the JSON), returning a reaction object. TypeScript expects a string (due to the `TextCodec` generic), leading to runtime crashes if string methods (like `toUpperCase`) are called on the returned object. <b>[ Already posted ]</b>
- [line 60](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/src/lib/DecodedMessageV2.ts#L60): The `DecodedMessageV2.from` method deserializes JSON directly into the class properties without converting date strings to `Date` objects. `JSON.parse` returns strings for date fields (like `sentAt` and `expiresAt`), but the class properties are typed as `Date`. When a consumer attempts to call `Date` methods (e.g., `msg.sentAt.getTime()`) on these properties, the application will crash with `TypeError: ... is not a function` because the runtime value is a string. <b>[ Already posted ]</b>
- [line 149](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/src/lib/DecodedMessageV2.ts#L149): The `DecodedMessageV2` class fails to validate the existence of `nativeContent` on the parsed JSON object before assigning it. If the native layer returns a partial or malformed JSON object where `nativeContent` is missing (undefined), the `content()` method will throw a `TypeError` (e.g., `Cannot read properties of undefined (reading 'encoded')`) when accessing `this.nativeContent.encoded`. <b>[ Already posted ]</b>
- [line 202](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/src/lib/DecodedMessageV2.ts#L202): The logic in `DecodedMessageV2.content()` introduces a critical flaw in how decoders are selected for native content. The loop at lines 199-210 iterates over all registered codecs. The condition `allowEmptyProperties.some(...)` (lines 202-204) checks if `nativeContent` has *any* allowed empty property (e.g., `'text'`) but fails to verify if that property corresponds to the *current* `codec` in the loop. <b>[ Already posted ]</b>
- [line 208](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/src/lib/DecodedMessageV2.ts#L208): In `DecodedMessageV2.content()`, the logic iterates over all registered codecs in `Client.codecRegistry` to find a matching `NativeContentCodec`. However, it accesses `codec.contentKey` without first verifying that the property exists on the codec object. `Client.codecRegistry` can contain both `JSContentCodec` (which does not have `contentKey`) and `NativeContentCodec` (which does). Accessing `codec.contentKey` on a `JSContentCodec` will return `undefined`. While `this.nativeContent[undefined]` is generally safe in JS (returns undefined), if `allowEmptyProperties` logic is not met, the loop continues. If a `JSContentCodec` is encountered, the code does not crash immediately at the property check, but if the loop relies on `codec` being a `NativeContentCodec` for the `decode` call later, we must ensure it is one. More critically, the check `('contentKey' in codec ...)` is present, but TypeScript runtime behavior for `in` operator on objects is safe. The issue here is subtle: if `this.nativeContent.hasOwnProperty(prop)` is true for an empty property (like `text`), the code executes `(codec as NativeContentCodec<...>).decode(this.nativeContent)`. If the current `codec` in the loop happens to be a `JSContentCodec` (which lacks `decode(NativeMessageContent)` signature or implementation compatible with it, usually expecting `EncodedContent`), this will crash or throw a type error at runtime because `JSContentCodec.decode` takes `EncodedContent`, not `NativeMessageContent`. The loop iterates `Object.values(Client.codecRegistry)`, so it mixes both types. <b>[ Already posted ]</b>
</details>

<details>
<summary>src/lib/Dm.ts — 0 comments posted, 4 evaluated, 3 filtered</summary>

- [line 143](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/src/lib/Dm.ts#L143): The `prepareMessage` method accepts `SendOptions` (which includes `shouldPush`), but fails to pass this parameter to the underlying native calls. Specifically, in `_prepareWithJSCodec` (line 171) and the direct `XMTP.prepareMessage` call (line 159), the `shouldPush` option is dropped. This means users cannot control push notification behavior for prepared messages (e.g., suppressing push for silent messages), unlike the `send` method which correctly processes `opts.shouldPush`. <b>[ Already posted ]</b>
- [line 162](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/src/lib/Dm.ts#L162): The `prepareMessage` method accepts `opts: SendOptions` (which includes `shouldPush?: boolean`), but the implementation discards the `shouldPush` property in both execution paths. When calling `_prepareWithJSCodec` (line 162), `shouldPush` is not passed, and `_prepareWithJSCodec` itself does not accept it as an argument. Similarly, in the direct native call path (line 170), `XMTP.prepareMessage` is called without any push configuration. Because `prepareMessage` performs an optimistic send by default (when `noSend` is false), users invoking `prepareMessage` with `shouldPush: false` will have this preference ignored, resulting in unintended push notifications if the underlying default is to push. <b>[ Already posted ]</b>
- [line 199](https://github.com/xmtp/xmtp-react-native/blob/7eed89508fedbfd287fe0ec95b53597bb8c6f70c/src/lib/Dm.ts#L199): The `publishMessage` method triggers the sending of a previously prepared message, but because `prepareMessage` dropped the `shouldPush` preference during the initial storage phase, `publishMessage` has no way to retrieve or respect the user's original intent regarding push notifications. This results in the message being published with default push behavior (typically enabled) regardless of the options provided during preparation. <b>[ Already posted ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->