### PR TITLE
fix: make React Native test failures fail the CI check

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -26,7 +26,10 @@ defaults:
 
 jobs:
   android-tests:
-    timeout-minutes: 45
+    # Build and emulator setup take ~10 minutes; the rest of the budget is the
+    # unit test suite itself, which is bounded by the timeout in
+    # example/e2e/mainflow.yaml so that a hang fails with a readable message.
+    timeout-minutes: 75
     name: Android Tests
     runs-on: warp-ubuntu-latest-x64-16x
     permissions:

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -21,7 +21,10 @@ env:
 
 jobs:
   ios-tests:
-    timeout-minutes: 60
+    # The native build alone takes ~30-50 minutes; the rest of the budget is the
+    # unit test suite itself, which is bounded by the timeout in
+    # example/e2e/mainflow.yaml so that a hang fails with a readable message.
+    timeout-minutes: 120
     name: iOS Tests
     runs-on: macos-15-large
     permissions:

--- a/example/e2e/mainflow.yaml
+++ b/example/e2e/mainflow.yaml
@@ -4,11 +4,17 @@ appId: expo.modules.xmtpreactnativesdk.example
     clearState: true
 - tapOn: Unit-tests
 - assertVisible: Unit Tests
-- tapOn: 1,2,3
-- inputText: '1'
 - tapOn: RUN ALL
+# "tests-complete" renders only once every test in the suite has reported a
+# result, so this is what bounds the run. If a test hangs, this times out and
+# the job fails instead of reporting a green check.
 - extendedWaitUntil:
     visible: 'tests-complete'
-    timeout: 1200000
-- assertNotVisible:
-    id: 'FAIL'
+    timeout: 2400000
+# Capture the summary (pass/fail counts and the names of any failed tests) so
+# the uploaded artifact explains a failure without a local repro.
+- takeScreenshot: e2e/.maestro/test-summary
+# Positive assertion: "tests-passed" renders only when the completed run had
+# zero failures. Any failing test makes this assertion fail, which fails the
+# flow and therefore the CI job.
+- assertVisible: 'tests-passed'

--- a/example/src/TestScreen.tsx
+++ b/example/src/TestScreen.tsx
@@ -425,18 +425,37 @@ export default function TestScreen(): JSX.Element {
                 Failed: {summary.failedTestNames.join(', ')}
               </Text>
             )}
+            {/*
+              Machine-readable outcome of the whole run, kept in the fixed
+              header so it is always on screen for E2E tooling. Exactly one of
+              these renders, and only once every test has reported a result.
+            */}
+            {summary.failedTests > 0 ? (
+              <Text
+                testID="tests-failed"
+                accessible
+                accessibilityLabel="tests-failed"
+                style={{ marginTop: 4, fontSize: 12 }}
+              >
+                Result: tests-failed
+              </Text>
+            ) : (
+              <Text
+                testID="tests-passed"
+                accessible
+                accessibilityLabel="tests-passed"
+                style={{ marginTop: 4, fontSize: 12 }}
+              >
+                Result: tests-passed
+              </Text>
+            )}
           </View>
         )}
       </View>
 
       {/* Scrollable Test List */}
       <ScrollView style={{ flex: 1 }}>
-        <View
-          testID="tests"
-          accessible
-          accessibilityLabel="tests-complete"
-          style={{ paddingHorizontal: 12 }}
-        >
+        <View testID="tests" style={{ paddingHorizontal: 12 }}>
           {(filteredTests || [])
             .slice(0, autoRun ? completedTests + 1 : filteredTests.length)
             .map((test: Test, i) => {


### PR DESCRIPTION
Part of #709

## What was wrong

While looking through the React Native E2E flow, I noticed the CI could report success before the full test run had actually finished.

The completion marker was available too early, and the flow was checking that a FAIL marker was not visible instead of positively confirming that the whole suite finished successfully.

## What I changed

- Updated example/src/TestScreen.tsx to expose clear final states for the test run:
  - tests-complete
  - tests-passed
  - tests-failed
- Updated example/e2e/mainflow.yaml so Maestro waits for the real completion state and then checks for tests-passed.
- Increased the Android and iOS workflow timeouts so the full suite has enough time to finish.
- Kept the existing CI failure diagnostics.

I did not touch the shipped SDK code under src/.

## Testing

I validated the parts I could run locally:

- dependency installs with immutable lockfiles
- ESLint
- Prettier
- workflow YAML checks
- Expo module build
- checked the repo for any other usage of the changed test markers

I could not run the native E2E flow locally because I do not have an Android emulator / macOS simulator setup available, so the first CI run on this PR will be the first full native execution of the updated flow.

## Notes

The exact runtime of the full suite may need some timeout tuning once there is real CI data.

Branch protection / required-check configuration still needs to be handled by a maintainer, and I did not add automatic flaky-test issue creation because I did not want to introduce noisy or unreliable behavior.

## Checklist

- [x] No tests skipped or weakened
- [x] No new secrets or permissions
- [x] No shipped SDK runtime code changed
- [x] Local validation completed
- [x] Native E2E limitation documented

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix React Native CI to fail on test failures
> - Adds `tests-passed` and `tests-failed` elements with accessibility labels to [TestScreen.tsx](https://github.com/xmtp/xmtp-react-native/pull/776/files#diff-3a8647c06921cc558f40587dd9655903304a04585763c684ca31394ef0ccc063), giving the Maestro flow a machine-readable pass/fail signal
> - Updates [mainflow.yaml](https://github.com/xmtp/xmtp-react-native/pull/776/files#diff-5728c17285a039c0ef690ef398cb0eeac8e702034826b681794d022d6d824dfd) to assert visibility of `tests-passed` (failing the run if tests fail), extends the wait timeout to 40 minutes, and captures a summary screenshot
> - Increases CI timeouts: Android from 45→75 min, iOS from 60→120 min to accommodate longer builds
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a41cb61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->